### PR TITLE
Identify fields, filters, etc. coming from civicrm_entity moduel to avoid confusion with fields provided by core's implementation of hook_views_data().

### DIFF
--- a/civicrm_entity_default_views_controller.inc
+++ b/civicrm_entity_default_views_controller.inc
@@ -76,7 +76,7 @@ class CiviCRMEntityDefaultViewsController extends EntityDefaultViewsController {
 
     $description = array(
       'title' => $property_info['label'],
-      'help' => isset($property_info['description']) ? $property_info['description'] : NULL,
+      'help' => 'Provided by CiviCRM Entity' . (isset($property_info['description']) ? ': ' . $property_info['description'] : NULL),
     );
 
     // Add in relationships to related entities.


### PR DESCRIPTION
civicm_entity provides duplicate fields and filters for contacts, contributions, etc. etc. and they don't work with core's fields. I'm unsure for the reason for providing a duplicate implementation of these fields.

For now, this patch helps identify fields, filters, etc. coming from civicrm_entity moduel to avoid confusion with fields provided by core's implementation of hook_views_data().
