### PR TITLE
fix so that civicrm_contribution source displays properly

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -401,7 +401,7 @@ function _civicrm_entity_labels($entity) {
     'civicrm_activity' => 'subject',
     'civicrm_address' => 'address_name',
     'civicrm_contact' => 'display_name',
-    'civicrm_contribution' => 'source',
+    'civicrm_contribution' => 'contribution_source',
     'civicrm_email' => 'email',
     'civicrm_event' => 'title',
     'civicrm_entity_tag' => 'tag_id',

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -576,6 +576,8 @@ function _civicrm_entity_getproperties($civicrm_entity, $context = '') {
       8 => 'datetime',
       12 => 'datetime',
       256 => 'datetime',
+      512 => 'decimal',
+      1024 => 'decimal',
     );
     if (!empty($field_specs['type']) &&
       array_key_exists($field_specs['type'], $types)


### PR DESCRIPTION
For the Drupal entity labels, you have to set a property that is on the Drupal entity object. For some reason, the source column is coming through to the Drupal entity object as 'contribution_source'. 
