### PR TITLE
WIP -- Enabling civicrm_entity_reference fields on add/create

### DIFF
--- a/civicrm_entity.default_form.inc
+++ b/civicrm_entity.default_form.inc
@@ -446,9 +446,50 @@ function civicrm_entity_form_submit(&$form, &$form_state) {
   $entity->changed = time();
 
   $wrapper = entity_metadata_wrapper($entity_type, $entity);
-  field_attach_submit($entity_type, $entity, $form, $form_state);
+  //field_attach_submit($entity_type, $entity, $form, $form_state);
 
-  $wrapper->save();
+  //$wrapper->save();
+  // handling for civicrm entity reference fields on civicrm entities
+  $target_id_columns = array();
+  if ($entity->is_new) {
+    foreach ($form as $key => $form_field) {
+      if (strpos($key, 'field_') === 0) {
+        $field = field_info_field($key);
+        if ($field['type'] == 'civicrm_entity_reference') {
+          $ief_id = $form_field['und']['#ief_id'];
+          $host_entity_type = $form_state['inline_entity_form'][$ief_id]['instance']['entity_type'];
+          if ($host_entity_type == $entity_type) {
+            $target_id_columns[$key] = array($field['settings']['host_source_id'] => $field['settings']['target_id_column']);
+          }
+        }
+      }
+    }
+
+    if (!empty($target_id_columns)) {
+      // first save the entity
+      $wrapper->save();
+      // then update civicrm entity target id values with host id
+      foreach ($target_id_columns as $key => $target_id_column) {
+        $host_id = key($target_id_column);
+        $target_id = reset($target_id_column);
+        $ief_id = $form[$key]['und']['#ief_id'];
+        foreach ($form_state['inline_entity_form'][$ief_id]['entities'] as $item_index => $item) {
+          if(!empty($form_state['inline_entity_form'][$ief_id]['entities'][$item_index]['entity']->is_new)) {
+            $form_state['inline_entity_form'][$ief_id]['entities'][$item_index]['entity']->{$target_id} = $entity->{$host_id};
+          }
+        }
+      }
+      // this will create the civicrm entity reference fields entities
+      field_attach_submit($entity_type, $entity, $form, $form_state);
+    }
+  }
+  // is update, handle "normally"
+  else {
+    field_attach_submit($entity_type, $entity, $form, $form_state);
+    $wrapper->save();
+  }
+
+
 
   $t_args = array(
     '%label' => entity_label($entity_type, $entity),

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -248,7 +248,10 @@ function civicrm_entity_views_data_alter(&$data) {
   foreach ($civicrm_entity_types as $civicrm_entity_type => $info) {
     foreach ($data[$civicrm_entity_type] as $property => $prop_info) {
       if (strpos($property, 'custom_') === 0) {
-        unset($data[$civicrm_entity_type][$property]);
+        $name_array = explode('_', $property);
+        if(!isset($name_array[1]) && is_numeric($name_array[1])) {
+          unset($data[$civicrm_entity_type][$property]);
+        }
       }
     }
   }

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -1862,7 +1862,32 @@ function civicrm_entity_supported_entities_info() {
       ),
     ),
   );
-
+  $civicrm_entity_info['civicrm_website'] = array(
+    'civicrm entity name' => 'website',
+    'label property' => 'url',
+    'permissions' => array(
+      'view' => array('view all contacts'),
+      'edit' => array('edit all contacts'),
+      'update' => array('edit all contacts'),
+      'create' => array('edit all contacts'),
+      'delete' => array('delete contacts'),
+    ),
+    'theme' => array(
+      'template' => 'civicrm-website',
+      'path' => drupal_get_path('module', 'civicrm_entity') . '/templates',
+    ),
+    'display suite' => array(
+      'link fields' => array(
+        array(
+          'link_field' => 'contact_id',
+          'target' => 'civicrm_contact',
+        ),
+      ),
+      'option fields' => array(
+        'website_type_id',
+      ),
+    ),
+  );
   return $civicrm_entity_info;
 }
 

--- a/civicrm_entity_controller.inc
+++ b/civicrm_entity_controller.inc
@@ -174,6 +174,8 @@ class CivicrmEntityController extends EntityAPIController {
       $params['version'] = 3;
       $params['sequential'] = 1;
 
+
+
       if ($entity->is_new) {
         if (isset($params['id'])) {
           unset($params['id']);

--- a/modules/civicrm_entity_inline/civicrm_entity_inline.module
+++ b/modules/civicrm_entity_inline/civicrm_entity_inline.module
@@ -25,5 +25,6 @@ function civicrm_entity_inline_inline_entity_form_entity_form_alter(&$entity_for
   $form_id = $form_state['build_info']['form_id'] . '_ief_' . $entity_form['#entity_type'] . '_' . $entity_form['#bundle'];
   $entity_form['#form_id'] = $form_id;
 
-  drupal_alter(array('form', 'form_' . $form_id, 'form_' . $form_state['build_info']['base_form_id']), $entity_form, $form_state, $form_id);
+  //drupal_alter(array('form', 'form_' . $form_id, 'form_' . $form_state['build_info']['base_form_id']), $entity_form, $form_state, $form_id);
+  drupal_alter('form', $entity_form, $form_state, $form_id);
 }

--- a/modules/civicrm_entity_inline/includes/civicrm.civicrm_entity_inline.inc
+++ b/modules/civicrm_entity_inline/includes/civicrm.civicrm_entity_inline.inc
@@ -227,6 +227,7 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
         } // end if isset widget
       } // end else not a drupal field
     } // end foreach
+
     return $entity_form;
   }
 
@@ -430,7 +431,6 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
 
       // First parent name is not the field name, then this reference field is nested inside another
       if ($field_name != $entity_form['#parents'][0]) {
-
         $parent_field_parents = array();
         foreach($entity_form['#parents'] as $index => $name) {
           $parent_field_parents[] = $name;

--- a/modules/civicrm_entity_inline/includes/civicrm.civicrm_entity_inline.inc
+++ b/modules/civicrm_entity_inline/includes/civicrm.civicrm_entity_inline.inc
@@ -458,21 +458,26 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
             $parent_field_wrapper = entity_metadata_wrapper($parent_field_entity_type, $parent_field_entity);
 
             $parent_field_wrapper->save();
+
             $parent_submitted_values[$field_host_source_id] = $parent_field_wrapper->{$field_host_source_id}->value();
             if ($parent_field_entity_type == 'civicrm_contact') {
+              $parent_field_wrapper->contact_id->set($parent_field_wrapper->{$field_host_source_id}->value());
               $parent_submitted_values['contact_id'] = $parent_field_wrapper->{$field_host_source_id}->value();
             }
             $child_form_state_values[$field_target_id_column] = $parent_field_wrapper->{$field_host_source_id}->value();
+
+            //$entity->{$field_target_id_column} = $parent_field_wrapper->{$field_host_source_id}->value();
+
 
             drupal_array_set_nested_value($form_state['values'], $parent_field_parents, $parent_submitted_values);
             foreach($form_state['inline_entity_form'] as $iefid => $ief_data) {
               if($ief_data['instance']['field_name'] == $parent_field_name) {
                 $entity_count = count($form_state['inline_entity_form'][$iefid]['entities']);
-                $form_state['inline_entity_form'][$iefid]['entities'][$entity_count]['entity'] = $parent_field_wrapper->value();
+                //$form_state['inline_entity_form'][$iefid]['entities'][$entity_count]['entity'] = $parent_field_wrapper->value();
                 if ($parent_field_entity_type == 'civicrm_contact') {
-                  $form_state['inline_entity_form'][$iefid]['entities'][$entity_count]['entity']->contact_id = $parent_field_wrapper->{$field_host_source_id}->value();
+                  //$form_state['inline_entity_form'][$iefid]['entities'][$entity_count]['entity']->contact_id = $parent_field_wrapper->{$field_host_source_id}->value();
                 }
-                $form_state['inline_entity_form'][$iefid]['entities'][$entity_count]['needs_save'] = FALSE;
+                //$form_state['inline_entity_form'][$iefid]['entities'][$entity_count]['needs_save'] = FALSE;
               }
             }
 
@@ -480,16 +485,20 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
           else {
             $child_form_state_values[$field_target_id_column] = $parent_submitted_values[$field_host_source_id];
 
+            //$entity->{$field_target_id_column} = $parent_submitted_values[$field_host_source_id];
           }
         }
 
       }
 
       drupal_array_set_nested_value($form_state['values'], $entity_form['#parents'], $child_form_state_values);
-      $entity_form['#entity'] = $entity;
+
     }
     // Add in created and changed times.
+    //dsm($entity_form);
+   // dsm($form_state);
     parent::entityFormSubmit($entity_form, $form_state);
+
   }
 
   /**

--- a/modules/civicrm_entity_inline/includes/civicrm.civicrm_entity_inline.inc
+++ b/modules/civicrm_entity_inline/includes/civicrm.civicrm_entity_inline.inc
@@ -495,10 +495,7 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
 
     }
     // Add in created and changed times.
-    //dsm($entity_form);
-   // dsm($form_state);
     parent::entityFormSubmit($entity_form, $form_state);
-
   }
 
   /**

--- a/modules/civicrm_entity_inline/includes/civicrm.civicrm_entity_inline.inc
+++ b/modules/civicrm_entity_inline/includes/civicrm.civicrm_entity_inline.inc
@@ -5,8 +5,9 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
    * Overrides EntityInlineEntityFormController::entityForm().
    */
   public function entityForm($entity_form, &$form_state) {
-    $entity_type = $form_state['entity_type'] = $entity_form['#entity_type'];
-    $entity = $form_state['entity'] = $entity_form['#entity'];
+    $entity_type = $entity_form['#entity_type'];
+
+    $entity =  $entity_form['#entity'];
     $entity->type = $entity_type;
     $op = $entity_form['#op'];
 
@@ -230,9 +231,10 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
   }
 
   public function entityFormValidate($entity_form, &$form_state) {
-    $entity_type = $form_state['entity_type'];
-    $field_name = $entity_form['#parents'][0];
+    $entity_type = $entity_form['#entity_type'];
     $ief_id = $entity_form['#ief_id'];
+    $field_name = $form_state['inline_entity_form'][$ief_id]['instance']['field_name'];
+
     $op = $entity_form['#op'];
     if ($op == 'edit') {
       foreach ($form_state['inline_entity_form'][$ief_id]['entities'] as $delta => &$entity_array) {
@@ -256,9 +258,11 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
       }
     }
     elseif ($op == 'create' || $op == 'add') {
-      $entity = $form_state['entity'];
 
-      foreach ($form_state['values'][$field_name]['und']['form'] as $key => $value) {
+      $entity = $entity_form['#entity'];
+
+      $child_form_state_values = drupal_array_get_nested_value($form_state['values'], $entity_form['#parents']);
+      foreach ($child_form_state_values as $key => $value) {
         if (!is_array($value)) {
           $entity->{$key} = $value;
         }
@@ -342,9 +346,10 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
   }
 
   public function entityFormSubmit(&$entity_form, &$form_state) {
-    $entity_type = $form_state['entity_type'];
-    $field_name = $entity_form['#parents'][0];
+    //$entity_type = $form_state['entity_type'];
+    $entity_type = $entity_form['#entity_type'];
     $ief_id = $entity_form['#ief_id'];
+    $field_name = $form_state['inline_entity_form'][$ief_id]['instance']['field_name'];
     $op = $entity_form['#op'];
     civicrm_initialize();
     $civicrm_entity_fields = civicrm_api(substr_replace($entity_type, '', 0, 8), 'getfields', array(
@@ -396,62 +401,145 @@ class CivicrmInlineEntityFormController extends EntityInlineEntityFormController
           }
           $entity_array['entity']->changed = time();
 
-          //$wrapper = entity_metadata_wrapper($entity_type, $entity);
           field_attach_submit($entity_type, $entity_array['entity'], $entity_form, $form_state);
 
         }
       }
     }
     elseif ($op == 'create' || $op == 'add') {
+      $entity = $entity_form['#entity'];
 
-      $entity = $form_state['entity'];
-      foreach ($form_state['values'][$field_name]['und']['form'] as $key => $value) {
-        if (substr($key, 0, 7) == 'custom_') {
-          if ($civicrm_entity_fields['values'][$key]['html_type'] == 'CheckBox') {
-            if (is_array($value)) {
-              $stored_value = array();
-              foreach ($value as $option => $checkbox_value) {
-                if ($checkbox_value) {
-                  $stored_value[] = $option;
+      $child_form_state_values = drupal_array_get_nested_value($form_state['values'], $entity_form['#parents']);
+      $field_info = field_info_field($field_name);
+      $field_target_id_column = !empty($field_info['settings']['target_id_column']) ? $field_info['settings']['target_id_column'] : '';
+      $field_host_source_id = !empty($field_info['settings']['host_source_id']) ? $field_info['settings']['host_source_id'] : '';
+
+      $this->fillEntityValues($child_form_state_values, $entity, $civicrm_entity_fields);
+
+      if(!empty($entity->is_new) && !empty($entity->id)) {
+        $entity->is_new = FALSE;
+        if($entity_type == 'civicrm_contact') {
+          $entity->contact_id = $entity->id;
+        }
+      }
+
+      if ($entity->is_new = isset($entity->is_new) ? $entity->is_new : 0) {
+        $entity->created = time();
+      }
+      $entity->changed = time();
+
+      // First parent name is not the field name, then this reference field is nested inside another
+      if ($field_name != $entity_form['#parents'][0]) {
+
+        $parent_field_parents = array();
+        foreach($entity_form['#parents'] as $index => $name) {
+          $parent_field_parents[] = $name;
+          if ($name == $field_name) {
+            unset($parent_field_parents[$index]);
+            $parent_field_name = $entity_form['#parents'][$index-3];
+            break;
+          }
+        }
+
+        $parent_field_info = field_info_field($parent_field_name);
+        if (!empty($parent_field_info['settings']['target_type'])) {
+          $parent_field_entity_type = $parent_field_info['settings']['target_type'];
+        }
+        elseif (!empty($parent_field_info['settings']['target_entity_type'])) {
+          $parent_field_entity_type = $parent_field_info['settings']['target_entity_type'];
+        }
+        if(!empty($parent_field_parents) && !empty($parent_field_entity_type) && !empty($field_host_source_id) && !empty($field_target_id_column) ) {
+          $parent_submitted_values = drupal_array_get_nested_value($form_state['values'], $parent_field_parents);
+          if(empty($parent_submitted_values[$field_host_source_id])) {
+            // save parent entity and update something?
+            $parent_field_entity = new CivicrmEntity(array(), $parent_field_entity_type);
+            $this->fillEntityValues($parent_submitted_values, $parent_field_entity, $civicrm_entity_fields);
+
+            $parent_field_wrapper = entity_metadata_wrapper($parent_field_entity_type, $parent_field_entity);
+
+            $parent_field_wrapper->save();
+            $parent_submitted_values[$field_host_source_id] = $parent_field_wrapper->{$field_host_source_id}->value();
+            if ($parent_field_entity_type == 'civicrm_contact') {
+              $parent_submitted_values['contact_id'] = $parent_field_wrapper->{$field_host_source_id}->value();
+            }
+            $child_form_state_values[$field_target_id_column] = $parent_field_wrapper->{$field_host_source_id}->value();
+
+            drupal_array_set_nested_value($form_state['values'], $parent_field_parents, $parent_submitted_values);
+            foreach($form_state['inline_entity_form'] as $iefid => $ief_data) {
+              if($ief_data['instance']['field_name'] == $parent_field_name) {
+                $entity_count = count($form_state['inline_entity_form'][$iefid]['entities']);
+                $form_state['inline_entity_form'][$iefid]['entities'][$entity_count]['entity'] = $parent_field_wrapper->value();
+                if ($parent_field_entity_type == 'civicrm_contact') {
+                  $form_state['inline_entity_form'][$iefid]['entities'][$entity_count]['entity']->contact_id = $parent_field_wrapper->{$field_host_source_id}->value();
                 }
+                $form_state['inline_entity_form'][$iefid]['entities'][$entity_count]['needs_save'] = FALSE;
               }
-              $entity->{$key} = !empty($stored_value) ? $stored_value : array('');
             }
 
           }
           else {
-            if (is_array($value) && isset($value['value'])) {
-              $value = $value['value'];
-              $form_state['values'][$field_name]['und']['form'][$key] = $value;
-            }
-            $entity->{$key} = $value;
-          }
+            $child_form_state_values[$field_target_id_column] = $parent_submitted_values[$field_host_source_id];
 
-          if (!empty($civicrm_entity_fields['values'][$key]['is_view'])) {
-            unset($entity->{$key});
+          }
+        }
+
+      }
+
+      drupal_array_set_nested_value($form_state['values'], $entity_form['#parents'], $child_form_state_values);
+      $entity_form['#entity'] = $entity;
+    }
+    // Add in created and changed times.
+    parent::entityFormSubmit($entity_form, $form_state);
+  }
+
+  /**
+   * Utility function to fill entity with form values
+   *
+   * @param $values
+   * @param $entity
+   * @param $civicrm_entity_fields
+   * @param string $entity_type
+   */
+  private function fillEntityValues(&$values, $entity, $civicrm_entity_fields, $entity_type = '') {
+
+    foreach ($values as $key => $value) {
+
+      if (substr($key, 0, 7) == 'custom_') {
+        if (!empty($civicrm_entity_fields['values'][$key]['html_type']) && $civicrm_entity_fields['values'][$key]['html_type'] == 'CheckBox') {
+          if (is_array($value)) {
+            $stored_value = array();
+            foreach ($value as $option => $checkbox_value) {
+              if ($checkbox_value) {
+                $stored_value[] = $option;
+              }
+            }
+            $entity->{$key} = !empty($stored_value) ? $stored_value : array('');
           }
 
         }
         else {
           if (is_array($value) && isset($value['value'])) {
             $value = $value['value'];
-            $form_state['values'][$field_name]['und']['form'][$key] = $value;
+            //$form_state['values'][$field_name]['und']['form'][$key] = $value;
+            $values[$key] = $value;
           }
           $entity->{$key} = $value;
         }
-      }
-      if ($entity->is_new = isset($entity->is_new) ? $entity->is_new : 0) {
-        $entity->created = time();
-      }
-      $entity->changed = time();
 
-      //$wrapper = entity_metadata_wrapper($entity_type, $entity);
-      field_attach_submit($entity_type, $entity, $entity_form, $form_state);
+        if (!empty($civicrm_entity_fields['values'][$key]['is_view'])) {
+          unset($entity->{$key});
+        }
+
+      }
+      else {
+        if (is_array($value) && isset($value['value'])) {
+          $value = $value['value'];
+          //$form_state['values'][$field_name]['und']['form'][$key] = $value;
+          $values[$key] = $value;
+        }
+        $entity->{$key} = $value;
+      }
     }
-    // Add in created and changed times.
-
-
-    parent::entityFormSubmit($entity_form, $form_state);
   }
 
 }

--- a/modules/civicrm_entity_price_set_field/civicrm_entity_price_set_field.api.php
+++ b/modules/civicrm_entity_price_set_field/civicrm_entity_price_set_field.api.php
@@ -117,7 +117,7 @@ function civicrm_customs_event_registration_access_callback($entity_type, $entit
       return TRUE;
     }
     // disallow access if the user doesn't have role id 5 and the event type is 7 or 9
-    elseif(!isset($account->roles[5]) && !empty($entity->event_type_id) && in_array($entity->event_type_id, array(7, 9))) {
+    elseif(!isset($account->roles[5]) && (!empty($entity->event_type_id) && in_array($entity->event_type_id, array(7, 9)))) {
       return FALSE;
     }
   }

--- a/modules/civicrm_entity_reference_field/civicrm_entity_reference_field.module
+++ b/modules/civicrm_entity_reference_field/civicrm_entity_reference_field.module
@@ -657,9 +657,9 @@ function civicrm_entity_reference_field_field_widget_form_alter(&$element, &$for
     }
     elseif ($context['instance']['widget']['type'] == 'inline_entity_form') {
       if ((!empty($form_state['op']) && $form_state['op'] == 'create') || (!empty($context['form']['#op'])) && $context['form']['#op'] == 'add') {
-        if ($element['#entity_type'] != 'civicrm_contact') {
+        //if ($element['#entity_type'] != 'civicrm_contact') {
           $element['actions']['ief_add']['#disabled'] = TRUE;
-        }
+        //}
       }
     }
     elseif ($context['instance']['widget']['type'] == 'civicrm_entity_reference_default_widget') {
@@ -708,10 +708,10 @@ function civicrm_entity_reference_field_inline_entity_form_entity_form_alter(&$e
     // this doesn't handle a field that is nested on an entityreference field that is on say a node....
     // this handles the 'multi' widget
     if (isset($form_state['complete form'][$host_id_prop]['#default_value']) && isset($entity_form[$target_id_column]) && is_array($entity_form[$target_id_column])) {
-        if ($entity_form['#op'] == 'add' || $entity_form['#op'] == 'create') {
-         $entity_form[$target_id_column]['#default_value'] = $form_state['complete form'][$host_id_prop]['#default_value'];
-        }
-        $entity_form[$target_id_column]['#disabled'] = TRUE;
+      if ($entity_form['#op'] == 'add' || $entity_form['#op'] == 'create') {
+        $entity_form[$target_id_column]['#default_value'] = $form_state['complete form'][$host_id_prop]['#default_value'];
+      }
+      $entity_form[$target_id_column]['#disabled'] = TRUE;
     }// this handles the 'single' widget
     elseif (isset($form_state['field'][$field_name][LANGUAGE_NONE]['instance']['entity_type'])) {
       $host_entity_type = $form_state['field'][$field_name][LANGUAGE_NONE]['instance']['entity_type'];

--- a/modules/civicrm_entity_reference_field/civicrm_entity_reference_field.module
+++ b/modules/civicrm_entity_reference_field/civicrm_entity_reference_field.module
@@ -647,8 +647,6 @@ function civicrm_entity_reference_field_field_widget_form_alter(&$element, &$for
         if ($element['#entity_type'] == 'civicrm_contact' && array_key_exists($field, $element['form'])) {
           $element['form'][$field]['#required'] = FALSE;
           $element['form'][$field]['#disabled'] = TRUE;
-          if (empty($element['form'][$field]['#default_value'])) {
-          }
         }
         else {
           unset($element['form']);
@@ -657,10 +655,8 @@ function civicrm_entity_reference_field_field_widget_form_alter(&$element, &$for
     }
     elseif ($context['instance']['widget']['type'] == 'inline_entity_form') {
       if ((!empty($form_state['op']) && $form_state['op'] == 'create') || (!empty($context['form']['#op'])) && $context['form']['#op'] == 'add') {
-        //if ($element['#entity_type'] != 'civicrm_contact') {
-          $element['actions']['ief_add']['#disabled'] = TRUE;
-        //}
-      }
+           $element['actions']['ief_add']['#disabled'] = TRUE;
+        }
     }
     elseif ($context['instance']['widget']['type'] == 'civicrm_entity_reference_default_widget') {
       if ($form_state['op'] == 'create') {

--- a/modules/civicrm_entity_reference_field/civicrm_entity_reference_field.module
+++ b/modules/civicrm_entity_reference_field/civicrm_entity_reference_field.module
@@ -644,7 +644,7 @@ function civicrm_entity_reference_field_field_widget_form_alter(&$element, &$for
     if ($context['instance']['widget']['type'] == 'inline_entity_form_single') {
       if ((!empty($form_state['op']) && $form_state['op'] == 'create') || (!empty($element['form']['#op'])) && $element['form']['#op'] == 'add') {
         $field = $context['field']['settings']['target_id_column'];
-        if (array_key_exists($field, $element['form'])) {
+        if ($element['#entity_type'] == 'civicrm_contact' && array_key_exists($field, $element['form'])) {
           $element['form'][$field]['#required'] = FALSE;
           $element['form'][$field]['#disabled'] = TRUE;
           if (empty($element['form'][$field]['#default_value'])) {
@@ -656,8 +656,10 @@ function civicrm_entity_reference_field_field_widget_form_alter(&$element, &$for
       }
     }
     elseif ($context['instance']['widget']['type'] == 'inline_entity_form') {
-      if ((!empty($form_state['op']) && $form_state['op'] == 'create') || (!empty($element['form']['#op'])) && $element['form']['#op'] == 'add') {
-        $element['actions']['ief_add']['#disabled'] = TRUE;
+      if ((!empty($form_state['op']) && $form_state['op'] == 'create') || (!empty($context['form']['#op'])) && $context['form']['#op'] == 'add') {
+        if ($element['#entity_type'] != 'civicrm_contact') {
+          $element['actions']['ief_add']['#disabled'] = TRUE;
+        }
       }
     }
     elseif ($context['instance']['widget']['type'] == 'civicrm_entity_reference_default_widget') {
@@ -703,13 +705,14 @@ function civicrm_entity_reference_field_inline_entity_form_entity_form_alter(&$e
     $target_id_column = isset($field_info['settings']['target_id_column']) ? $field_info['settings']['target_id_column'] : '';
     $host_id_prop = isset($field_info['settings']['host_source_id']) ? $field_info['settings']['host_source_id'] : '';
 
+    // this doesn't handle a field that is nested on an entityreference field that is on say a node....
     // this handles the 'multi' widget
     if (isset($form_state['complete form'][$host_id_prop]['#default_value']) && isset($entity_form[$target_id_column]) && is_array($entity_form[$target_id_column])) {
-      if ($entity_form['#op'] == 'add' || $entity_form['#op'] == 'create') {
-        $entity_form[$target_id_column]['#default_value'] = $form_state['complete form'][$host_id_prop]['#default_value'];
-      }
-      $entity_form[$target_id_column]['#disabled'] = TRUE;
-    } // this handles the 'single' widget
+        if ($entity_form['#op'] == 'add' || $entity_form['#op'] == 'create') {
+         $entity_form[$target_id_column]['#default_value'] = $form_state['complete form'][$host_id_prop]['#default_value'];
+        }
+        $entity_form[$target_id_column]['#disabled'] = TRUE;
+    }// this handles the 'single' widget
     elseif (isset($form_state['field'][$field_name][LANGUAGE_NONE]['instance']['entity_type'])) {
       $host_entity_type = $form_state['field'][$field_name][LANGUAGE_NONE]['instance']['entity_type'];
       if (isset($form_state[$host_entity_type]->{$host_id_prop})) {
@@ -719,6 +722,11 @@ function civicrm_entity_reference_field_inline_entity_form_entity_form_alter(&$e
         $entity_form[$target_id_column]['#disabled'] = TRUE;
       }
     }
+    //temporary ... necessary to disable target_id_column when civicrm_entity_reference field is embedded on a entityreference field which is embedded on a node
+    if(!empty($entity_form[$target_id_column]['#default_value'])) {
+      $entity_form[$target_id_column]['#disabled'] = TRUE;
+    }
+
     // special handling of address fields on location blocks, because in this case the contact_id is not required
     $contact_id_entities = array(
       'civicrm_address',

--- a/modules/civicrm_entity_reference_field/civicrm_entity_reference_field.module
+++ b/modules/civicrm_entity_reference_field/civicrm_entity_reference_field.module
@@ -642,12 +642,21 @@ function civicrm_entity_reference_field_civicrm_post($op, $objectName, $objectId
 function civicrm_entity_reference_field_field_widget_form_alter(&$element, &$form_state, $context) {
   if ($context['field']['type'] == 'civicrm_entity_reference') {
     if ($context['instance']['widget']['type'] == 'inline_entity_form_single') {
-      if ($form_state['op'] == 'create') {
-        unset($element['form']);
+      if ((!empty($form_state['op']) && $form_state['op'] == 'create') || (!empty($element['form']['#op'])) && $element['form']['#op'] == 'add') {
+        $field = $context['field']['settings']['target_id_column'];
+        if (array_key_exists($field, $element['form'])) {
+          $element['form'][$field]['#required'] = FALSE;
+          $element['form'][$field]['#disabled'] = TRUE;
+          if (empty($element['form'][$field]['#default_value'])) {
+          }
+        }
+        else {
+          unset($element['form']);
+        }
       }
     }
     elseif ($context['instance']['widget']['type'] == 'inline_entity_form') {
-      if ($form_state['op'] == 'create') {
+      if ((!empty($form_state['op']) && $form_state['op'] == 'create') || (!empty($element['form']['#op'])) && $element['form']['#op'] == 'add') {
         $element['actions']['ief_add']['#disabled'] = TRUE;
       }
     }

--- a/modules/civicrm_entity_views_extras/civicrm_entity_views_extras.module
+++ b/modules/civicrm_entity_views_extras/civicrm_entity_views_extras.module
@@ -352,5 +352,88 @@ function civicrm_entity_views_extras_views_data() {
     ),
   );
 
+//----------------------------------------------------------------
+  // CIVICRM World Region
+  //----------------------------------------------------------------
+  $data['civicrm_worldregion']['table']['group'] = t('CiviCRM World Region');
+
+  $data['civicrm_worldregion']['table']['base'] = array(
+    'field' => 'id',
+    'title' => t('CiviCRM World Regions'),
+    'help' => t("View displays CiviCRM World Regions"),
+  );
+
+  //----------------------------------------------------------------
+  // CIVICRM World Region - FIELDS
+  //----------------------------------------------------------------
+
+  // ID
+  $data['civicrm_worldregion']['id'] = array(
+    'title' => t('ID'),
+    'help' => t('The numeric ID of the world region'),
+    'field' => array(
+      'handler' => 'views_handler_field_numeric',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+      'numeric' => TRUE,
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+
+  // Name
+  $data['civicrm_worldregion']['name'] = array(
+    'title' => t('Name'),
+    'help' => t('The world region name'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_string',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+
+  //----------------------------------------------------------------
+  // CIVICRM Country Relationships
+  //----------------------------------------------------------------
+  $data['civicrm_address']['civicrm_country'] = array(
+    'title' => t('CiviCRM Country'),
+    'help' => t('Relates Country to Address'),
+    'real field' => 'country_id',
+    'relationship' => array(
+      'base' => 'civicrm_country',
+      'base field' => 'id',
+      'handler' => 'views_handler_relationship',
+      'label' => t('CiviCRM Country'),
+    ),
+  );
+
+
+  $data['civicrm_country']['civicrm_worldregion'] = array(
+    'title' => t('CiviCRM World Region'),
+    'help' => t('Relates World Region to Country'),
+    'real field' => 'region_id',
+    'relationship' => array(
+      'base' => 'civicrm_worldregion',
+      'base field' => 'id',
+      'handler' => 'views_handler_relationship',
+      'label' => t('CiviCRM World Region'),
+    ),
+  );
+
   return $data;
 }

--- a/templates/civicrm-website.tpl.php
+++ b/templates/civicrm-website.tpl.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * A basic template for civicrm_website entities
+ *
+ * Available variables:
+ * - $content: An array of comment items. Use render($content) to print them all, or
+ *   print a subset such as render($content['field_example']). Use
+ *   hide($content['field_example']) to temporarily suppress the printing of a
+ *   given element.
+ * - $title: The name of the civicrm_website
+ * - $url: The standard URL for viewing a civicrm_website entity
+ * - $page: TRUE if this is the main view page $url points too.
+ * - $classes: String of classes that can be used to style contextually through
+ *   CSS. It can be manipulated through the variable $classes_array from
+ *   preprocess functions. By default the following classes are available, where
+ *   the parts enclosed by {} are replaced by the appropriate values:
+ *   - entity-profile
+ *   - civicrm_website-{TYPE}
+ *
+ * Other variables:
+ * - $classes_array: Array of html class attribute values. It is flattened
+ *   into a string within the variable $classes.
+ *
+ * @see template_preprocess()
+ * @see template_preprocess_entity()
+ * @see template_process()
+ */
+?>
+<div class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
+  <?php if (!$page): ?>
+    <h2<?php print $title_attributes; ?>>
+      <a href="<?php print $url; ?>"><?php print $title; ?></a>
+    </h2>
+  <?php endif; ?>
+
+  <div class="content"<?php print $content_attributes; ?>>
+    <?php print render($content); ?>
+  </div>
+</div>


### PR DESCRIPTION
The goal here is to allow adding of referenced entities from the "add/create" form

This could either be on the Drupal based CiviCRM entity forms, or via an entityreference field on say a content type.

This PR is working for me, for the Inline Entity Form Single widget, and I've currently limited it to CER fields attached to a contact entity.  This shouldn't be a limitation, but its untested...

This code does nothing yet for Inline Entity Form - Multiple widget, nor does it handle nested forms...that is something like a reference to a location block on the Event entity type, and an address CER on the location block entity type....

Its pretty hairy, so bite sized chunks....

@Vgratioulet , I used some of your code from your PR, but modified it, and also added a lot of changes to the civicrm_entity_inline module to make it possible for this to work with CER on ER on nodes...