### PR TITLE
Load custom fields when loading entities, relates to #2399251 #220137#23...

### DIFF
--- a/civicrm_entity_controller.inc
+++ b/civicrm_entity_controller.inc
@@ -230,6 +230,10 @@ class CivicrmEntityController extends EntityAPIController {
    */
   protected function loadEntities($condition) {
     $entities = array();
+    $fields = civicrm_api3($this->entityInfo['description'], 'getfields', array('action' => 'get'));
+    if (!empty($fields['values'])) {
+      $condition['return'] = array_keys($fields['values']);
+    }
 
     $civicrm_entities = civicrm_api3($this->entityInfo['description'], 'get', $condition);
     if ($civicrm_entities['count']) {


### PR DESCRIPTION
...72723

Note that this causes the api to request all fields declared in getfields api call.
The risk here is that the api has been becoming more solid about how it deals
with this but we are more reliant on the quality of the api
and there are significant changes between 4.4 & 4.5 on this
There are some cases where passing in 'return' will cause desired fields not to be returned

However, this is diminishing and since we are in dev we can probably add this here now.
