### PR TITLE
Display Suite Integration, display formatters!

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -143,13 +143,13 @@ function civicrm_entity_get_field_type($field_spec) {
     return array('type' => 'serial');
   }
   if (!isset($field_spec['type'])) {
-    return array('type' => 'text');
+    return array('type' => 'text', 'field_type' => 'text');
   }
 
   switch ($field_spec['type']) {
     case CRM_Utils_Type::T_INT:
     case CRM_Utils_Type::T_BOOLEAN:
-      return array('type' => 'integer');
+      return array('type' => 'integer', 'field_type' => 'number_integer');
 
     case CRM_Utils_Type::T_MONEY:
     case CRM_Utils_Type::T_FLOAT:
@@ -161,7 +161,7 @@ function civicrm_entity_get_field_type($field_spec) {
     case CRM_Utils_Type::T_CCNUM:
     case CRM_Utils_Type::T_EMAIL:
     case CRM_Utils_Type::T_URL:
-      return array('type' => 'text');
+      return array('type' => 'text','field_type' => 'text');
 
     case CRM_Utils_Type::T_DATE:
     case CRM_Utils_Type::T_TIME:
@@ -255,7 +255,7 @@ function civicrm_entity_entity_property_info_alter(&$info) {
   if (!civicrm_initialize(TRUE)) {
     return;
   }
-
+  
   // We'll start with a few basic entities but we could get them the
   // same way the API explorer does.
   $entities = _civicrm_entity_enabled_entities();
@@ -523,6 +523,7 @@ function civicrm_entity_get_field_widget($field_spec,$civicrm_entity) {
   }
   
   if(isset($field_spec['type'])) {
+
      switch($field_spec['type']) {
        case 4:
          $widget = array('widget' => 'date_select','format' => 'Y:m:d');
@@ -1563,6 +1564,7 @@ function civicrm_entity_theme() {
       'path' => drupal_get_path('module', 'civicrm_entity') . '/templates',
     );
   }
+
   return $themes;
 }
 
@@ -1576,7 +1578,7 @@ function civicrm_entity_theme() {
  * @return string content
  */
 
-function civicrm_entity_page_view($id, $entity_type, $view_mode = 'default') {
+function civicrm_entity_page_view($id, $entity_type) {
   $content = "";
   $entity = entity_load($entity_type, array($id));
 
@@ -1588,13 +1590,12 @@ function civicrm_entity_page_view($id, $entity_type, $view_mode = 'default') {
       // as contact_is_deleted ...special handling to have the page value set properly
       $entity->is_deleted = $entity->contact_is_deleted; 
      }
-    $content = $controller->view(array($id => $entity), $view_mode);
+    
+    $content = $controller->view(array($id => $entity));
   }
   else {
-    $content = '<p>No ' . $entity_type . ' record found for id: ' . $id .
-      '</p>';
+    $content = '<p>No ' . $entity_type . ' record found for id: ' . $id . '</p>';
   }
-
   $formatted_entity_title = ucwords(str_replace('_', ' ', $entity_type));
   drupal_set_title($formatted_entity_title . ' ' . $id);
 
@@ -1762,3 +1763,137 @@ function  civicrm_entity_op_access($op, $entity) {
   }
 
 }
+
+/**
+ * Implements hook_ds_field_settings_form().
+ */
+function civicrm_entity_ds_field_settings_form($field) {
+  return ds_ds_field_settings_form($field);
+}
+
+/**
+ * Implements hook_ds_field_format_summary().
+ */
+function civicrm_entity_ds_field_format_summary($field) {
+  return ds_ds_field_format_summary($field);
+}
+
+/*
+ * Implementes hook_form_alter()
+ */
+function civicrm_entity_form_alter(&$form, &$form_state, $form_id){
+// For the manage display form, add a submit handler to make display suite custom civicrm "field" settings stick
+  if($form_id == 'field_ui_display_overview_form' ) {
+    if (!civicrm_initialize(TRUE)) {
+       return;
+    }
+    $entities = _civicrm_entity_enabled_entities();
+    $entity_type = $form['#entity_type'];
+    if(array_key_exists($entity_type,$entities)) {
+      $submits = array();
+      $submits[] = '_civicrm_entity_manage_display_submit';
+      foreach($form['#submit'] as $submit_callback){
+        $submits[] = $submit_callback;
+      }
+      $form['#submit'] = $submits;
+    }
+    
+  }
+}
+
+/*
+ * Custom submit handler 
+ * updates bundle visibility settings if a display suite layout is used
+ *
+ */
+function _civicrm_entity_manage_display_submit(&$form, &$form_state) {
+  if($form_state['values']['additional_settings']['layout']!=''){
+    $entity_type = $form['#entity_type'];
+    $bundle = $form['#bundle'];
+    $bundle_settings = field_bundle_settings($entity_type, $bundle);
+ 
+    foreach($bundle_settings['extra_fields']['display'] as $key => $field) {
+      $form_state['values']['fields'][$key]['type'] = 'visible';
+    }
+  }
+}
+
+/*
+ *  Implements hook_field_extra_fields_alter()
+ *  put civicrm properties on the manage fields form for weight based ordering of edit form elements
+ *
+ */
+function civicrm_entity_field_extra_fields_alter(&$info) {
+  if (!civicrm_initialize(TRUE)) {
+    return;
+  }
+  $entities = _civicrm_entity_enabled_entities();
+  foreach ($entities as $drupal_entity => $civicrm_entity) {
+    $properties[$drupal_entity]['properties'] = _civicrm_entity_getproperties($civicrm_entity, 'property_info');
+    
+    foreach($info[$drupal_entity][$drupal_entity]['display'] as $name => $props) {
+      $info[$drupal_entity][$drupal_entity]['form'][$name] = $props;
+    }
+  }
+  
+}
+
+/*
+ *  Implements hook_ds_fields_info()
+ *  setup custom display suite "field" handling for CiviCRM properties
+ *
+ */
+function civicrm_entity_ds_fields_info($entity_type) {
+  $fields = array();
+   if (!civicrm_initialize(TRUE)) {
+    return;
+  }  
+  $properties = _civicrm_entity_getproperties(substr($entity_type,8), 'property_info');
+  // Basic wrapper and class settings for all CiviCRM properties, also makes the label visibility work
+  foreach($properties as $name => $settings) {
+    $fields[$entity_type][$name] = array(
+      'title' => $settings['label'],
+      'field_type' => 2,
+      'function' => '_civicrm_entity_render_fields',
+      'properties' => array(
+        'settings' => array(
+          'wrapper' => array('type' => 'textfield', 'description' => t('Eg: h1, h2, p')),
+          'class' => array('type' => 'textfield', 'description' => t('Put a class on the wrapper. Eg: block-title')),
+        ),
+       'default' => array('wrapper' => 'div', 'class' => 'civicrm-field'),
+      ),
+    );
+  }
+    
+  if (isset($fields[$entity_type])) {
+    return array($entity_type => $fields[$entity_type]);
+  }
+}
+
+/**
+ * Default Display Suite Render handler for CiviCRM "fields".
+ */
+function _civicrm_entity_render_fields($field) {
+  $settings = isset($field['formatter_settings']) ? $field['formatter_settings'] : array();
+  $settings += $field['properties']['default'];
+  
+  $wrapper = entity_metadata_wrapper($field['entity_type'], $field['entity']->id);
+  
+  $formatted_value = $wrapper->{$field['field_name']}->value();
+   
+   // primary_contact_id_contact and other fields are objects produced by the meta wrapper
+   // Will be ease to generate links to the entities if it is consistent across entities
+   if(is_object($formatted_value)){
+    $formatted_value = $formatted_value->id;
+   }
+   
+  // Wrapper and class.
+  if (!empty($settings['wrapper'])) {
+    $wrapper = check_plain($settings['wrapper']);
+    $class = (!empty($settings['class'])) ? ' class="' . check_plain($settings['class']) . '"' : '';
+    $output = '<' . $wrapper . $class . '>' . $formatted_value . '</' . $wrapper . '>';
+  }
+  
+  return $output;
+}
+

--- a/civicrm_entity_controller.inc
+++ b/civicrm_entity_controller.inc
@@ -204,9 +204,27 @@ class CivicrmEntityController extends EntityAPIController {
   }
 
   public function buildContent($entity, $view_mode = 'full', $langcode = NULL, $content = array()) {
-    $content = parent::buildContent($entity, $view_mode, $langcode, $content);
-    //do some custom stuff here
-
-    return $content;
+    $entity->content = $content;
+    $build = parent::buildContent($entity,$view_mode,$langcode,$content);
+    $langcode = isset($langcode) ? $langcode : $GLOBALS['language_content']->language;
+   
+    // Add in fields.
+    if (!empty($this->entityInfo['fieldable'])) {
+      // Perform the preparation tasks if they have not been performed yet.
+      // An internal flag prevents the operation from running twice.
+      $key = isset($entity->{$this->idKey}) ? $entity->{$this->idKey} : NULL;
+      field_attach_prepare_view($this->entityType, array($key => $entity), $view_mode);
+      $entity->content = field_attach_view($this->entityType, $entity, $view_mode, $langcode);
+    }
+    
+    $temp_build = $entity->content;
+    unset($entity->content);
+    
+    foreach($temp_build as $key => $value) {
+      $build[$key] = $value;
+    }
+        
+    return $build;
   }
+  
 }

--- a/templates/civicrm-price-field-value.tpl.php
+++ b/templates/civicrm-price-field-value.tpl.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file
+ * A basic template for civiimport entities
+ *
+ * Available variables:
+ * - $content: An array of comment items. Use render($content) to print them all, or
+ *   print a subset such as render($content['field_example']). Use
+ *   hide($content['field_example']) to temporarily suppress the printing of a
+ *   given element.
+ * - $title: The name of the civiimport
+ * - $url: The standard URL for viewing a civiimport entity
+ * - $page: TRUE if this is the main view page $url points too.
+ * - $classes: String of classes that can be used to style contextually through
+ *   CSS. It can be manipulated through the variable $classes_array from
+ *   preprocess functions. By default the following classes are available, where
+ *   the parts enclosed by {} are replaced by the appropriate values:
+ *   - entity-profile
+ *   - civiimport-{TYPE}
+ *
+ * Other variables:
+ * - $classes_array: Array of html class attribute values. It is flattened
+ *   into a string within the variable $classes.
+ *
+ * @see template_preprocess()
+ * @see template_preprocess_entity()
+ * @see template_process()
+ */
+?>
+<div class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
+  <?php if (!$page): ?>
+    <h2<?php print $title_attributes; ?>>
+        <a href="<?php print $url; ?>"><?php print $title; ?></a>
+    </h2>
+  <?php endif; ?>
+
+  <div class="content"<?php print $content_attributes; ?>>
+    <?php
+      print render($content);
+    ?>
+  </div>
+</div>

--- a/templates/civicrm-price-field.tpl.php
+++ b/templates/civicrm-price-field.tpl.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file
+ * A basic template for civiimport entities
+ *
+ * Available variables:
+ * - $content: An array of comment items. Use render($content) to print them all, or
+ *   print a subset such as render($content['field_example']). Use
+ *   hide($content['field_example']) to temporarily suppress the printing of a
+ *   given element.
+ * - $title: The name of the civiimport
+ * - $url: The standard URL for viewing a civiimport entity
+ * - $page: TRUE if this is the main view page $url points too.
+ * - $classes: String of classes that can be used to style contextually through
+ *   CSS. It can be manipulated through the variable $classes_array from
+ *   preprocess functions. By default the following classes are available, where
+ *   the parts enclosed by {} are replaced by the appropriate values:
+ *   - entity-profile
+ *   - civiimport-{TYPE}
+ *
+ * Other variables:
+ * - $classes_array: Array of html class attribute values. It is flattened
+ *   into a string within the variable $classes.
+ *
+ * @see template_preprocess()
+ * @see template_preprocess_entity()
+ * @see template_process()
+ */
+?>
+<div class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
+  <?php if (!$page): ?>
+    <h2<?php print $title_attributes; ?>>
+        <a href="<?php print $url; ?>"><?php print $title; ?></a>
+    </h2>
+  <?php endif; ?>
+
+  <div class="content"<?php print $content_attributes; ?>>
+    <?php
+      print render($content);
+    ?>
+  </div>
+</div>

--- a/templates/civicrm-price-set.tpl.php
+++ b/templates/civicrm-price-set.tpl.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file
+ * A basic template for civiimport entities
+ *
+ * Available variables:
+ * - $content: An array of comment items. Use render($content) to print them all, or
+ *   print a subset such as render($content['field_example']). Use
+ *   hide($content['field_example']) to temporarily suppress the printing of a
+ *   given element.
+ * - $title: The name of the civiimport
+ * - $url: The standard URL for viewing a civiimport entity
+ * - $page: TRUE if this is the main view page $url points too.
+ * - $classes: String of classes that can be used to style contextually through
+ *   CSS. It can be manipulated through the variable $classes_array from
+ *   preprocess functions. By default the following classes are available, where
+ *   the parts enclosed by {} are replaced by the appropriate values:
+ *   - entity-profile
+ *   - civiimport-{TYPE}
+ *
+ * Other variables:
+ * - $classes_array: Array of html class attribute values. It is flattened
+ *   into a string within the variable $classes.
+ *
+ * @see template_preprocess()
+ * @see template_preprocess_entity()
+ * @see template_process()
+ */
+?>
+<div class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
+  <?php if (!$page): ?>
+    <h2<?php print $title_attributes; ?>>
+        <a href="<?php print $url; ?>"><?php print $title; ?></a>
+    </h2>
+  <?php endif; ?>
+
+  <div class="content"<?php print $content_attributes; ?>>
+    <?php
+      print render($content);
+    ?>
+  </div>
+</div>


### PR DESCRIPTION
Code to integrate more fully with display suite.  If you enable a display suite layout for a view mode, then CiviCRM properties will respect region, label, and display formatter settings when rendered on the view pages. 
Methodology for adding custom display formatters in place. Image, Date, and "entity linking" formatters now possible.
Also integrated CiviCRM properties on the 'Manage Forms' tab for weight ordering of fields on edit forms..

Added templates for price set, price field, price field values
