### PR TITLE
issue https://www.drupal.org/node/2816119

### DIFF
--- a/modules/civicrm_entity_actions/civicrm_entity_actions_action_schedule.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_action_schedule.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_action_schedule_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_action_schedule_view_action' => array(
+        'type' => 'civicrm_action_schedule',
+        'label' => t('View Action_schedule'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_action_schedule_add_action' => array(
+        'type' => 'civicrm_action_schedule',
+        'label' => t('Add Action_schedule'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_action_schedule_edit_action' => array(
+        'type' => 'civicrm_action_schedule',
+        'label' => t('Edit Action_schedule'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_action_schedule_delete_action' => array(
+        'type' => 'civicrm_action_schedule',
+        'label' => t('Delete Action_schedule'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_action_schedule_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-action_schedule
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_action_schedule_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-action_schedule
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_action_schedule_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-action_schedule
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_action_schedule_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-action_schedule
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_activity.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_activity.inc
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_activity_action_info() {
+  return array(
+    'civicrm_entity_actions_activity_assign_action' => array(
+      'label' => t('Assign Activity'),
+      'type' => 'civicrm_activity',
+      'configurable' => TRUE,
+    ),
+    'civicrm_entity_actions_activity_unassign_action' => array(
+      'label' => t('Unassign Activity'),
+      'type' => 'civicrm_activity',
+      'configurable' => FALSE,
+    ),
+    //Crud operations
+    'civicrm_entity_actions_activity_view_action' => array(
+        'type' => 'civicrm_activity',
+        'label' => t('View Activity'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_activity_add_action' => array(
+        'type' => 'civicrm_activity',
+        'label' => t('Add Activity'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_activity_edit_action' => array(
+        'type' => 'civicrm_activity',
+        'label' => t('Edit Activity'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_activity_delete_action' => array(
+        'type' => 'civicrm_activity',
+        'label' => t('Delete Activity'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_activity_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-activity
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_activity_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-activity
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_activity_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-activity
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_activity_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-activity
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}
+
+/**
+ *
+ * @param unknown $object
+ * @param array $context
+ */
+
+function civicrm_entity_actions_activity_assign_action(&$object, $context = array()) {
+  if(!civicrm_initialize()) {
+    return;
+  }
+  civicrm_api3('activity', 'create', array(
+    'id' => $object->id,
+    'assignee_contact_id' => $context['state']['entity_id'])
+  );
+}
+
+/**
+ *
+ * @param array $context
+ * @return multitype:string unknown
+ */
+
+function civicrm_entity_actions_activity_assign_action_form($context = array()) {
+  $entities = _civicrm_entity_enabled_entities();
+  $entity = $entities[$context['entity_type']];
+  $form[$entity]['assignee_contact_id'] = array(
+      '#type' => 'entityreference',
+      '#title' => t('Assign To'),
+      '#era_entity_type' => 'civicrm_contact',
+  );
+  return $form;
+}
+
+/**
+ *
+ * @param unknown $form
+ * @param unknown $form_state
+ * @return multitype:NULL
+ */
+
+function civicrm_entity_actions_activity_assign_action_submit($form, $form_state) {
+  return array('state' => $form_state['values']['assignee_contact_id']);
+}
+
+/**
+ *
+ * @param unknown $object
+ * @param array $context
+ */
+
+function civicrm_entity_actions_activity_unassign_action(&$object, $context = array()) {
+  if(!civicrm_initialize()) {
+    return;
+  }
+  civicrm_api3('activity', 'create', array(
+    'id' => $object->id,
+    'deleteActivityAssignment' => TRUE)
+  );
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_address.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_address.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_address_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_address_view_action' => array(
+        'type' => 'civicrm_address',
+        'label' => t('View Address'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_address_add_action' => array(
+        'type' => 'civicrm_address',
+        'label' => t('Add Address'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_address_edit_action' => array(
+        'type' => 'civicrm_address',
+        'label' => t('Edit Address'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_address_delete_action' => array(
+        'type' => 'civicrm_address',
+        'label' => t('Delete Address'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_address_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-address
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_address_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-address
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_address_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-address
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_address_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-address
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_campaign.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_campaign.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_campaign_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_campaign_view_action' => array(
+        'type' => 'civicrm_campaign',
+        'label' => t('View Campaign'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_campaign_add_action' => array(
+        'type' => 'civicrm_campaign',
+        'label' => t('Add Campaign'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_campaign_edit_action' => array(
+        'type' => 'civicrm_campaign',
+        'label' => t('Edit Campaign'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_campaign_delete_action' => array(
+        'type' => 'civicrm_campaign',
+        'label' => t('Delete Campaign'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_campaign_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-campaign
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_campaign_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-campaign
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_campaign_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-campaign
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_campaign_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-campaign
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_case.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_case.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_case_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_case_view_action' => array(
+        'type' => 'civicrm_case',
+        'label' => t('View Case'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_case_add_action' => array(
+        'type' => 'civicrm_case',
+        'label' => t('Add Case'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_case_edit_action' => array(
+        'type' => 'civicrm_case',
+        'label' => t('Edit Case'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_case_delete_action' => array(
+        'type' => 'civicrm_case',
+        'label' => t('Delete Case'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_case_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-case
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_case_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-case
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_case_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-case
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_case_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-case
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_contact.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_contact.inc
@@ -1,0 +1,279 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_contact_action_info() {
+  return array(
+    'civicrm_entity_actions_contact_add_to_group_action' => array(
+      'label' => t('Add Contact to Group'),
+      'type' => 'civicrm_contact',
+      'configurable' => TRUE,
+    ),
+    'civicrm_entity_actions_contact_remove_from_group_action' => array(
+      'label' => t('Remove Contact From Group'),
+      'type' => 'civicrm_contact',
+      'configurable' => TRUE,
+    ),
+    'civicrm_entity_actions_contact_add_entity_tag_action' => array(
+      'label' => t('Tag Contact'),
+      'type' => 'civicrm_contact',
+      'configurable' => TRUE,
+    ),
+      'civicrm_entity_actions_contact_add_relationship_with_contact_action' => array(
+      'label' => t('Add relationship with Contact'),
+      'type' => 'civicrm_contact',
+      'configurable' => TRUE,
+    ),
+    //Crud operations
+    'civicrm_entity_actions_contact_view_action' => array(
+        'type' => 'civicrm_contact',
+        'label' => t('View Contact'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_contact_add_action' => array(
+        'type' => 'civicrm_contact',
+        'label' => t('Add Contact'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_contact_edit_action' => array(
+        'type' => 'civicrm_contact',
+        'label' => t('Edit Contact'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_contact_delete_action' => array(
+        'type' => 'civicrm_contact',
+        'label' => t('Delete Contact'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_contact_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-contact
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_contact_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-contact
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_contact_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-contact
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_contact_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-contact
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}
+
+/**
+ *
+ * @param unknown $object
+ * @param array $context
+ */
+
+function civicrm_entity_actions_contact_add_to_group_action(&$object, $context = array()) {
+  if(!civicrm_initialize()) {
+    return;
+  }
+  civicrm_api3('group_contact', 'create', array(
+      'contact_id' => $object->id,
+      'group_id' => $context['state']['entity_id'],
+      'status' => 'Added',
+    )
+  );
+}
+
+/**
+ *
+ * @param array $context
+ * @return multitype:string unknown
+ */
+
+function civicrm_entity_actions_contact_add_to_group_action_form( $context = array()) {
+  $form['civicrm_contact']['group_id'] = array(
+    '#type' => 'entityreference',
+    '#title' => t('Add To Group'),
+    '#era_entity_type' => 'civicrm_group',
+  );
+  return $form;
+}
+
+/**
+ *
+ * @param array $context
+ * @return multitype:string unknown
+ */
+
+function civicrm_entity_actions_contact_add_to_group_action_submit($form, $form_state) {
+  return array('state' => $form_state['values']['group_id']);
+}
+
+/**
+ *
+ * @param unknown $object
+ * @param array $context
+ */
+
+function civicrm_entity_actions_contact_remove_from_group_action(&$object, $context = array()) {
+  if(!civicrm_initialize()) {
+    return;
+  }
+  civicrm_api3('group_contact', 'create', array(
+  'contact_id' => $object->id,
+  'group_id' => $context['state']['entity_id'],
+  'status' => 'Removed',
+  )
+  );
+}
+
+/**
+ *
+ * @param array $context
+ * @return multitype:string unknown
+ */
+
+function civicrm_entity_actions_contact_remove_from_group_action_form( $context = array()) {
+  $form['civicrm_contact']['group_id'] = array(
+      '#type' => 'entityreference',
+      '#title' => t('Remove From'),
+      '#era_entity_type' => 'civicrm_group',
+  );
+  return $form;
+}
+
+/**
+ *
+ * @param array $context
+ * @return multitype:string unknown
+ */
+
+function civicrm_entity_actions_contact_remove_from_group_action_submit($form, $form_state) {
+  return array('state' => $form_state['values']['group_id']);
+}
+
+/**
+ *
+ * @param unknown $object
+ * @param array $context
+ */
+
+function civicrm_entity_actions_contact_add_entity_tag_action(&$object, $context = array()) {
+  if(!civicrm_initialize()) {
+    return;
+  }
+  civicrm_api3('entity_tag', 'create', array(
+    'contact_id' => $object->id,
+    'tag_id' => $context['state']['entity_id'],
+  )
+  );
+}
+
+/**
+ *
+ * @param array $context
+ * @return multitype:string unknown
+ */
+
+function civicrm_entity_actions_contact_add_entity_tag_action_form( $context = array()) {
+  $form['civicrm_contact']['tag_id'] = array(
+      '#type' => 'entityreference',
+      '#title' => t('Add Tag'),
+      '#era_entity_type' => 'civicrm_tag',
+  );
+  return $form;
+}
+
+/**
+ *
+ * @param array $context
+ * @return multitype:string unknown
+ */
+
+function civicrm_entity_actions_contact_add_entity_tag_action_submit($form, $form_state) {
+  return array('state' => $form_state['values']['tag_id']);
+}
+
+/**
+ *
+ * @param unknown $object
+ * @param array $context
+ */
+
+function civicrm_entity_actions_contact_add_relationship_with_contact_action(&$object, $context = array()) {
+  if(!civicrm_initialize()) {
+    return;
+  }
+  $contact_id_b = null;
+  if (!empty($context['state']['contact_id_b_me'])) {
+    $contact_id_b = trim(strip_tags(views_embed_view('user_contact', 'block')));;
+  } elseif (!empty($context['state']['contact_id_b_my_team'])) {
+    $contact_id_b = trim(strip_tags(views_embed_view('user_team', 'block')));;
+  } else {
+    $contact_id_b = $context['state']['contact_id_b']['entity_id'];
+  }
+  civicrm_api3('relationship', 'create', array(
+      'contact_id_a' => $object->id,
+      'contact_id_b' => $contact_id_b,
+      'relationship_type_id' => $context['state']['relationship_type_id']['entity_id']
+    )
+  );
+}
+
+/**
+ *
+ * @param array $context
+ * @return multitype:string unknown
+ */
+
+function civicrm_entity_actions_contact_add_relationship_with_contact_action_form( $context = array()) {
+  $form['civicrm_contact']['relationship_type_id'] = array(
+      '#type' => 'entityreference',
+      '#title' => t('Add Relationship'),
+      '#era_entity_type' => 'civicrm_relationship_type',
+  );
+  $form['civicrm_contact']['contact_id_b'] = array(
+      '#type' => 'entityreference',
+      '#title' => t('Relationship with contact'),
+      '#era_entity_type' => 'civicrm_contact',
+  );
+  $form['civicrm_contact']['contact_id_b_me'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Relationship with me'),
+  );
+  $form['civicrm_contact']['contact_id_b_my_team'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Relationship with my team'),
+  );
+  return $form;
+}
+
+/**
+ *
+ * @param array $context
+ * @return multitype:string unknown
+ */
+
+function civicrm_entity_actions_contact_add_relationship_with_contact_action_submit($form, $form_state) {
+  return array('state' => $form_state['values']);
+}
+

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_contribution.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_contribution.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_contribution_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_contribution_view_action' => array(
+        'type' => 'civicrm_contribution',
+        'label' => t('View Contribution'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_contribution_add_action' => array(
+        'type' => 'civicrm_contribution',
+        'label' => t('Add Contribution'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_contribution_edit_action' => array(
+        'type' => 'civicrm_contribution',
+        'label' => t('Edit Contribution'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_contribution_delete_action' => array(
+        'type' => 'civicrm_contribution',
+        'label' => t('Delete Contribution'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_contribution_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-contribution
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_contribution_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-contribution
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_contribution_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-contribution
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_contribution_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-contribution
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_contribution_page.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_contribution_page.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_contribution_page_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_contribution_page_view_action' => array(
+        'type' => 'civicrm_contribution_page',
+        'label' => t('View Contribution_page'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_contribution_page_add_action' => array(
+        'type' => 'civicrm_contribution_page',
+        'label' => t('Add Contribution_page'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_contribution_page_edit_action' => array(
+        'type' => 'civicrm_contribution_page',
+        'label' => t('Edit Contribution_page'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_contribution_page_delete_action' => array(
+        'type' => 'civicrm_contribution_page',
+        'label' => t('Delete Contribution_page'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_contribution_page_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-contribution_page
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_contribution_page_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-contribution_page
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_contribution_page_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-contribution_page
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_contribution_page_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-contribution_page
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_country.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_country.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_country_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_country_view_action' => array(
+        'type' => 'civicrm_country',
+        'label' => t('View Country'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_country_add_action' => array(
+        'type' => 'civicrm_country',
+        'label' => t('Add Country'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_country_edit_action' => array(
+        'type' => 'civicrm_country',
+        'label' => t('Edit Country'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_country_delete_action' => array(
+        'type' => 'civicrm_country',
+        'label' => t('Delete Country'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_country_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-country
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_country_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-country
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_country_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-country
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_country_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-country
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_custom_field.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_custom_field.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_custom_field_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_custom_field_view_action' => array(
+        'type' => 'civicrm_custom_field',
+        'label' => t('View Custom_field'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_custom_field_add_action' => array(
+        'type' => 'civicrm_custom_field',
+        'label' => t('Add Custom_field'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_custom_field_edit_action' => array(
+        'type' => 'civicrm_custom_field',
+        'label' => t('Edit Custom_field'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_custom_field_delete_action' => array(
+        'type' => 'civicrm_custom_field',
+        'label' => t('Delete Custom_field'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_custom_field_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-custom_field
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_custom_field_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-custom_field
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_custom_field_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-custom_field
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_custom_field_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-custom_field
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_custom_group.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_custom_group.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_custom_group_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_custom_group_view_action' => array(
+        'type' => 'civicrm_custom_group',
+        'label' => t('View Custom_group'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_custom_group_add_action' => array(
+        'type' => 'civicrm_custom_group',
+        'label' => t('Add Custom_group'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_custom_group_edit_action' => array(
+        'type' => 'civicrm_custom_group',
+        'label' => t('Edit Custom_group'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_custom_group_delete_action' => array(
+        'type' => 'civicrm_custom_group',
+        'label' => t('Delete Custom_group'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_custom_group_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-custom_group
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_custom_group_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-custom_group
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_custom_group_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-custom_group
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_custom_group_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-custom_group
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_email.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_email.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_email_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_email_view_action' => array(
+        'type' => 'civicrm_email',
+        'label' => t('View Email'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_email_add_action' => array(
+        'type' => 'civicrm_email',
+        'label' => t('Add Email'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_email_edit_action' => array(
+        'type' => 'civicrm_email',
+        'label' => t('Edit Email'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_email_delete_action' => array(
+        'type' => 'civicrm_email',
+        'label' => t('Delete Email'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_email_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-email
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_email_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-email
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_email_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-email
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_email_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-email
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_entity_tag.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_entity_tag.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_entity_tag_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_entity_tag_view_action' => array(
+        'type' => 'civicrm_entity_tag',
+        'label' => t('View Entity_tag'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_entity_tag_add_action' => array(
+        'type' => 'civicrm_entity_tag',
+        'label' => t('Add Entity_tag'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_entity_tag_edit_action' => array(
+        'type' => 'civicrm_entity_tag',
+        'label' => t('Edit Entity_tag'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_entity_tag_delete_action' => array(
+        'type' => 'civicrm_entity_tag',
+        'label' => t('Delete Entity_tag'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_entity_tag_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-entity_tag
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_entity_tag_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-entity_tag
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_entity_tag_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-entity_tag
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_entity_tag_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-entity_tag
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_event.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_event.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_event_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_event_view_action' => array(
+        'type' => 'civicrm_event',
+        'label' => t('View Event'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_event_add_action' => array(
+        'type' => 'civicrm_event',
+        'label' => t('Add Event'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_event_edit_action' => array(
+        'type' => 'civicrm_event',
+        'label' => t('Edit Event'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_event_delete_action' => array(
+        'type' => 'civicrm_event',
+        'label' => t('Delete Event'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_event_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-event
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_event_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-event
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_event_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-event
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_event_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-event
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_financial_type.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_financial_type.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_financial_type_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_financial_type_view_action' => array(
+        'type' => 'civicrm_financial_type',
+        'label' => t('View Financial_type'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_financial_type_add_action' => array(
+        'type' => 'civicrm_financial_type',
+        'label' => t('Add Financial_type'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_financial_type_edit_action' => array(
+        'type' => 'civicrm_financial_type',
+        'label' => t('Edit Financial_type'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_financial_type_delete_action' => array(
+        'type' => 'civicrm_financial_type',
+        'label' => t('Delete Financial_type'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_financial_type_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-financial_type
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_financial_type_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-financial_type
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_financial_type_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-financial_type
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_financial_type_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-financial_type
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_grant.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_grant.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_grant_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_grant_view_action' => array(
+        'type' => 'civicrm_grant',
+        'label' => t('View Grant'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_grant_add_action' => array(
+        'type' => 'civicrm_grant',
+        'label' => t('Add Grant'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_grant_edit_action' => array(
+        'type' => 'civicrm_grant',
+        'label' => t('Edit Grant'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_grant_delete_action' => array(
+        'type' => 'civicrm_grant',
+        'label' => t('Delete Grant'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_grant_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-grant
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_grant_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-grant
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_grant_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-grant
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_grant_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-grant
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_group.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_group.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_group_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_group_view_action' => array(
+        'type' => 'civicrm_group',
+        'label' => t('View Group'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_group_add_action' => array(
+        'type' => 'civicrm_group',
+        'label' => t('Add Group'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_group_edit_action' => array(
+        'type' => 'civicrm_group',
+        'label' => t('Edit Group'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_group_delete_action' => array(
+        'type' => 'civicrm_group',
+        'label' => t('Delete Group'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_group_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-group
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_group_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-group
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_group_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-group
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_group_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-group
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_membership.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_membership.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_membership_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_membership_view_action' => array(
+        'type' => 'civicrm_membership',
+        'label' => t('View Membership'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_membership_add_action' => array(
+        'type' => 'civicrm_membership',
+        'label' => t('Add Membership'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_membership_edit_action' => array(
+        'type' => 'civicrm_membership',
+        'label' => t('Edit Membership'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_membership_delete_action' => array(
+        'type' => 'civicrm_membership',
+        'label' => t('Delete Membership'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_membership_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-membership
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_membership_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-membership
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_membership_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-membership
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_membership_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-membership
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_membership_type.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_membership_type.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_membership_type_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_membership_type_view_action' => array(
+        'type' => 'civicrm_membership_type',
+        'label' => t('View Membership_type'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_membership_type_add_action' => array(
+        'type' => 'civicrm_membership_type',
+        'label' => t('Add Membership_type'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_membership_type_edit_action' => array(
+        'type' => 'civicrm_membership_type',
+        'label' => t('Edit Membership_type'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_membership_type_delete_action' => array(
+        'type' => 'civicrm_membership_type',
+        'label' => t('Delete Membership_type'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_membership_type_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-membership_type
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_membership_type_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-membership_type
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_membership_type_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-membership_type
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_membership_type_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-membership_type
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_note.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_note.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_note_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_note_view_action' => array(
+        'type' => 'civicrm_note',
+        'label' => t('View Note'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_note_add_action' => array(
+        'type' => 'civicrm_note',
+        'label' => t('Add Note'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_note_edit_action' => array(
+        'type' => 'civicrm_note',
+        'label' => t('Edit Note'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_note_delete_action' => array(
+        'type' => 'civicrm_note',
+        'label' => t('Delete Note'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_note_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-note
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_note_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-note
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_note_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-note
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_note_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-note
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_participant.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_participant.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_participant_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_participant_view_action' => array(
+        'type' => 'civicrm_participant',
+        'label' => t('View Participant'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_participant_add_action' => array(
+        'type' => 'civicrm_participant',
+        'label' => t('Add Participant'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_participant_edit_action' => array(
+        'type' => 'civicrm_participant',
+        'label' => t('Edit Participant'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_participant_delete_action' => array(
+        'type' => 'civicrm_participant',
+        'label' => t('Delete Participant'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_participant_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-participant
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_participant_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-participant
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_participant_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-participant
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_participant_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-participant
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_phone.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_phone.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_phone_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_phone_view_action' => array(
+        'type' => 'civicrm_phone',
+        'label' => t('View Phone'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_phone_add_action' => array(
+        'type' => 'civicrm_phone',
+        'label' => t('Add Phone'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_phone_edit_action' => array(
+        'type' => 'civicrm_phone',
+        'label' => t('Edit Phone'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_phone_delete_action' => array(
+        'type' => 'civicrm_phone',
+        'label' => t('Delete Phone'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_phone_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-phone
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_phone_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-phone
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_phone_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-phone
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_phone_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-phone
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_pledge.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_pledge.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_pledge_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_pledge_view_action' => array(
+        'type' => 'civicrm_pledge',
+        'label' => t('View Pledge'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_pledge_add_action' => array(
+        'type' => 'civicrm_pledge',
+        'label' => t('Add Pledge'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_pledge_edit_action' => array(
+        'type' => 'civicrm_pledge',
+        'label' => t('Edit Pledge'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_pledge_delete_action' => array(
+        'type' => 'civicrm_pledge',
+        'label' => t('Delete Pledge'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_pledge_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-pledge
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_pledge_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-pledge
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_pledge_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-pledge
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_pledge_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-pledge
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_pledge_payment.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_pledge_payment.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_pledge_payment_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_pledge_payment_view_action' => array(
+        'type' => 'civicrm_pledge_payment',
+        'label' => t('View Pledge_payment'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_pledge_payment_add_action' => array(
+        'type' => 'civicrm_pledge_payment',
+        'label' => t('Add Pledge_payment'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_pledge_payment_edit_action' => array(
+        'type' => 'civicrm_pledge_payment',
+        'label' => t('Edit Pledge_payment'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_pledge_payment_delete_action' => array(
+        'type' => 'civicrm_pledge_payment',
+        'label' => t('Delete Pledge_payment'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_pledge_payment_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-pledge_payment
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_pledge_payment_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-pledge_payment
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_pledge_payment_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-pledge_payment
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_pledge_payment_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-pledge_payment
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_price_field.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_price_field.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_price_field_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_price_field_view_action' => array(
+        'type' => 'civicrm_price_field',
+        'label' => t('View Price_field'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_price_field_add_action' => array(
+        'type' => 'civicrm_price_field',
+        'label' => t('Add Price_field'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_price_field_edit_action' => array(
+        'type' => 'civicrm_price_field',
+        'label' => t('Edit Price_field'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_price_field_delete_action' => array(
+        'type' => 'civicrm_price_field',
+        'label' => t('Delete Price_field'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_price_field_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-price_field
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_price_field_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-price_field
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_price_field_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-price_field
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_price_field_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-price_field
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_price_field_value.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_price_field_value.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_price_field_value_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_price_field_value_view_action' => array(
+        'type' => 'civicrm_price_field_value',
+        'label' => t('View Price_field_value'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_price_field_value_add_action' => array(
+        'type' => 'civicrm_price_field_value',
+        'label' => t('Add Price_field_value'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_price_field_value_edit_action' => array(
+        'type' => 'civicrm_price_field_value',
+        'label' => t('Edit Price_field_value'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_price_field_value_delete_action' => array(
+        'type' => 'civicrm_price_field_value',
+        'label' => t('Delete Price_field_value'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_price_field_value_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-price_field_value
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_price_field_value_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-price_field_value
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_price_field_value_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-price_field_value
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_price_field_value_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-price_field_value
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_price_set.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_price_set.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_price_set_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_price_set_view_action' => array(
+        'type' => 'civicrm_price_set',
+        'label' => t('View Price_set'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_price_set_add_action' => array(
+        'type' => 'civicrm_price_set',
+        'label' => t('Add Price_set'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_price_set_edit_action' => array(
+        'type' => 'civicrm_price_set',
+        'label' => t('Edit Price_set'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_price_set_delete_action' => array(
+        'type' => 'civicrm_price_set',
+        'label' => t('Delete Price_set'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_price_set_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-price_set
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_price_set_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-price_set
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_price_set_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-price_set
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_price_set_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-price_set
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_relationship.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_relationship.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_relationship_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_relationship_view_action' => array(
+        'type' => 'civicrm_relationship',
+        'label' => t('View Relationship'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_relationship_add_action' => array(
+        'type' => 'civicrm_relationship',
+        'label' => t('Add Relationship'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_relationship_edit_action' => array(
+        'type' => 'civicrm_relationship',
+        'label' => t('Edit Relationship'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_relationship_delete_action' => array(
+        'type' => 'civicrm_relationship',
+        'label' => t('Delete Relationship'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_relationship_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-relationship
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_relationship_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-relationship
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_relationship_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-relationship
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_relationship_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-relationship
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_relationship_type.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_relationship_type.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_relationship_type_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_relationship_type_view_action' => array(
+        'type' => 'civicrm_relationship_type',
+        'label' => t('View Relationship_type'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_relationship_type_add_action' => array(
+        'type' => 'civicrm_relationship_type',
+        'label' => t('Add Relationship_type'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_relationship_type_edit_action' => array(
+        'type' => 'civicrm_relationship_type',
+        'label' => t('Edit Relationship_type'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_relationship_type_delete_action' => array(
+        'type' => 'civicrm_relationship_type',
+        'label' => t('Delete Relationship_type'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_relationship_type_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-relationship_type
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_relationship_type_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-relationship_type
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_relationship_type_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-relationship_type
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_relationship_type_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-relationship_type
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_survey.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_survey.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_survey_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_survey_view_action' => array(
+        'type' => 'civicrm_survey',
+        'label' => t('View Survey'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_survey_add_action' => array(
+        'type' => 'civicrm_survey',
+        'label' => t('Add Survey'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_survey_edit_action' => array(
+        'type' => 'civicrm_survey',
+        'label' => t('Edit Survey'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_survey_delete_action' => array(
+        'type' => 'civicrm_survey',
+        'label' => t('Delete Survey'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_survey_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-survey
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_survey_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-survey
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_survey_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-survey
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_survey_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-survey
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}

--- a/modules/civicrm_entity_actions/civicrm_entity_actions_tag.inc
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions_tag.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ *
+ * @return multitype:multitype:string boolean NULL
+ */
+
+function civicrm_entity_actions_tag_action_info() {
+  return array(
+    //Crud operations
+    'civicrm_entity_actions_tag_view_action' => array(
+        'type' => 'civicrm_tag',
+        'label' => t('View Tag'),
+        'configurable' => FALSE,
+        'behavior' => array('views_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_tag_add_action' => array(
+        'type' => 'civicrm_tag',
+        'label' => t('Add Tag'),
+        'configurable' => FALSE,
+        'behavior' => array('creates_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_tag_edit_action' => array(
+        'type' => 'civicrm_tag',
+        'label' => t('Edit Tag'),
+        'configurable' => FALSE,
+        'behavior' => array('changes_property'),
+        'triggers' => array('any'),
+    ),
+    'civicrm_entity_actions_tag_delete_action' => array(
+        'type' => 'civicrm_tag',
+        'label' => t('Delete Tag'),
+        'configurable' => FALSE,
+        'behavior' => array('deletes_property'),
+        'triggers' => array('any'),
+    ),
+  );
+}
+
+function civicrm_entity_actions_tag_add_action($entity, $context = array()) {
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-tag
+  drupal_goto($base_url . '/add');
+}
+
+function civicrm_entity_actions_tag_view_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-tag
+  drupal_goto($base_url . '/' . $entity_id);
+}
+
+function civicrm_entity_actions_tag_edit_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-tag
+  drupal_goto($base_url . '/' . $entity_id . '/edit');
+}
+
+function civicrm_entity_actions_tag_delete_action($entity, $context = array()) {
+  $info = entity_get_info($context['entity_type']);
+  $entity_id = $entity->{$info['entity keys']['id']};
+  $base_url = str_replace('_', '-', $context['entity_type']); // civicrm-tag
+  drupal_goto($base_url . '/' . $entity_id . '/delete');
+}


### PR DESCRIPTION
Here are the same changes I made on civicrm_entity_actions when it was a standalone module
I hope it sticks this time ;-)

For the pathes
/
/add
/edit
/delete

there is an action for each entity and each operation,
to see the actions in vbo settings
and to be able to manage distinct permissions in actions_permissions
