### PR TITLE
Better labels.

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -197,7 +197,7 @@ function civicrm_entity_entity_info() {
     $info[$drupal_entity] = array(
       'description' => $civicrm_entity,
       'optional' => TRUE,
-      'label' => "CiviCRM " . ucwords($civicrm_entity),
+      'label' => "CiviCRM " . ucwords(str_replace('_', ' ', $civicrm_entity)),
       'module' => 'civicrm_entity',
       'controller class' => 'CivicrmEntityController',
       'metadata controller class' => 'CivicrmEntityMetadataController',


### PR DESCRIPTION
Currently we see "CiviCRM Entity_tag" but it's nicer to see "CiviCRM Entity Tag".
