### PR TITLE
VBO fixes

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -54,18 +54,13 @@ function civicrm_entity_permission() {
  * @return bool
  */
 function civicrm_entity_access($op, $entity, $account, $entity_type) {
-  if ($op == 'view' && $entity_type == 'civicrm_event') {
-    return user_access('view event info');
+  // expected $op values for civicrm_entity_access when called from VBO: view, update, create, delete
+  // expected $op values for civicrm_entity_op_access: view, edit, create, delete
+  if ($op = "update") {
+    $op = "edit";
   }
-  elseif ($op == 'view' && $entity_type == 'civicrm_participant') {
-    return user_access('view event participants');
-  }
-  elseif ($op == 'view' && $entity_type == 'civicrm_contribution_page') {
-    return user_access('make online contributions');
-  }
-  else {
-    return user_access('administer CiviCRM');
-  }
+  return (civicrm_entity_op_access($op, $entity_type) ||
+    user_access('administer CiviCRM'));
 }
 
 /**
@@ -1744,6 +1739,7 @@ function  civicrm_entity_op_access($op, $entity) {
       case "civicrm_event":
         return user_access('view event info');
       case "civicrm_contribution":
+        return user_access('access CiviContribute');
       case "civicrm_financial_type":
         return user_access('access CiviContribute') &&
         user_access('administer CiviCRM');
@@ -1792,8 +1788,7 @@ function  civicrm_entity_op_access($op, $entity) {
       case "civicrm_event":
         return user_access('edit all events');
       case "civicrm_contribution":
-        return user_access('administer CiviCRM') &&
-        user_access('edit contributions');
+        return user_access('edit contributions');
       case "civicrm_participant":
         return user_access('edit event participants') &&
         user_access('access CiviEvent');
@@ -1845,8 +1840,7 @@ function  civicrm_entity_op_access($op, $entity) {
         return user_access('edit all events') &&
         user_access('delete in CiviEvent');
       case "civicrm_contribution":
-        return user_access('administer CiviCRM') &&
-        user_access('edit contributions') &&
+        return user_access('edit contributions') &&
         user_access('delete in CiviContribute');
       case "civicrm_participant":
         return user_access('edit event participants') &&

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -54,13 +54,14 @@ function civicrm_entity_permission() {
  * @return bool
  */
 function civicrm_entity_access($op, $entity, $account, $entity_type) {
-  // expected $op values for civicrm_entity_access when called from VBO: view, update, create, delete
-  // expected $op values for civicrm_entity_op_access: view, edit, create, delete
+  // when called from VBO $op is: view, update, create, delete
+  // civicrm_entity_op_access expects $op as: view, edit, create, delete
   if ($op = "update") {
     $op = "edit";
   }
-  return (civicrm_entity_op_access($op, $entity_type) ||
-    user_access('administer CiviCRM'));
+  // retain previous behaviour where 'administer CiviCRM' can do anything
+  return (user_access('administer CiviCRM') || 
+    civicrm_entity_op_access($op, $entity_type) );
 }
 
 /**


### PR DESCRIPTION
Fixes for working with VBO:
Make civicrm_entity_access() use more extensive checks in civicrm_entity_op_access() - relates to https://www.drupal.org/node/2505111
civicrm_entity_access is called by VBO so this lets VBO update more without requiring 'administer CiviCRM' perms.
Also remove 'administer CiviCRM' requirements relating to contributions

'Administer CiviCRM' enables any action - not sure that's the right behaviour but changing it will probably break existing setups.
