### PR TITLE
issue https://www.drupal.org/node/2816109

### DIFF
--- a/civicrm_entity.default_form.inc
+++ b/civicrm_entity.default_form.inc
@@ -398,15 +398,14 @@ function civicrm_entity_form_submit(&$form, &$form_state) {
   $entity_type = $form['#entity_type'];
   $entity = $form['#entity'];
   civicrm_initialize();
-  $civicrm_entity_fields = civicrm_api(substr_replace($entity_type, '', 0, 8), 'getfields', array(
-    'version' => 3,
-    'action' => 'create',
-  ));
+  $civicrm_entity_fields = _civicrm_entity_getproperties(substr_replace($entity_type, '', 0, 8));
 
   foreach ($form_state['values'] as $key => $value) {
-    //need to convert checkbox values to a consumable format for checkboxes custom fields
     if (substr($key, 0, 7) == 'custom_') {
-      if ($civicrm_entity_fields['values'][$key]['html_type'] == 'CheckBox') {
+      //need to convert custom fields to schema fields name
+      $schema_field = $civicrm_entity_fields[$key]['schema field'];
+    //need to convert checkbox values to a consumable format for checkboxes custom fields
+      if ($civicrm_entity_fields[$key]['widget']['widget'] == 'checkbox') {
         if (is_array($value)) {
           $stored_value = array();
           foreach ($value as $option => $checkbox_value) {
@@ -414,7 +413,7 @@ function civicrm_entity_form_submit(&$form, &$form_state) {
               $stored_value[] = $option;
             }
           }
-          $entity->{$key} = !empty($stored_value) ? $stored_value : array('');
+          $entity->{$schema_field} = !empty($stored_value) ? $stored_value : array('');
         }
 
       }
@@ -422,11 +421,11 @@ function civicrm_entity_form_submit(&$form, &$form_state) {
         if (is_array($value) && isset($value['value'])) {
           $value = $value['value'];
         }
-        $entity->{$key} = $value;
+        $entity->{$schema_field} = $value;
       }
 
-      if (!empty($civicrm_entity_fields['values'][$key]['is_view'])) {
-        unset($entity->{$key});
+      if (!empty($civicrm_entity_fields[$key]['is_view'])) {
+        unset($entity->{$schema_field});
       }
 
     }

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -2043,6 +2043,14 @@ function _civicrm_entity_getproperties($civicrm_entity, $context = '') {
     if (!empty($field_specs['type']) &&
       array_key_exists($field_specs['type'], $types)
     ) {
+
+      //custom fields should be handled by name and not number for compatibility with export
+      if (substr($fieldname, 0, 7) == 'custom_'
+          and isset($field_specs['column_name'])) {
+        $fieldname = 'custom_' . $field_specs['column_name'];
+        $custom_field = true;
+      }
+
       //determine the label of the field
       $label = _civicrm_entity_get_title($field_specs);
       $info[$fieldname] = array(
@@ -2050,6 +2058,7 @@ function _civicrm_entity_getproperties($civicrm_entity, $context = '') {
         'type' => $types[$field_specs['type']],
         'sanitize' => 'check_plain',
         'setter callback' => 'entity_property_verbatim_set',
+        'custom_field' => isset($custom_field),
       );
 
       if (!empty($field_specs['api.required']) || !empty($field_specs['is_required'])) {
@@ -3387,7 +3396,7 @@ function civicrm_entity_rules_action_entity_create_info_alter(&$element_info, Ru
 
 /**
  * Gets the custom fields for a CiviCRM entity
- *
+ * custom fields should be handled by name and not number for compatibility with export
  * @param $entity
  * @return array
  */
@@ -3404,17 +3413,17 @@ function civicrm_entity_get_custom_fields($entity, $types = array(
     'getoptions' => TRUE,
   ));
   $fields = $fields['values'];
+  $custom_fields = array();
   foreach ($fields as $field_name => $field) {
-    if (substr($field_name, 0, 7) != 'custom_' ||
-      !in_array($field['data_type'], array_keys($types))
+    if (substr($field_name, 0, 7) == 'custom_'
+        and in_array($field['data_type'], array_keys($types))
     ) {
-      unset($fields[$field_name]);
-    }
-    else {
-      $fields[$field_name]['type'] = $types[$field['data_type']];
+      $fieldname = $field['column_name'];
+      $custom_fields[$fieldname] = $field;
+      $custom_fields[$fieldname]['type'] = $types[$field['data_type']];
     }
   }
-  return $fields;
+  return $custom_fields;
 }
 
 

--- a/modules/civicrm_entity_inline/includes/civicrm.civicrm_entity_inline.inc
+++ b/modules/civicrm_entity_inline/includes/civicrm.civicrm_entity_inline.inc
@@ -352,10 +352,7 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
     $ief_id = $entity_form['#ief_id'];
     $op = $entity_form['#op'];
     civicrm_initialize();
-    $civicrm_entity_fields = civicrm_api(substr_replace($entity_type, '', 0, 8), 'getfields', array(
-      'version' => 3,
-      'action' => 'create',
-    ));
+    $civicrm_entity_fields = _civicrm_entity_getproperties(substr_replace($entity_type, '', 0, 8));
     if ($op == 'edit') {
 
 
@@ -363,7 +360,7 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
         if (isset($form_state['values'][$field_name]['und']['entities'][$k]['form'])) {
           foreach ($form_state['values'][$field_name]['und']['entities'][$k]['form'] as $key => $value) {
             if (substr($key, 0, 7) == 'custom_') {
-              if ($civicrm_entity_fields['values'][$key]['html_type'] == 'CheckBox') {
+              if ($civicrm_entity_fields[$key]['widget']['widget'] == 'checkbox') {
                 if (is_array($value)) {
                   $stored_value = array();
                   foreach ($value as $option => $checkbox_value) {
@@ -384,7 +381,7 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
 
               }
 
-              if (!empty($civicrm_entity_fields['values'][$key]['is_view'])) {
+              if (!empty($civicrm_entity_fields[$key]['is_view'])) {
                 unset($entity_array['entity']->{$key});
               }
 
@@ -414,7 +411,7 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
       $entity = $form_state['entity'];
       foreach ($form_state['values'][$field_name]['und']['form'] as $key => $value) {
         if (substr($key, 0, 7) == 'custom_') {
-          if ($civicrm_entity_fields['values'][$key]['html_type'] == 'CheckBox') {
+          if ($civicrm_entity_fields[$key]['widget']['widget'] == 'checkbox') {
             if (is_array($value)) {
               $stored_value = array();
               foreach ($value as $option => $checkbox_value) {
@@ -434,7 +431,7 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
             $entity->{$key} = $value;
           }
 
-          if (!empty($civicrm_entity_fields['values'][$key]['is_view'])) {
+          if (!empty($civicrm_entity_fields[$key]['is_view'])) {
             unset($entity->{$key});
           }
 


### PR DESCRIPTION
When displaying a CiviCRM custom field in a Display Suite view mode, in display or form,
and trying to export via features,
it can export the fields only in another site where the custom fields have the same ids

if you have two sites that are creating CiviCRM custom fields, they can't export view modes to one another.

Here are whanges to handle the custom fields by names instead of ids
I was able to test it in display mode and form
but not in views where I can't get to display any custom field managed by CiviCRM Entity, with any version of civicrm-entity
