### PR TITLE
controller, form, inline entity form, civicrm entity reference, and c…

### DIFF
--- a/civicrm_entity.default_form.inc
+++ b/civicrm_entity.default_form.inc
@@ -78,6 +78,7 @@ function civicrm_entity_form($form, &$form_state, $entity, $op, $entity_type) {
             }
           }
 
+          // Handle default value
           if($op == 'edit') {
             $form[$name]['#default_value'] = $child->value();
           }
@@ -97,6 +98,17 @@ function civicrm_entity_form($form, &$form_state, $entity, $op, $entity_type) {
             }
             if(!empty($info['maxlength'])) {
               $form[$name]['#maxlength'] = $info['maxlength'];
+            }
+          }
+
+          //set rows and cols if available for textarea or text_format
+          if($form[$name]['#type'] == 'textarea' || $form[$name]['#type'] == 'text_format') {
+            // set rows value if not empty
+            if (!empty($info['rows'])) {
+              $form[$name]['#rows'] = $info['rows'];
+            }
+            if (!empty($info['cols'])) {
+              $form[$name]['#cols'] = $info['cols'];
             }
           }
 
@@ -158,6 +170,7 @@ function civicrm_entity_form($form, &$form_state, $entity, $op, $entity_type) {
             }
           }
 
+          // contact special handling
           if ($entity_type=='civicrm_contact') {
             //for some reason the is_deleted column of the contact record is coming to the entity
             // as contact_is_deleted ...special handling to have the form value set properly
@@ -180,6 +193,13 @@ function civicrm_entity_form($form, &$form_state, $entity, $op, $entity_type) {
               $form[$name]['#suffix'] = '</div>';
               $form[$name]['#validated'] = TRUE;
               unset($form[$name]['#size']);
+            }
+          }
+
+          // event special handling
+          if ($entity_type=='civicrm_event') {
+            if($name == 'thankyou_text' || $name == 'thankyou_footer_text') {
+              //$form[$name]['#type'] = 'text_format';
             }
           }
 

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -845,6 +845,51 @@ function civicrm_entity_supported_entities_info(){
       'boolean fields' => array('grant_report_received',),
     ),
   );
+  $civicrm_entity_info['civicrm_loc_block'] = array(
+    'civicrm entity name' => 'loc_block',
+    'label property' => '',
+    'permissions' => array(
+      'view' => array('administer CiviCRM'),
+      'edit' => array('administer CiviCRM'),
+      'update' => array('administer CiviCRM'),
+      'create' => array('administer CiviCRM'),
+      'delete' => array('administer CiviCRM'),
+    ),
+    'theme' => array(
+      'template' => 'civicrm-loc-block',
+      'path' => drupal_get_path('module', 'civicrm_entity') . '/templates'
+    ),
+    'display suite' => array(
+      'link fields' => array(
+        array(
+          'link_field' => 'address_id',
+          'target' => 'civicrm_address',
+        ),
+        array(
+          'link_field' => 'email_id',
+          'target' => 'civicrm_email',
+        ),
+        array(
+          'link_field' => 'phone_id',
+          'target' => 'civicrm_phone',
+        ),
+        array(
+          'link_field' => 'address_2_id',
+          'target' => 'civicrm_address',
+        ),
+        array(
+          'link_field' => 'phone_2_id',
+          'target' => 'civicrm_phone',
+        ),
+        array(
+          'link_field' => 'email_2_id',
+          'target' => 'civicrm_email',
+        ),
+      ),
+      'option fields' => array(),
+      'boolean fields' => array(),
+    ),
+  );
   $civicrm_entity_info['civicrm_membership'] = array(
     'civicrm entity name' => 'membership',
     'permissions' => array(
@@ -1121,7 +1166,27 @@ function civicrm_entity_supported_entities_info(){
       'boolean fields' => array('is_default', 'is_active',),
     ),
   );
+  $civicrm_entity_info['civicrm_recurring_entity'] = array(
+    'civicrm entity name' => 'recurring_entity',
+    'permissions' => array(
+      'view' => array(),
+      'edit' => array(),
+      'update' => array(),
+      'create' => array(),
+      'delete' => array(),
+    ),
+    'theme' => array(
+      'template' => 'civicrm-recurring-entity',
+      'path' => drupal_get_path('module', 'civicrm_entity') . '/templates'
+    ),
+    'display suite' => array(
+      'link fields' => array(
 
+      ),
+      'option fields' => array(),
+      'boolean fields' => array(),
+    ),
+  );
   $civicrm_entity_info['civicrm_relationship'] = array(
     'civicrm entity name' => 'relationship',
     'label property' => 'description',
@@ -1563,6 +1628,15 @@ function _civicrm_entity_getproperties($civicrm_entity, $context = '') {
         $info[$fieldname]['default_value'] = $field_specs['default_value'];
       }
 
+      // add field rows to metadata
+      if(isset($field_specs['rows'])) {
+        $info[$fieldname]['rows'] = $field_specs['rows'];
+      }
+      // add field rows to metadata
+      if(isset($field_specs['cols'])) {
+        $info[$fieldname]['cols'] = $field_specs['cols'];
+      }
+
       if ($field_specs['type'] == 16) {
         $info[$fieldname]['size'] = 'tiny';
       }
@@ -1735,11 +1809,25 @@ function civicrm_entity_get_field_widget($field_spec, $civicrm_entity) {
         }
         break;
       case 'RichTextEditor':
-      case 'TextArea':
         $widget = array(
-          'widget' => 'textarea',
+          'widget' => 'text_format',
           'civicrm_field_type' => $field_type,
         );
+        break;
+      case 'TextArea':
+        //if(!empty($field_spec['description']) && strpos($field_spec['description'], 'Text and html allowed.') !== FALSE) {
+        if(0 == 1) {
+          $widget = array(
+            'widget' => 'text_format',
+            'civicrm_field_type' => $field_type,
+          );
+        }
+        else {
+          $widget = array(
+            'widget' => 'textarea',
+            'civicrm_field_type' => $field_type,
+          );
+        }
         break;
       default:
         $widget = array(
@@ -2797,7 +2885,7 @@ function civicrm_entity_ds_field_format_summary($field) {
  */
 function civicrm_entity_form_alter(&$form, &$form_state, $form_id){
 // For the manage display form, add a submit handler to make display suite custom civicrm "field" settings stick
-  if($form_id == 'field_ui_display_overview_form' ) {
+  if($form_id == 'field_ui_display_overview_form') {
     if (!civicrm_initialize(TRUE)) {
        return;
     }
@@ -2844,9 +2932,7 @@ function _civicrm_entity_manage_display_submit(&$form, &$form_state) {
     $entity_type = $form['#entity_type'];
     $bundle = $form['#bundle'];
     $bundle_settings = field_bundle_settings($entity_type, $bundle);
-
     foreach($bundle_settings['extra_fields']['display'] as $key => $field) {
-      $form_state['values']['fields'][$key]['type'] = 'visible';
     }
   }
 

--- a/civicrm_entity_controller.inc
+++ b/civicrm_entity_controller.inc
@@ -139,7 +139,12 @@ class CivicrmEntityController extends EntityAPIController {
 
       $params_to_unset = array('is_new', 'rdf_mapping', 'original', 'submit', 'form_build_id', 'form_token', 'form_id', 'op', 'changed');
       foreach($params as $key => $value){
+        // unset some drupal form stuff
         if(in_array($key, $params_to_unset)) {
+          unset($params[$key]);
+        }
+        // unset the drupal fields
+        if(strpos($key, 'field_') === 0) {
           unset($params[$key]);
         }
         if ( substr($key, 0, 7) === 'custom_' && empty($entity->original->{$key}) && empty($value)   ) {
@@ -167,12 +172,10 @@ class CivicrmEntityController extends EntityAPIController {
 
       if (!civicrm_error($result)) {
         if($is_new) {
-          $entity->id= $result['values'][0]['id'];
-          field_attach_insert($this->entityType, $entity);
-         // $this->invoke('insert', $entity);
+          $entity->id = $result['values'][0]['id'];
+          $this->invoke('insert', $entity);
         }
         else {
-          field_attach_update($this->entityType, $entity);
           $this->invoke('update', $entity);
         }
 

--- a/modules/civicrm_entity_inline/civicrm_entity_inline.module
+++ b/modules/civicrm_entity_inline/civicrm_entity_inline.module
@@ -1,7 +1,9 @@
 <?php
 
-/*
+/**
  * Implements hook_entity_info_alter().
+ *
+ * @param $entity_info
  */
 function civicrm_entity_inline_entity_info_alter(&$entity_info) {
   $entities = _civicrm_entity_enabled_entities();
@@ -11,4 +13,16 @@ function civicrm_entity_inline_entity_info_alter(&$entity_info) {
       'controller' => 'CivicrmInlineEntityFormController',
     );
   }
+}
+
+/**
+ * Implements hook_inline_entity_form_entity_form_alter().
+ *
+ * @param $entity_form
+ * @param $form_state
+ */
+function civicrm_entity_inline_inline_entity_form_entity_form_alter(&$entity_form, &$form_state) {
+  $form_id = $form_state['build_info']['form_id'] . '-ief-' . $entity_form['#entity_type'] . '-' . $entity_form['#bundle'];
+  $entity_form['#form_id'] = $form_id;
+  drupal_alter('form', $entity_form, $form_state, $form_id);
 }

--- a/modules/civicrm_entity_inline/includes/civicrm.civicrm_entity_inline.inc
+++ b/modules/civicrm_entity_inline/includes/civicrm.civicrm_entity_inline.inc
@@ -84,6 +84,17 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
             }
           }
 
+          //set rows and cols if available for textarea or text_format
+          if($entity_form[$name]['#type'] == 'textarea' || $entity_form[$name]['#type'] == 'text_format') {
+            // set rows value if not empty
+            if (!empty($info['rows'])) {
+              $form[$name]['#rows'] = $info['rows'];
+            }
+            if (!empty($info['cols'])) {
+              $form[$name]['#cols'] = $info['cols'];
+            }
+          }
+
           //set the options for select options, radios, and checkboxes
           if ($entity_form[$name]['#type'] == 'select') {
             if(!empty($info['widget']['options'])) {
@@ -167,25 +178,10 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
             }
           }
 
-          // Automatically set the referenced entity target id column with the id of the host entity
-
-          if( $op == 'add' || $op == 'create' ) {
-            $field_name = $entity_form['#parents'][0];
-            $field_info = field_info_field($field_name);
-            $target_id_column = isset($field_info['settings']['target_id_column']) ? $field_info['settings']['target_id_column'] : '';
-            $host_id_prop =isset($field_info['settings']['host_source_id']) ? $field_info['settings']['host_source_id'] : '';
-            if ($name == $target_id_column ) {
-              if(isset($form_state['complete form'][$host_id_prop]['#default_value'])) {
-                $entity_form[$name]['#default_value'] = $form_state['complete form'][$host_id_prop]['#default_value'];
-                $entity_form[$name]['#disabled'] = TRUE;
-              }
-              elseif(isset($form_state['field'][$field_name][LANGUAGE_NONE]['instance']['entity_type'])){
-                $host_entity_type = $form_state['field'][$field_name][LANGUAGE_NONE]['instance']['entity_type'];
-                if(isset($form_state[$host_entity_type]->{$host_id_prop})) {
-                  $entity_form[$name]['#default_value'] = $form_state[$host_entity_type]->{$host_id_prop};
-                  $entity_form[$name]['#disabled'] = TRUE;
-                }
-              }
+          // event special handling
+          if ($entity_type=='civicrm_event') {
+            if($name == 'thankyou_text' || $name == 'thankyou_footer_text') {
+              $form[$name]['#type'] = 'text_format';
             }
           }
 

--- a/modules/civicrm_entity_price_set_field/civicrm_entity_price_set_field.info
+++ b/modules/civicrm_entity_price_set_field/civicrm_entity_price_set_field.info
@@ -1,0 +1,5 @@
+name = CiviCRM Entity Price Set Field
+description = "Provides CiviCRM Entity Price Set Field Type.  Provides a widget for manipulating price sets for events and contribution pages."
+dependencies[] = civicrm_entity
+package = CiviCRM Entity
+core = 7.x

--- a/modules/civicrm_entity_price_set_field/civicrm_entity_price_set_field.module
+++ b/modules/civicrm_entity_price_set_field/civicrm_entity_price_set_field.module
@@ -1,0 +1,949 @@
+<?php
+
+/**
+ * @file
+ * Provide CiviCRM Entity Price Set Field Type.
+ */
+
+/**
+ * Implements hook_field_info().
+ *
+ * @return array
+ */
+function civicrm_entity_price_set_field_field_info() {
+  return array(
+    'civicrm_entity_price_set_field' => array(
+      'label' => t('CiviCRM Entity Price Set'),
+      'description' => t('This field provides a widget for manipulating event and contribution page price sets.'),
+      'settings' => array('groups' => array()),
+      'instance_settings' => array(),
+      'default_widget' => 'civicrm_entity_price_set_field_default_widget',
+      'default_formatter' => 'civicrm_entity_price_set_field_default_formatter',
+    ),
+  );
+}
+
+/**
+ * Implements hook_form_FORMID_alter().
+ *
+ * form id : field_ui_field_edit_form
+ *
+ * Alter Field Settings form to set cardinality to 1 and disable the select widget
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_entity_price_set_field_form_field_ui_field_edit_form_alter(&$form, &$form_state) {
+  if($form['#field']['type'] == 'civicrm_entity_price_set_field') {
+    // field settings mods
+    $form['field']['cardinality']['#default_value'] = 1;
+    $form['field']['cardinality']['#disabled'] = TRUE;
+  }
+}
+
+/**
+ * Implements hook_form_FORMID_alter().
+ *
+ * form id : field_ui_field_overview_form
+ *
+ * Only allow creation of civicrm_entity_price_set_field to civicrm_event or civicrm_contribution_page entity type
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_entity_price_set_field_form_field_ui_field_overview_form_alter(&$form, &$form_state){
+  if ($form['#entity_type'] != 'civicrm_event' && $form['#entity_type'] != 'civicrm_contribution_page') {
+    unset($form['fields']['_add_new_field']['type']['#options']['civicrm_entity_price_set_field']);
+
+    foreach($form['fields']['_add_existing_field']['field_name']['#options'] as $field_name => $description){
+      if(strpos($description, 'CiviCRM Entity Price Set') !== FALSE) {
+        unset($form['fields']['_add_existing_field']['field_name']['#options'][$field_name]);
+      }
+    }
+  }
+}
+
+
+/**
+ * Implements hook_field_settings_form().
+ *
+ * @param $field
+ * @param $instance
+ * @param $has_data
+ */
+function civicrm_entity_price_set_field_field_settings_form($field, $instance, $has_data) {
+  $defaults = field_info_field_settings($field['type']);
+  $settings = array_merge($defaults, $field['settings']);
+
+ // $options = array('civicrm_contribution_page' => 'Contribution Page', 'civicrm_event' => 'Event');
+
+  /*$form['price_set_entity_table'] = array(
+    '#type' => 'select',
+    '#title' => t('Price Set Entity Table'),
+    '#multiple' => TRUE,
+    '#default_value' => $settings['price_set_entity_table'],
+    '#description' => t('Entity table for the price set field'),
+    '#options' => $options,
+  )*/
+
+  //return $form;
+}
+
+/**
+ * Implements hook_field_load().
+ *
+ * @param $entity_type
+ * @param $entities
+ * @param $field
+ * @param $instances
+ * @param $langcode
+ * @param $items
+ * @param $age
+ */
+function civicrm_entity_price_set_field_field_load($entity_type, $entities, $field, $instances, $langcode, &$items, $age) {
+  if($entity_type == 'civicrm_event' || $entity_type == 'civicrm_contribution_page') {
+    foreach ($entities as $entity_id => $entity) {
+      $query = db_select('civicrm_price_set_entity', 'pce');
+      $price_set_id = $query->fields('pce', array('price_set_id'))
+        ->condition('entity_table', $entity_type)
+        ->condition('entity_id', $entity_id)
+        ->execute()
+        ->fetchField();
+      if(!empty($price_set_id)) {
+        $items[$entity_id][0]['price_set_id'] = $price_set_id;
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_field_is_empty().
+ *
+ * @param $item
+ * @param $field
+ * @return bool
+ */
+function civicrm_entity_price_set_field_field_is_empty($item, $field) {
+  if(empty($item['price_set_id']) && !is_numeric($item['price_set_id'])){
+    return TRUE;
+  }
+  return FALSE;
+}
+
+
+/**
+ * Implements hook_field_insert().
+ *
+ * @param $entity_type
+ * @param $entity
+ * @param $field
+ * @param $instance
+ * @param $langcode
+ * @param $items
+ */
+function civicrm_entity_price_set_field_field_insert($entity_type, $entity, $field, $instance, $langcode, &$items) {
+  if($entity_type == 'civicrm_event') {
+    if(empty($items[0]['price_set_id']) && !is_numeric($items[0]['price_set_id'])) {
+      return;
+    }
+    else {
+      if(!empty($entity->id)) {
+        _civicrm_entity_price_set_field_process_field_items($entity_type, $entity->id, $field, $instance, $items);
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_field_update().
+ *
+ * @param $entity_type
+ * @param $entity
+ * @param $field
+ * @param $instance
+ * @param $langcode
+ * @param $items
+ */
+function civicrm_entity_price_set_field_field_update($entity_type, $entity, $field, $instance, $langcode, &$items) {
+  if($entity_type == 'civicrm_event') {
+    if(empty($items[0]['price_set_id']) && !is_numeric($items[0]['price_set_id'])) {
+      return;
+    }
+    else {
+      if(!empty($entity->id)) {
+        _civicrm_entity_price_set_field_process_field_items($entity_type, $entity->id, $field, $instance, $items);
+      }
+    }
+  }
+}
+
+/**
+ * Helper function to process field items on entity update
+ *
+ * @param $entity_type
+ * @param $entity_id
+ * @param $field
+ * @param $instance
+ * @param $items
+ */
+function _civicrm_entity_price_set_field_process_field_items($entity_type, $entity_id, $field, $instance, &$items) {
+// maybe the different widgets need different stuff
+  if ($instance['widget']['type'] ==  'civicrm_entity_price_set_field_simple_widget' && civicrm_initialize()) {
+    // first check if there is only one empty row, if so then don't do anything
+    // if there are more than one row, at least more than one with some values, then start the process
+    $abort = TRUE;
+    foreach ($items[0]['price_set']['price_field'] as $id => $values) {
+      if(!empty($values['label']) && !empty($values['amount'])) {
+        $abort = FALSE;
+      }
+      else {
+        unset($items[0]['price_set']['price_field'][$id]);
+      }
+    }
+    if($abort) {
+      return;
+    }
+
+    //fetch event by api to use its values....
+    try {
+      $result = civicrm_api3(substr($entity_type, 8), 'get', array(
+        'id' => $entity_id,
+        'sequential' => 1,
+      ));
+    } catch(CiviCRM_API3_Exception $e) {
+      drupal_set_message('Error fetching event when attempting to save price set');
+      return;
+    }
+    if($result['count']) {
+      $event = $result['values'][0];
+    } else {
+      drupal_set_message('Error fetching event when attempting to save price set');
+      return;
+    }
+
+    //if price_set_id = 0;
+    if($items[0]['price_set_id'] == 0) {
+      //create price set and update item data structure
+      $items[0]['price_set']['orig_data']['price_set']->title = $event['title'];
+      $items[0]['price_set']['orig_data']['price_set']->is_active = 1;
+      $items[0]['price_set']['orig_data']['price_set']->is_quick_config = 1;
+
+      switch($entity_type) {
+        case 'civicrm_event':
+          $items[0]['price_set']['orig_data']['price_set']->extends = 'CiviEvent';
+          break;
+      }
+      if(!empty($event['financial_type_id'])) {
+        $items[0]['price_set']['orig_data']['price_set']->financial_type_id = $event['financial_type_id'];
+      }
+
+      $price_set_wrapper = entity_metadata_wrapper('civicrm_price_set', $items[0]['price_set']['orig_data']['price_set']);
+      try {
+        $price_set_wrapper->save();
+      }
+      catch (Exception $e) {
+        drupal_set_message('Error creating price set.');
+        watchdog_exception('civicrm_entity_price_set_field', $e);
+        return;
+      }
+      $items[0]['price_set_id'] =  $price_set_wrapper->id->value();
+
+      // create price set entity
+      db_insert('civicrm_price_set_entity')
+        ->fields(array(
+          'entity_table' => $entity_type,
+          'entity_id' => $event['id'],
+          'price_set_id' => $items[0]['price_set_id'],
+        ))
+        ->execute();
+
+      //create price field and update item data structure
+      $items[0]['price_set']['orig_data']['price_fields'][0]['pf_entity']->label = $event['fee_label'];
+      $items[0]['price_set']['orig_data']['price_fields'][0]['pf_entity']->html_type = 'Radio';
+      $items[0]['price_set']['orig_data']['price_fields'][0]['pf_entity']->weight = 1;
+      $items[0]['price_set']['orig_data']['price_fields'][0]['pf_entity']->is_enter_quantity = 0;
+      $items[0]['price_set']['orig_data']['price_fields'][0]['pf_entity']->is_display_amounts = 1;
+      $items[0]['price_set']['orig_data']['price_fields'][0]['pf_entity']->options_per_line = 1;
+      $items[0]['price_set']['orig_data']['price_fields'][0]['pf_entity']->is_active = 1;
+      $items[0]['price_set']['orig_data']['price_fields'][0]['pf_entity']->is_required = 1;
+      $items[0]['price_set']['orig_data']['price_fields'][0]['pf_entity']->visibility_id = 1;
+      $items[0]['price_set']['orig_data']['price_fields'][0]['pf_entity']->price_set_id = $items[0]['price_set_id'];
+
+      $price_field_wrapper = entity_metadata_wrapper('civicrm_price_field', $items[0]['price_set']['orig_data']['price_fields'][0]['pf_entity']);
+      try {
+        $price_field_wrapper->save();
+      }
+      catch (Exception $e) {
+        drupal_set_message('Error creating price field.');
+        watchdog_exception('civicrm_entity_price_set_field', $e);
+        return;
+      }
+      $price_field_id = $items[0]['price_set']['orig_data']['price_fields'][0]['price_field_id'] = $price_field_wrapper->id->value();
+      $temp_pf = $items[0]['price_set']['orig_data']['price_fields'][0];
+      unset($items[0]['price_set']['orig_data']['price_fields'][0]);
+      $items[0]['price_set']['orig_data']['price_fields'][$price_field_id] = $temp_pf;
+
+    }
+
+    $price_field_ids = array_keys($items[0]['price_set']['orig_data']['price_fields']);
+    $price_field_id = $price_field_ids[0];
+
+    foreach ($items[0]['price_set']['price_field'] as $id => $values) {
+      if(empty($values['label']) && empty($values['amount']) && empty($values['is_default'])) {
+        continue;
+      }
+      // if new get data and add some defaults
+      if(strpos($id, 'new-') === 0) {
+        //need the financial type id of the event
+        $price_field_value = new CiviCRMEntity(
+          array(
+            'is_new' => TRUE,
+            'price_field_id' => $price_field_id,
+            'name' => strtolower($values['label']),
+            'label' => $values['label'],
+            'amount' => $values['amount'],
+            'weight' => $values['weight'],
+            'is_default' => $values['is_default'],
+            'is_active' => 1,
+          ),
+          'civicrm_price_field_value'
+        );
+        if(!empty($event['financial_type_id'])) {
+          $price_field_value->financial_type_id = $event['financial_type_id'];
+        }
+        $wrapper = entity_metadata_wrapper('civicrm_price_field_value', $price_field_value);
+      }
+      else {
+        // else update existing values
+        $items[0]['price_set']['orig_data']['price_fields'][$price_field_id]['price_field_values'][$id]->label = $values['label'];
+        $items[0]['price_set']['orig_data']['price_fields'][$price_field_id]['price_field_values'][$id]->amount = $values['amount'];
+        $items[0]['price_set']['orig_data']['price_fields'][$price_field_id]['price_field_values'][$id]->weight = $values['weight'];
+        $items[0]['price_set']['orig_data']['price_fields'][$price_field_id]['price_field_values'][$id]->is_default = $values['is_default'];
+
+        $wrapper = entity_metadata_wrapper('civicrm_price_field_value', $items[0]['price_set']['orig_data']['price_fields'][$price_field_id]['price_field_values'][$id]);
+      }
+      try {
+        $wrapper->save();
+      }
+      catch (Exception $e) {
+        drupal_set_message('Error saving price field value.');
+        watchdog_exception('civicrm_entity_price_set_field', $e);
+      }
+    }
+
+    // delete necessary items
+    foreach($items[0]['price_set']['orig_data']['price_fields'][$price_field_id]['price_field_values'] as $pfv_id => $values) {
+      if(is_numeric($pfv_id) && !isset($items[0]['price_set']['price_field'][$pfv_id])) {
+        $wrapper = entity_metadata_wrapper('civicrm_price_field_value', $items[0]['price_set']['orig_data']['price_fields'][$price_field_id]['price_field_values'][$pfv_id]);
+        try {
+          $wrapper->delete();
+        }
+        catch (Exception $e) {
+          drupal_set_message('Error removing price field value.');
+          watchdog_exception('civicrm_entity_price_set_field', $e);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Utility function to load the price set and child entities relevant to the widget or display formatter
+ *
+ * @param $price_set_id
+ * @return bool|array
+ */
+function _civicrm_entity_price_set_field_get_relevant_entities($price_set_id) {
+  $data = array();
+  $price_set = entity_load_single('civicrm_price_set', $price_set_id);
+  if ($price_set) {
+    $data['price_set'] = $price_set;
+    $price_field_query = new EntityFieldQuery();
+    $price_field_result = $price_field_query->entityCondition('entity_type', 'civicrm_price_field')
+      ->propertyCondition('price_set_id', $price_set_id)
+      ->execute();
+    $data['price_fields'] = array();
+    if (!empty($price_field_result['civicrm_price_field'])) {
+      foreach ($price_field_result['civicrm_price_field'] as $id => $pf_id) {
+        $data['price_fields'][$id]['price_field_id'] = $id;
+        $data['price_fields'][$id]['pf_entity'] = entity_load_single('civicrm_price_field', $id);
+        $data['price_fields'][$id]['price_field_values'] = array();
+
+        $price_field_value_query = new EntityFieldQuery();
+        $price_field_value_result = $price_field_value_query->entityCondition('entity_type', 'civicrm_price_field_value')
+          ->propertyCondition('price_field_id', $id)
+          ->propertyOrderBy('weight', 'ASC')
+          ->execute();
+        if (!empty($price_field_value_result['civicrm_price_field_value'])) {
+          $data['price_fields'][$id]['price_field_values'] = entity_load('civicrm_price_field_value', array_keys($price_field_value_result['civicrm_price_field_value']));
+        }
+
+      }
+    }
+  }
+  else {
+    return FALSE;
+  }
+  return $data;
+}
+
+/**
+ * Helper function to setup data structure for price set, price field, price field values, for an event
+ *
+ * @return array
+ */
+function _civicrm_entity_price_set_field_setup_entities() {
+  $data = array();
+  $data['price_set'] = new CiviCRMEntity(array('is_new' => TRUE), 'civicrm_price_set');
+  $data['price_fields'][0]['price_field_id'] = 0;
+  $data['price_fields'][0]['pf_entity'] = new CiviCRMEntity(array('is_new' => TRUE), 'civicrm_price_field');
+  $data['price_fields'][0]['price_field_values']['new-0'] = new CiviCRMEntity(array('is_new' => TRUE, 'label' => '', 'amount' => '', 'weight' => 0, 'is_default' => 0), 'civicrm_price_field_value');
+  return $data;
+}
+
+/**
+ *
+ *
+ * Field Widget -- Simple
+ *
+ *
+ */
+
+
+/**
+ * Implements hook_field_widget_info().
+ */
+function civicrm_entity_price_set_field_field_widget_info() {
+  return array(
+    'civicrm_entity_price_set_field_simple_widget' => array(
+      'label' => t('Simple -- one price field'),
+      'field types' => array('civicrm_entity_price_set_field'),
+      'settings' => array(),
+      'behaviors' => array(
+        'multiple values' => FIELD_BEHAVIOR_DEFAULT,
+        'default value' => FIELD_BEHAVIOR_DEFAULT,
+      ),
+    ),
+    /* 'civicrm_entity_price_set_field_full_edit_widget' => array(
+       'label' => t('Full Edit and multiple price fields'),
+       'field types' => array('civicrm_entity_price_set_field'),
+       'settings' => array(),
+       'behaviors' => array(
+         'multiple values' => FIELD_BEHAVIOR_DEFAULT,
+         'default value' => FIELD_BEHAVIOR_DEFAULT,
+       ),
+     ),*/
+  );
+}
+
+
+/**
+ * Implements hook_field_widget_form().
+ */
+function civicrm_entity_price_set_field_field_widget_form(&$form, &$form_state, $field, $instance, $langcode, $items, $delta, $element) {
+  $orig_element = $element;
+  switch ($instance['widget']['type']) {
+    case 'civicrm_entity_price_set_field_simple_widget':
+      if(!empty($items[$delta]['price_set_id'])) {
+        $price_set_id = $items[$delta]['price_set_id'];
+      }
+      else {
+        $price_set_id = 0;
+      }
+      $entity_type = $instance['entity_type'];
+      $widget = $orig_element + array(
+          '#type' => 'value',
+          '#value' => $price_set_id,
+          //'#options' => $options,
+        );
+      $element['price_set_id'] = $widget;
+      _civicrm_entity_price_set_field_prepare_simple_widget($price_set_id, $instance, $element);
+      drupal_add_js(drupal_get_path('module', 'civicrm_entity_price_set_field') . '/js/civicrm_entity_price_set_field_simple_widget.js');
+      break;
+    case 'civicrm_entity_price_set_field_full_edit_widget':
+      // To Be Developed -- this widget should have the works, multiple price fields, editing of price set settings, price field settings etc...
+      if(!empty($items[$delta]['price_set_id'])) {
+        $price_set_id = $items[$delta]['price_set_id'];
+      }
+      else {
+        $price_set_id = 0;
+      }
+      $data = _civicrm_entity_price_set_field_get_relevant_entities($price_set_id);
+      $widget = $orig_element + array(
+          '#type' => 'value',
+          '#value' => !empty($items[$delta]['price_set_id']) ? $items[$delta]['price_set_id'] : NULL,
+          //'#options' => $options,
+        );
+      $element['price_set_id'] = $widget;
+      break;
+  }
+  return $element;
+}
+
+/**
+ * Helper function to create FAPI form element for the Simple widget
+ *
+ * @param $price_set_id
+ * @param $instance
+ * @param $element
+ */
+function _civicrm_entity_price_set_field_prepare_simple_widget($price_set_id, $instance, &$element) {
+  $entity_type = $instance['entity_type'];
+  switch ($entity_type) {
+    case 'civicrm_event':
+      break;
+  }
+  // setup price set form elements
+  $element['price_set'] = array(
+    '#type' => 'fieldset',
+    '#title' => t($instance['label']),
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+  );
+}
+
+/**
+ *  Implements hook_field_widget_form_alter().
+ *
+ * We have to implement to gain access to the form state, for ajax
+ *
+ * @param $element
+ * @param $form_state
+ * @param $context
+ */
+function civicrm_entity_price_set_field_field_widget_form_alter(&$element, &$form_state, $context) {
+  if($context['instance']['widget']['type'] ==  'civicrm_entity_price_set_field_simple_widget') {
+    $price_set_id = $element['price_set_id']['#value'];
+    // need these form state checks because of all the ajax
+    // setup, or reuse the data
+    if(empty($form_state['price_set_data'])) {
+      if ($price_set_id) {
+        $data = _civicrm_entity_price_set_field_get_relevant_entities($price_set_id);
+      }
+      else {
+        $data = _civicrm_entity_price_set_field_setup_entities();
+      }
+      $form_state['price_set_data'] = $data;
+    }
+    else {
+      $data = $form_state['price_set_data'];
+    }
+
+    $element['price_set']['orig_data'] = array(
+      '#type' => 'value',
+      '#value' => $data,
+    );
+
+    // setup price field form elements
+    $data = $element['price_set']['orig_data']['#value'];
+    $price_field = reset($data['price_fields']);
+    $element['price_set']['price_field'] = array(
+      '#prefix' => '<div id="price-field-' . $price_field['price_field_id'] . '-attributes">',
+      '#suffix' => '</div>',
+      '#tree' => TRUE,
+      '#theme' => 'civicrm_entity_price_set_field_price_field_drag_components',
+    );
+
+    if(empty($form_state['price_field_values-' . $price_field['price_field_id']])) {
+      if (!empty($price_field['price_field_values'])) {
+        foreach ($price_field['price_field_values'] as $id => $price_field_value) {
+          $form_state['price_field_values-' . $price_field['price_field_id']][$id] = $price_field_value;
+        }
+      }
+    }
+
+    if(!isset($form_state['num_new_rows'])) {
+      $form_state['num_new_rows'] = 0;
+    }
+
+    // setup price field value form elements
+    if (!empty($form_state['price_field_values-' . $price_field['price_field_id']])) {
+      foreach ($form_state['price_field_values-' . $price_field['price_field_id']] as $id => $price_field_value) {
+        $element['price_set']['price_field'][$id]['weight'] = array(
+          '#type' => 'textfield',
+          '#default_value' => $price_field_value->weight,
+          '#attributes' => array('class' => array('item-row-weight')),
+        );
+        $element['price_set']['price_field'][$id]['label'] = array(
+          '#element_id' => $id,
+          '#type' => 'textfield',
+          '#title' => 'Label',
+          '#default_value' => $price_field_value->label,
+          '#element_validate' => array('_civicrm_entity_price_set_field_label_element_validate'),
+        );
+        $element['price_set']['price_field'][$id]['amount'] = array(
+          '#element_id' => $id,
+          '#type' => 'textfield',
+          '#title' => 'Amount',
+          '#default_value' => $price_field_value->amount,
+          '#element_validate' => array('_civicrm_entity_price_set_field_amount_element_validate'),
+        );
+        $element['price_set']['price_field'][$id]['is_default'] = array(
+          '#type' => 'radio',
+          '#title' => 'Default?',
+          '#return_value' => 1,
+          '#default_value' => $price_field_value->is_default,
+        );
+        $element['price_set']['price_field'][$id]['remove_row'] = array(
+          '#element_id' => $id,
+          '#price_field_id' => $price_field['price_field_id'],
+          '#type' => 'submit',
+          '#value' => 'Remove',
+          '#name' => 'remove-button-' . $id,
+          '#submit' => array('_civicrm_entity_price_set_field_simple_widget_remove_button_submit'),
+          '#limit_validation_errors' => array(array('price_field', $id)),
+          '#ajax' => array(
+            'callback' => '_civicrm_entity_price_set_field_simple_widget_price_field_ajax',
+            'wrapper' => 'price-field-' . $price_field['price_field_id'] . '-attributes',
+            'method' => 'replace',
+            'effect' => 'fade',
+          ),
+        );
+      }
+    }
+
+    //Add Option button
+    $element['price_set']['price_field' . $price_field['price_field_id']]['add_row'] = array(
+      '#price_field_id' => $price_field['price_field_id'],
+      '#type' => 'submit',
+      '#value' => 'Add Option',
+      '#name' => 'add-option-button',
+      '#submit' => array('_civicrm_entity_price_set_field_simple_widget_add_button_submit'),
+      '#limit_validation_errors' => array(array('price_field', 'price_field' . $price_field['price_field_id'])),
+      '#ajax' => array(
+        'callback' => '_civicrm_entity_price_set_field_simple_widget_price_field_ajax',
+        'wrapper' => 'price-field-' . $price_field['price_field_id'] . '-attributes',
+        'method' => 'replace',
+        'effect' => 'fade',
+      ),
+    );
+  }
+}
+
+/**
+ * Helper function to setup the price set data area for a new entity
+ *
+ * @param $entity_type
+ * @return array
+ */
+function _civicrm_entity_price_set_field_create_new_priceset_data($entity_type) {
+  $data = array();
+  switch ($entity_type) {
+    case 'civicrm_event':
+      break;
+  }
+  return $data;
+}
+
+/**
+ * Implements hook_theme().
+ */
+function civicrm_entity_price_set_field_theme($existing, $type, $theme, $path) {
+  $themes = array(
+    'civicrm_entity_price_set_field_price_field_drag_components' => array(
+      'render element' => 'element'
+    ),
+  );
+  return $themes;
+}
+
+/**
+ * Theme function for price field form components
+ *
+ * @param $vars
+ * @return string|void
+ */
+function theme_civicrm_entity_price_set_field_price_field_drag_components($vars) {
+  $element = $vars['element'];
+  drupal_add_tabledrag('price_field_value_table', 'order', 'sibling', 'item-row-weight');
+
+  $header = array(
+    '' => '',
+    'weight' => t('Weight'),
+    'label' => t('Label'),
+    'amount' => t('Amount'),
+    'is_default' => t('Default Choice'),
+    'remove_row' => t('Delete')
+  );
+
+  $rows = array();
+  foreach (element_children($element) as $key) {
+    $row = array();
+    $row['data'] = array();
+    foreach ($header as $fieldname => $title) {
+      $row['data'][] = drupal_render($element[$key][$fieldname]);
+      $row['class'] = array('draggable');
+    }
+    $rows[] = $row;
+  }
+
+  return theme('table', array(
+    'header' => $header,
+    'rows' => $rows,
+    'attributes' => array('id' => 'price_field_value_table'),
+  ));
+}
+
+
+/**
+ * Submit callback for Price Field Values table Remove button , Simple Widget
+ *
+ * @param $form
+ * @param $form_state
+ */
+function _civicrm_entity_price_set_field_simple_widget_remove_button_submit($form, &$form_state) {
+  $element_id = $form_state['triggering_element']['#element_id'];
+  $price_field_id = $form_state['triggering_element']['#price_field_id'];
+  unset($form_state['price_field_values-' . $price_field_id][$element_id]);
+  $form_state['rebuild'] = TRUE;
+}
+
+/**
+ * Submit callback for Price Field Values table add button, Simple Widget
+ *
+ * @param $form
+ * @param $form_state
+ */
+function _civicrm_entity_price_set_field_simple_widget_add_button_submit($form, &$form_state) {
+  $form_state['num_new_rows'] += 1;
+  $price_field_id = $form_state['triggering_element']['#price_field_id'];
+  $defaults = new stdClass();
+  $defaults->label = '';
+  $defaults->amount = '';
+  $defaults->is_default = 0;
+
+  $largest_weight = 0;
+  foreach($form_state['price_field_values-' . $price_field_id] as $id => $values) {
+    if($values->weight > $largest_weight) {
+      $largest_weight = $values->weight;
+    }
+  }
+  $defaults->weight = $largest_weight + 1;
+
+  $form_state['price_field_values-' . $price_field_id]['new-' . $form_state['num_new_rows']] = $defaults;
+  $form_state['rebuild'] = TRUE;
+}
+
+/**
+ * Ajax callback for Price Field Values table, Simple Widget
+ *
+ * @param $form
+ * @param $form_state
+ * @return array|null
+ */
+function _civicrm_entity_price_set_field_simple_widget_price_field_ajax($form, $form_state) {
+  $element_id = $form_state['triggering_element']['#element_id'];
+  $price_field_id = $form_state['triggering_element']['#price_field_id'];
+  $element_parents = $form_state['triggering_element']['#parents'];
+  $parents = array();
+  $field_name = '';
+  foreach($element_parents as $index => $parent) {
+    if(strpos($parent, 'field_') === 0) {
+      $field_name = str_replace('_', '-', $parent);
+    }
+    if(strpos($parent, 'price_field') === 0) {
+      $parents[] = 'price_field';
+      break;
+    }
+    else {
+      $parents[] = $parent;
+    }
+  }
+  $output = drupal_array_get_nested_value($form, $parents);
+  $row_state = drupal_array_get_nested_value($form_state['input'], $parents);
+
+  $selected_id = 0;
+
+  foreach($row_state as $id => $values) {
+    if($values['is_default'] == 1) {
+      $selected_id = $id;
+      break;
+    }
+  }
+
+  $commands = array();
+  $commands[] = ajax_command_html('#price-field-' . $price_field_id . '-attributes', render($output));
+  $commands[] = array(
+    'command' => 'afterPriceFieldAjaxReplaceCallback',
+    'selectedValue' => $selected_id,
+    'fieldName' => $field_name,
+  );
+
+  return array('#type' => 'ajax', '#commands' => $commands);
+}
+
+/**
+ * Element validation handler for price field value label element of the price set widget
+ *
+ * @param $element
+ * @param $form_state
+ * @param $form
+ */
+function _civicrm_entity_price_set_field_label_element_validate($element, &$form_state, $form) {
+  $element_parents = $element['#parents'];
+  $element_id = $element['#element_id'];
+  $parents = array();
+  foreach($element_parents as $index => $parent) {
+    if(!is_numeric($parent) && $parent == 'price_field') {
+      $parents[] = 'price_field';
+      break;
+    }
+    else {
+      $parents[] = $parent;
+    }
+  }
+  $price_field_values = drupal_array_get_nested_value($form_state['values'], $parents);
+  if(strpos($element_id, 'new-') !== FALSE && empty($price_field_values[$element_id]['label']) && empty($price_field_values[$element_id]['amount']) && empty($price_field_values[$element_id]['is_default'])) {
+    // ignore?
+  }
+  else {
+    if(empty($price_field_values[$element_id]['label'])) {
+      form_set_error(implode('][', $parents) . '][' . $element_id . '][label', t('Label cannot be empty'));
+    }
+  }
+}
+
+/**
+ * Element validation handler for price field value amount element of the price set widget
+ *
+ * @param $element
+ * @param $form_state
+ * @param $form
+ */
+function _civicrm_entity_price_set_field_amount_element_validate($element, &$form_state, $form) {
+  $element_parents = $element['#parents'];
+  $element_id = $element['#element_id'];
+  $parents = array();
+  foreach($element_parents as $index => $parent) {
+    if(!is_numeric($parent) && $parent == 'price_field') {
+      $parents[] = 'price_field';
+      break;
+    }
+    else {
+      $parents[] = $parent;
+    }
+  }
+  $price_field_values = drupal_array_get_nested_value($form_state['values'], $parents);
+  if(strpos($element_id, 'new-') !== FALSE && empty($price_field_values[$element_id]['label']) && empty($price_field_values[$element_id]['amount']) && empty($price_field_values[$element_id]['is_default'])) {
+    // ignore?
+  }
+  else {
+    if(empty($price_field_values[$element_id]['amount'])) {
+      form_set_error(implode('][', $parents) . '][' . $element_id . '][amount', t('Amount cannot be empty'));
+    }
+    elseif(!is_numeric($price_field_values[$element_id]['amount'])) {
+      form_set_error(implode('][', $parents) . '][' . $element_id . '][amount', t('Amount must be numeric (do not include "$" sign)'));
+    }
+  }
+}
+
+/**
+ *
+ *
+ * Field Formatter
+ *
+ *
+ */
+
+/**
+ * Implements hook_field_formatter_info().
+ */
+function civicrm_entity_price_set_field_field_formatter_info() {
+  return array(
+    'civicrm_entity_price_set_field_default_formatter' => array( // Machine name of the formatter
+      'label' => t('Default'),
+      'field types' => array('civicrm_entity_price_set_field'),
+      'settings'  => array( // Array of the settings we'll create
+      ),
+    ),
+
+  );
+}
+
+/**
+ * Implements hook_field_formatter_settings_form().
+ *
+ * @param $field
+ * @param $instance
+ * @param $view_mode
+ * @param $form
+ * @param $form_state
+ * @return array
+ */
+function civicrm_entity_price_set_field_field_formatter_settings_form($field, $instance, $view_mode, $form, &$form_state){
+  if ($field['type'] == 'civicrm_entity_price_set_field') {
+    $display = $instance['display'][$view_mode];
+    $settings = $display['settings'];
+    $element = array();
+
+
+    return $element;
+  }
+}
+
+/**
+ * Implements hook_field_formatter_settings_summary().
+ *
+ * @param $field
+ * @param $instance
+ * @param $view_mode
+ * @return string
+ */
+function civicrm_entity_price_set_field_field_formatter_settings_summary($field, $instance, $view_mode) {
+  if($field['type'] == 'civicrm_entity_price_set_field') {
+    $display = $instance['display'][$view_mode];
+    $settings = $display['settings'];
+    $summary = '';
+    if ($display['type'] == 'civicrm_entity_price_set_field_default_formatter') {
+
+    }
+    return $summary;
+  }
+}
+
+/**
+ * Implements hook_field_formatter_view().
+ */
+function civicrm_entity_price_set_field_field_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display) {
+  $element = array();
+  $settings = $display['settings'];
+  switch ($display['type']) {
+    case 'civicrm_entity_price_set_field_default_formatter':
+
+      foreach ($items as $delta => $item) {
+        $markup ='';
+        if(!empty($item['price_set_id'])){
+          $element[$delta] = array(
+            '#markup' => $item['price_set_id'],
+          );
+        }
+
+      }
+      break;
+  }
+  return $element;
+}
+
+/**
+ * Implements hook_civicrm_post().
+ *
+ * Here we need to probably clear some field caches when price sets / price fields / price field values are created/edited/deleted
+ *
+ * @param $op
+ * @param $objectName
+ * @param $objectId
+ * @param $objectRef
+ */
+function civicrm_entity_price_set_field_civicrm_post($op, $objectName, $objectId, &$objectRef){
+  //dsm($objectName);
+  /*if ($objectName == 'PriceSet' && ($op == 'create' || $op == 'delete' || $op == 'edit')) {
+    $civicrm_entity_reference_fields = db_select('field_config', 'fc')
+      ->fields('fc', array('id'))
+      ->condition('type', 'civicrm_entity_price_set_field')
+      ->execute();
+    if($civicrm_entity_reference_fields->rowCount()) {
+      cache_clear_all('field:civicrm_contact:' . $objectRef[0], 'cache_field');
+    }
+  }*/
+}
+

--- a/modules/civicrm_entity_price_set_field/js/civicrm_entity_price_set_field_simple_widget.js
+++ b/modules/civicrm_entity_price_set_field/js/civicrm_entity_price_set_field_simple_widget.js
@@ -1,0 +1,23 @@
+jQuery(document).ready(function($) {
+
+  $('.field-type-civicrm-entity-price-set-field #price_field_value_table .form-type-radio input').click(function() {
+    $('.field-type-civicrm-entity-price-set-field #price_field_value_table .form-type-radio input').not(this).prop('checked', false);
+  });
+
+});
+
+(function($, Drupal)
+{
+  // Our function name is prototyped as part of the Drupal.ajax namespace, adding to the commands:
+  Drupal.ajax.prototype.commands.afterPriceFieldAjaxReplaceCallback = function(ajax, response, status)
+  {
+    console.log(response);
+    console.log('#edit-' + response.fieldName + ' .form-item-' + response.fieldName + '-und-0-price-set-price-field-' + response.selectedValue + '-is-default input');
+    $('#edit-' + response.fieldName + ' #price_field_value_table .form-type-radio input').prop('checked', false);
+    $('#edit-' + response.fieldName + ' .form-item-' + response.fieldName + '-und-0-price-set-price-field-' + response.selectedValue + '-is-default input').prop('checked', true);
+
+    $('#edit-' + response.fieldName + ' #price_field_value_table .form-type-radio input').click(function() {
+      $('#edit-' + response.fieldName + ' #price_field_value_table .form-type-radio input').not(this).prop('checked', false);
+    });
+  };
+}(jQuery, Drupal));

--- a/modules/civicrm_entity_reference_field/civicrm_entity_reference_field.module
+++ b/modules/civicrm_entity_reference_field/civicrm_entity_reference_field.module
@@ -78,13 +78,15 @@ function civicrm_entity_reference_field_field_create_field($field) {
 function civicrm_entity_reference_field_form_field_ui_field_edit_form_alter(&$form, &$form_state) {
   if($form['#field']['type'] == 'civicrm_entity_reference') {
     // field settings mods
-    $form['field']['cardinality']['#default_value'] = -1;
-    $form['field']['cardinality']['#disabled'] = TRUE;
+    // Commenting our for now, for cases like location block on events, there is only one value, maybe it doesn't make sense to force 'Unlimited'
+    //$form['field']['cardinality']['#default_value'] = -1;
+    //$form['field']['cardinality']['#disabled'] = TRUE;
 
     if ($form['instance']['widget']['type']['#value'] == 'inline_entity_form_single' || $form['instance']['widget']['type']['#value'] == 'inline_entity_form') {
       // Its going to delete the referenced entity so we just set this value to 1 and disable the checkbox to avoid confusion
-      $form['instance']['widget']['settings']['type_settings']['delete_references']['#default_value'] = 1;
-      $form['instance']['widget']['settings']['type_settings']['delete_references']['#disabled'] = TRUE;
+      // UPDATE: OR not? Cases like Events that have location blocks, don't need to delete the location block when deleting the event?
+      //$form['instance']['widget']['settings']['type_settings']['delete_references']['#default_value'] = 1;
+      //$form['instance']['widget']['settings']['type_settings']['delete_references']['#disabled'] = TRUE;
       // Does it make sense to have the "add existing entities?" functionality, disabling it for now
       if(isset($form['instance']['widget']['settings']['type_settings']['allow_existing'])){
         $form['instance']['widget']['settings']['type_settings']['allow_existing']['#default_value'] = 0;
@@ -145,7 +147,8 @@ function civicrm_entity_reference_field_field_settings_form($field, $instance, $
     '#title' => t('Host Source Column'),
     '#default_value' => $settings['host_source_id'],
     '#description' => t('Host Entity property which value is used query target entity table.'),
-    '#options' => array ('id' => 'ID')
+    // want to automate choices for this setting in the future
+    '#options' => array ('id' => 'ID',  'loc_block_id' => 'Location Block ID (CiviCRM Event Entity)', 'address_id' => 'Address ID (Location Block Entity)')
   );
 
   return $form;
@@ -549,8 +552,9 @@ function civicrm_entity_reference_field_civicrm_post($op, $objectName, $objectId
   }
 }
 
+
 /**
- * Implements hook_form_alter().
+ * Implements hook_field_widget_form_alter().
  *
  * For CiviCRM Entity Add forms
  *
@@ -558,30 +562,140 @@ function civicrm_entity_reference_field_civicrm_post($op, $objectName, $objectId
  * Disable widget buttons for Inline Entity Form -- Multiple on entity create.
  * Disable widget for default widget.
  *
- * @param $form
+ * @param $element
  * @param $form_state
- * @param $form_id
+ * @param $context
  */
-function civicrm_entity_reference_field_form_alter(&$form, &$form_state, $form_id) {
-  $civicrm_entities = _civicrm_entity_enabled_entities();
-  foreach ($civicrm_entities as $drupal_name => $civicrm_name) {
-    if(strpos($form_id, $drupal_name) === 0 && $form_state['op'] == 'create') {
-      foreach($form as $index => $data) {
-        if(strpos($index,'field_') === 0) {
-          if(!empty($data[LANGUAGE_NONE]['#field_name'])) {
-            $field = field_info_field($data[LANGUAGE_NONE]['#field_name']);
-            if($field['type'] == 'civicrm_entity_reference') {
-              $instance = field_info_instance($form['#entity_type'], $data[LANGUAGE_NONE]['#field_name'], $form['#entity_type']);
-              if($instance['widget']['type'] == 'inline_entity_form_single') {
-                unset($form[$index][LANGUAGE_NONE]['form']);
-              }
-              elseif ($instance['widget']['type'] == 'inline_entity_form') {
-                $form[$index][LANGUAGE_NONE]['actions']['ief_add']['#disabled'] = TRUE;
-              }
-              elseif ($instance['widget']['type'] == 'civicrm_entity_reference_default_widget') {
-                $form[$index]['#disabled'] = TRUE;
-              }
+function civicrm_entity_reference_field_field_widget_form_alter(&$element, &$form_state, $context) {
+  if($context['field']['type'] == 'civicrm_entity_reference') {
+    if($context['instance']['widget']['type'] == 'inline_entity_form_single') {
+      if($form_state['op'] == 'create'){
+        unset($element['form']);
+      }
+    }
+    elseif($context['instance']['widget']['type'] == 'inline_entity_form') {
+      if($form_state['op'] == 'create'){
+        $element['actions']['ief_add']['#disabled'] = TRUE;
+      }
+    }
+    elseif($context['instance']['widget']['type'] == 'civicrm_entity_reference_default_widget') {
+      if($form_state['op'] == 'create'){
+        $element['#disabled'] = TRUE;
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_inline_entity_form_entity_form_alter().
+ *
+ * @param $entity_form
+ * @param $form_state
+ */
+function civicrm_entity_reference_field_inline_entity_form_entity_form_alter(&$entity_form, &$form_state) {
+
+  $ief_id = $entity_form['#ief_id'];
+  $host_entity_type = $form_state['inline_entity_form'][$ief_id]['instance']['entity_type'];
+
+  $field_info = array();
+
+  foreach($entity_form['#parents'] as $key => $parent) {
+    if(strpos($parent, 'field_') === 0) {
+      $field = field_info_field($parent);
+      $instances = db_select('field_config_instance', 'fi')
+        ->fields('fi', array('id'))
+        ->condition('field_id', $field['id'])
+        ->condition('entity_type', $host_entity_type)
+        ->condition('bundle', $host_entity_type)
+        ->execute();
+
+      if ($instances->rowCount()) {
+        $field_name = $parent;
+        $field_info = $field;
+      }
+    }
+  }
+
+  if(!empty($field_info) && $field_info['type'] == 'civicrm_entity_reference') {
+    // Generally you want to set the target_id_column to the host_id_prop
+    $target_id_column = isset($field_info['settings']['target_id_column']) ? $field_info['settings']['target_id_column'] : '';
+    $host_id_prop = isset($field_info['settings']['host_source_id']) ? $field_info['settings']['host_source_id'] : '';
+
+    // this handles the 'multi' widget
+    if (isset($form_state['complete form'][$host_id_prop]['#default_value']) && isset($entity_form[$target_id_column]) && is_array($entity_form[$target_id_column])) {
+      if ($entity_form['#op'] == 'add' || $entity_form['#op'] == 'create') {
+        $entity_form[$target_id_column]['#default_value'] = $form_state['complete form'][$host_id_prop]['#default_value'];
+      }
+      $entity_form[$target_id_column]['#disabled'] = TRUE;
+    } // this handles the 'single' widget
+    elseif (isset($form_state['field'][$field_name][LANGUAGE_NONE]['instance']['entity_type'])) {
+      $host_entity_type = $form_state['field'][$field_name][LANGUAGE_NONE]['instance']['entity_type'];
+      if (isset($form_state[$host_entity_type]->{$host_id_prop})) {
+        if ($entity_form['#op'] == 'add' || $entity_form['#op'] == 'create') {
+          $entity_form[$target_id_column]['#default_value'] = $form_state[$host_entity_type]->{$host_id_prop};
+        }
+        $entity_form[$target_id_column]['#disabled'] = TRUE;
+      }
+    }
+    // special handling of address fields on location blocks, because in this case the contact_id is not required
+    $contact_id_entities = array('civicrm_address', 'civicrm_email', 'civicrm_phone');
+    if($host_entity_type == 'civicrm_loc_block' && in_array($entity_form['#entity_type'], $contact_id_entities)) {
+      $entity_form['contact_id']['#required'] = FALSE;
+      $entity_form['contact_id']['#default_value'] = 1;
+      $entity_form['contact_id']['#disabled'] = TRUE;
+    }
+
+  }
+}
+
+/**
+ * Implements hook_entity_presave().
+ *
+ * We needed this because sometimes you need to back fill a value before save
+ *
+ * For example, if you put a civicrm entity reference field which targets the location block, on a event entity, you have to make sure the event gets a value for the location_block_id
+ * Another example is that the location block address_id property needs to be set after the address is saved (considering if you have an civicrm_entity_reference field on the location block form, targeting address
+ *
+ * More cases of this type may crop up and we'll better understand how to automate as time passes and experience hits us over the head
+ *
+ * @param $entity
+ * @param $type
+ */
+function civicrm_entity_reference_field_entity_presave($entity, $type) {
+  if($type == 'civicrm_loc_block' || $type == 'civicrm_event') {
+    foreach($entity as $key => $value) {
+      if(strpos($key, 'field_') === 0) {
+        $field = field_info_field($key);
+        if($field['type'] == 'civicrm_entity_reference') {
+          if($type == 'civicrm_loc_block') {
+            switch ($field['settings']['target_entity_type']) {
+              case 'address':
+                $entity->{$field['settings']['host_source_id']} = $entity->{$key}[LANGUAGE_NONE][0]['target_id'];
+                // VIA the API you cannot save/create an address without a contact id, we fool it in this special case by in the form setting the id to 1, then undoing it with sql directly
+                // it ain't pretty but it works
+                db_update('civicrm_address')
+                  ->fields(array('contact_id' => NULL))
+                  ->condition('id', $entity->{$key}[LANGUAGE_NONE][0]['target_id'])
+                  ->execute();
+                break;
+              case 'email':
+                $entity->{$field['settings']['host_source_id']} = $entity->{$key}[LANGUAGE_NONE][0]['target_id'];
+                db_update('civicrm_email')
+                  ->fields(array('contact_id' => NULL))
+                  ->condition('id', $entity->{$key}[LANGUAGE_NONE][0]['target_id'])
+                  ->execute();
+                break;
+              case 'phone':
+                $entity->{$field['settings']['host_source_id']} = $entity->{$key}[LANGUAGE_NONE][0]['target_id'];
+                db_update('civicrm_phone')
+                  ->fields(array('contact_id' => NULL))
+                  ->condition('id', $entity->{$key}[LANGUAGE_NONE][0]['target_id'])
+                  ->execute();
+                break;
             }
+          }
+          elseif($type == 'civicrm_event' && $field['settings']['target_entity_type'] == 'loc_block') {
+            $entity{$field['settings']['host_source_id']} = $entity->{$key}[LANGUAGE_NONE][0]['target_id'];
           }
         }
       }

--- a/modules/civicrm_entity_reference_field_storage/civicrm_entity_reference_field_storage.module
+++ b/modules/civicrm_entity_reference_field_storage/civicrm_entity_reference_field_storage.module
@@ -50,30 +50,31 @@ function civicrm_entity_reference_field_storage_field_storage_load($entity_type,
     civicrm_initialize();
     foreach($ids as $id) {
       $field_values = array();
-      try {
-        $params = array(
-          $field['settings']['target_id_column'] => $entities[$id]->{$field['settings']['host_source_id']},
-        );
-        $is_primary_entities = array('address', 'phone', 'email');
+      if (!empty($entities[$id]->{$field['settings']['host_source_id']})) {
+        try {
+          $params = array(
+            $field['settings']['target_id_column'] => $entities[$id]->{$field['settings']['host_source_id']},
+          );
+          $is_primary_entities = array('address', 'phone', 'email');
 
-        if(in_array($field['settings']['target_entity_type'], $is_primary_entities)) {
-          $params['options'] = array('sort' => 'is_primary DESC');
+          if (in_array($field['settings']['target_entity_type'], $is_primary_entities)) {
+            $params['options'] = array('sort' => 'is_primary DESC');
+          }
+          $result = civicrm_api3($field['settings']['target_entity_type'], 'get', $params);
+        } catch (CiviCRM_API3_Exception $e) {
+          $error = $e->getMessage();
+          drupal_set_message($error, 'error');
+          continue;
         }
-        $result = civicrm_api3($field['settings']['target_entity_type'], 'get', $params);
-      }
-      catch (CiviCRM_API3_Exception $e) {
-        $error = $e->getMessage();
-        drupal_set_message($error, 'error');
-        continue;
-      }
 
-      if ($result['count']) {
-        $delta = 0;
-        foreach ($result['values'] as $target_id => $data) {
-          $field_values[LANGUAGE_NONE][$delta]['target_id'] = $target_id;
-          $delta += 1;
+        if ($result['count']) {
+          $delta = 0;
+          foreach ($result['values'] as $target_id => $data) {
+            $field_values[LANGUAGE_NONE][$delta]['target_id'] = $target_id;
+            $delta += 1;
+          }
+          $entities[$id]->{$field_name} = $field_values;
         }
-        $entities[$id]->{$field_name} = $field_values;
       }
     }
   }


### PR DESCRIPTION
and introducing the Civicrm entity price set field
Add a field instance to the Event entity and see what happens!

Edit an events price set, price field, price field values. 

Only done with a simple widget, which handles price field values for the first price field...

So works good with events with only one price field....

Look for the payment side on event view pages coming soon. Bye Bye webform_civicrm we won't need you no more!
