### PR TITLE
Allowing admins to disable entity integration by API entity

### DIFF
--- a/civicrm_entity.admin_form.inc
+++ b/civicrm_entity.admin_form.inc
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @file
+ * CiviCRM Entity admin settings form callbacks
+ */
+
+/**
+ * Settings form callback function
+ *
+ * @param $form
+ * @param $form_state
+ * @return mixed
+ */
+function civicrm_entity_admin_settings_form($form, &$form_state) {
+  $available_entities = _civicrm_entity_available_entities();
+
+  $available_entities_option_set = _civicrm_entity_available_entities_get_option_set($available_entities);
+
+  $options = array();
+  foreach ($available_entities as $entity_type => $api_entity) {
+    $options[$entity_type] = ucwords(str_replace('_', ' ', $api_entity));
+  }
+
+  $default_value = variable_get('civicrm_entity_admin_enabled_entities', $available_entities_option_set);
+
+  $form['civicrm_entity_admin_enabled_entities']  = array(
+    '#type' => 'fieldset',
+    '#title' => 'Enabled Entities',
+    '#description' => 'Check all CiviCRM API entities that you would like to expose as Drupal entity types. If a checkbox is disabled, it is because a submodule requires it.' . "<br/>" .' This page does not check for existing Drupal Rules, Views, or 3rd party modules using CiviCRM entity types. Ask your web consultant if unsure.',
+    '#collapsible' => FALSE,
+    '#tree' => TRUE,
+  );
+
+  foreach ($options as $drupal_entity_type => $entity_type_label) {
+    $form['civicrm_entity_admin_enabled_entities'][$drupal_entity_type] = array(
+      '#type' => 'checkbox',
+      '#title' => $entity_type_label,
+      '#default_value' => !empty($default_value[$drupal_entity_type]) ?  1 : 0,
+    );
+  }
+
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save settings'),
+  );
+
+  return $form;
+}
+
+/**
+ * Form submit callback for the CiviCRM Entity admin config page
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_entity_admin_settings_form_submit($form, $form_state) {
+  $settings = array();
+  foreach ($form_state['values']['civicrm_entity_admin_enabled_entities'] as $drupal_entity_type => $value) {
+    $settings[$drupal_entity_type] = !empty($value) ? $drupal_entity_type : 0;
+  }
+
+  variable_set('civicrm_entity_admin_enabled_entities', $settings);
+  drupal_flush_all_caches();
+}

--- a/civicrm_entity.install
+++ b/civicrm_entity.install
@@ -15,6 +15,7 @@ function civicrm_entity_uninstall() {
   foreach ($civicrm_entity_info as $entity_type => $info) {
     field_attach_delete_bundle($entity_type, $entity_type);
   }
+  variable_del('civicrm_entity_admin_enabled_entities');
 }
 
 

--- a/civicrm_entity.install
+++ b/civicrm_entity.install
@@ -43,3 +43,17 @@ function civicrm_entity_update_7200() {
 function civicrm_entity_update_7201() {
   drupal_flush_all_caches();
 }
+
+
+/**
+ * Create enabled entities variable
+ */
+function civicrm_entity_update_7202() {
+  drupal_load('module', 'civicrm_entity');
+  $available_entities = _civicrm_entity_available_entities();
+  $settings = [];
+  foreach ($available_entities as $drupal_entity_type => $civicrm_api_entity) {
+    $settings[$drupal_entity_type] = $drupal_entity_type;
+  }
+  variable_set('civicrm_entity_admin_enabled_entities', $settings);
+}

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -25,6 +25,15 @@ function civicrm_entity_menu() {
     'file path' => drupal_get_path('module', 'system'),
     'file' => 'system.admin.inc',
   );
+  $items['admin/structure/civicrm-entity/settings'] = array(
+    'title' => 'Configure CiviCRM Entity',
+    'description' => 'Configure CiviCRM settings, such as enabled entities',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('civicrm_entity_admin_settings_form'),
+    'access arguments' => array('administer CiviCRM Entity'),
+    'type' => MENU_NORMAL_ITEM,
+    'file' => 'civicrm_entity.admin_form.inc',
+  );
   $items['civicrm-entity/autocomplete/%'] = array(
     'title' => 'CiviCRM entity autocomplete',
     'page callback' => 'civicrm_entity_autocomplete',
@@ -129,25 +138,27 @@ function civicrm_entity_permission() {
  *
  * Lets Drupal know to look for templates for the entity types
  *
- * @return themes
+ * @return array $themes
  */
 
 function civicrm_entity_theme() {
   $civicrm_entity_info = civicrm_entity_get_supported_entity_info();
-
+  $enabled_entities = _civicrm_entity_enabled_entities();
   $themes = array();
 
   foreach ($civicrm_entity_info as $drupal_entity => $data) {
-    $dashkey = str_replace('_', '-', $drupal_entity);
-    if (isset($data['theme'])) {
-      $themes[$drupal_entity] = array(
-        'render element' => 'elements',
-      );
-      if (isset($data['theme']['template'])) {
-        $themes[$drupal_entity]['template'] = $data['theme']['template'];
-      }
-      if (isset($data['theme']['path'])) {
-        $themes[$drupal_entity]['path'] = $data['theme']['path'];
+    if(!empty($enabled_entities[$drupal_entity])) {
+      $dashkey = str_replace('_', '-', $drupal_entity);
+      if (isset($data['theme'])) {
+        $themes[$drupal_entity] = [
+          'render element' => 'elements',
+        ];
+        if (isset($data['theme']['template'])) {
+          $themes[$drupal_entity]['template'] = $data['theme']['template'];
+        }
+        if (isset($data['theme']['path'])) {
+          $themes[$drupal_entity]['path'] = $data['theme']['path'];
+        }
       }
     }
   }
@@ -209,6 +220,10 @@ function  civicrm_entity_op_access($op, $entity_type, $entity = NULL, $account =
   }
 
   $civicrm_entity_info = civicrm_entity_get_supported_entity_info();
+  $enabled_entities = _civicrm_entity_enabled_entities();
+  if (empty($enabled_entities[$entity_type])) {
+    return FALSE;
+  }
 
   if (isset($civicrm_entity_info[$entity_type]['permissions'][$op])) {
     $permissions = $civicrm_entity_info[$entity_type]['permissions'][$op];
@@ -245,20 +260,22 @@ function  civicrm_entity_op_access($op, $entity_type, $entity = NULL, $account =
 function civicrm_entity_views_data_alter(&$data) {
 
   $civicrm_entity_types = civicrm_entity_get_supported_entity_info();
-
+  $enabled_entities = _civicrm_entity_enabled_entities();
   foreach ($civicrm_entity_types as $civicrm_entity_type => $info) {
-    foreach ($data[$civicrm_entity_type] as $property => $prop_info) {
-      // unset auto-generated custom field views handlers due to civicrm_entity entity metadata coming from API getfields call
-      if (strpos($property, 'custom_') === 0) {
-        $name_array = explode('_', $property);
-        if(isset($name_array[1]) && is_numeric($name_array[1])) {
-          unset($data[$civicrm_entity_type][$property]);
+    if(!empty($enabled_entities[$civicrm_entity_type]) && !empty($data[$civicrm_entity_type])) {
+      foreach ($data[$civicrm_entity_type] as $property => $prop_info) {
+        // unset auto-generated custom field views handlers due to civicrm_entity entity metadata coming from API getfields call
+        if (strpos($property, 'custom_') === 0) {
+          $name_array = explode('_', $property);
+          if (isset($name_array[1]) && is_numeric($name_array[1])) {
+            unset($data[$civicrm_entity_type][$property]);
+          }
         }
       }
     }
   }
 
- if(!empty($data['civicrm_contribution_recur']['next_sched_contribution'])) {
+ if(!empty($enabled_entities['civicrm_contribution_recur']) && !empty($data['civicrm_contribution_recur']['next_sched_contribution'])) {
     foreach($data['civicrm_contribution_recur'] as $property => $property_data) {
       if(strpos($property, 'next_sched_contribution') === 0) {
         $property_name_components = explode('_', $property);
@@ -275,7 +292,6 @@ function civicrm_entity_views_data_alter(&$data) {
       }
     }
   }
-
 }
 
 
@@ -1976,15 +1992,9 @@ function civicrm_entity_supported_entities_info() {
 }
 
 /**
- * Whitelist of enabled entities. We don't have a compelling reason for not including all entities
- * but some entities are fairly non-standard and of course the rule hook would instantiate rules
- * more often if all were enabled.
- *
- * The whitelist approach is mostly out of caution
- *
- * @return array of enabled entities keyed by the drupal entity name
+ * We gather a list entities that are available, either as hardcoded in this module, or provided by the hook
  */
-function _civicrm_entity_enabled_entities() {
+function _civicrm_entity_available_entities() {
   $civicrm_entity_info = civicrm_entity_get_supported_entity_info();
   $whitelist = array();
   foreach ($civicrm_entity_info as $drupal_entity => $data) {
@@ -1995,6 +2005,49 @@ function _civicrm_entity_enabled_entities() {
 
   _civicrm_enabled_entity_alter_whitelist($whitelist);
   return $whitelist;
+}
+
+
+/**
+ * Whitelist of enabled entities. We don't have a compelling reason for not including all entities
+ * but some entities are fairly non-standard and of course the rule hook would instantiate rules
+ * more often if all were enabled.
+ *
+ * The whitelist approach is mostly out of caution
+ *
+ * @return array of enabled entities keyed by the drupal entity name
+ */
+function _civicrm_entity_enabled_entities() {
+  $available_entities = _civicrm_entity_available_entities();
+  $available_entities_option_set = _civicrm_entity_available_entities_get_option_set($available_entities);
+
+  $selected_entities = variable_get('civicrm_entity_admin_enabled_entities', $available_entities_option_set);
+
+  $enabled_entities = array();
+  foreach ($available_entities as $entity_type => $api_entity) {
+    if (!empty($selected_entities[$entity_type])) {
+      $enabled_entities[$entity_type] = $api_entity;
+    }
+  }
+
+  return $enabled_entities;
+}
+
+/**
+ * Build an option set array used by the configure CiviCRM Entity form, and various submodules
+ *
+ * @param $available_entities
+ *
+ * @return array
+ */
+function _civicrm_entity_available_entities_get_option_set($available_entities) {
+  $available_entities_option_set = array();
+  if (!empty($available_entities)) {
+    foreach ($available_entities as $entity_type => $api_entity) {
+      $available_entities_option_set[$entity_type] = $entity_type;
+    }
+  }
+  return $available_entities_option_set;
 }
 
 /**
@@ -3886,6 +3939,10 @@ function _civicrm_entity_manage_display_suite_forms_validate(&$form, &$form_stat
 function civicrm_entity_ds_fields_info($entity_type) {
   $fields = array();
   if (!civicrm_initialize(TRUE)) {
+    return;
+  }
+  $enabled_entities = _civicrm_entity_enabled_entities();
+  if (empty($enabled_entities[$entity_type])) {
     return;
   }
   $properties = _civicrm_entity_getproperties(substr($entity_type, 8), 'property_info');

--- a/modules/civicrm_case_activity_reference_field/civicrm_case_activity_reference_field.install
+++ b/modules/civicrm_case_activity_reference_field/civicrm_case_activity_reference_field.install
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Implements hook_enable().
+ */
+function civicrm_case_activity_reference_field_enable() {
+  $selected_entities = variable_get('civicrm_entity_admin_enabled_entities', array());
+  $update = FALSE;
+  $required_entities = array(
+    'civicrm_case' => 'Case',
+    'civicrm_activity' => 'Activity',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if(empty($selected_entities[$drupal_entity_type])) {
+      $update = TRUE;
+      $selected_entities[$drupal_entity_type] = $drupal_entity_type;
+    }
+  }
+
+  if ($update) {
+    variable_set('civicrm_entity_admin_enabled_entities', $selected_entities);
+    drupal_flush_all_caches();
+  }
+}
+
+/**
+ * Ensure required entities are configured in civicrm_entity settings
+ */
+function civicrm_case_activity_reference_field_update_7200() {
+  $selected_entities = variable_get('civicrm_entity_admin_enabled_entities', array());
+  $update = FALSE;
+  $required_entities = array(
+    'civicrm_case' => 'Case',
+    'civicrm_activity' => 'Activity',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if(empty($selected_entities[$drupal_entity_type])) {
+      $update = TRUE;
+      $selected_entities[$drupal_entity_type] = $drupal_entity_type;
+    }
+  }
+
+  if ($update) {
+    variable_set('civicrm_entity_admin_enabled_entities', $selected_entities);
+    drupal_flush_all_caches();
+  }
+}

--- a/modules/civicrm_case_activity_reference_field/civicrm_case_activity_reference_field.module
+++ b/modules/civicrm_case_activity_reference_field/civicrm_case_activity_reference_field.module
@@ -611,7 +611,52 @@ function civicrm_case_activity_reference_field_inline_entity_form_entity_form_al
       $entity_form['case_id']['#disabled'] = TRUE;
     }
 
+  }
+}
 
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Alter the CiviCRM Entity enabled entities settings form
+ *
+ * Insure necessary entity types for this module remain enabled
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_case_activity_reference_field_form_civicrm_entity_admin_settings_form_alter(&$form, &$form_state) {
+  $required_entities = array(
+    'civicrm_case' => 'Case',
+    'civicrm_activity' => 'Activity',
+  );
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if (empty($selected_entities[$drupal_entity_type])) {
+      $form['civicrm_entity_admin_enabled_entities'][$drupal_entity_type]['#disabled'] = TRUE;
+      $form['civicrm_entity_admin_enabled_entities'][$drupal_entity_type]['#default_value'] = 1;
+    }
+  }
 
+  $form['#validate'][] = 'civicrm_case_activity_reference_field_admin_settings_form_validate';
+}
+
+/**
+ * Validation callback for the CiviCRM Entity Enabled Entities form at 'admin/structure/civicrm-entity/settings'
+ *
+ * If CiviCRM Case Activity Reference module enabled, make sure activity, case entities are enabled
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_case_activity_reference_field_admin_settings_form_validate($form, &$form_state) {
+  $selected_entities = $form_state['values']['civicrm_entity_admin_enabled_entities'];
+
+  $required_entities = array(
+    'civicrm_case' => 'Case',
+    'civicrm_activity' => 'Activity',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if (empty($selected_entities[$drupal_entity_type])) {
+      form_set_error('civicrm_entity_admin_enabled_entities][' . $drupal_entity_type, $entity_type_label . ' required by CiviCRM Case Activity Reference Field module');
+    }
   }
 }

--- a/modules/civicrm_entity_actions/civicrm_entity_actions.module
+++ b/modules/civicrm_entity_actions/civicrm_entity_actions.module
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * Implements hook_action_info().
+ *
+ * @return array
+ */
 function civicrm_entity_actions_action_info() {
 
   $action_info = array();

--- a/modules/civicrm_entity_contact_assign_rel_contact_field/civicrm_entity_contact_assign_rel_contact_field.install
+++ b/modules/civicrm_entity_contact_assign_rel_contact_field/civicrm_entity_contact_assign_rel_contact_field.install
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Implements hook_enable().
+ */
+function civicrm_entity_contact_assign_rel_contact_field_enable() {
+  $selected_entities = variable_get('civicrm_entity_admin_enabled_entities', array());
+  $update = FALSE;
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_relationship' => 'Relationship',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if(empty($selected_entities[$drupal_entity_type])) {
+      $update = TRUE;
+      $selected_entities[$drupal_entity_type] = $drupal_entity_type;
+    }
+  }
+
+  if ($update) {
+    variable_set('civicrm_entity_admin_enabled_entities', $selected_entities);
+    drupal_flush_all_caches();
+  }
+}
+
+/**
+ * Ensure required entities are configured in civicrm_entity settings
+ */
+function civicrm_entity_contact_assign_rel_contact_field_update_7200() {
+  $selected_entities = variable_get('civicrm_entity_admin_enabled_entities', array());
+  $update = FALSE;
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_relationship' => 'Relationship',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if(empty($selected_entities[$drupal_entity_type])) {
+      $update = TRUE;
+      $selected_entities[$drupal_entity_type] = $drupal_entity_type;
+    }
+  }
+
+  if ($update) {
+    variable_set('civicrm_entity_admin_enabled_entities', $selected_entities);
+    drupal_flush_all_caches();
+  }
+}

--- a/modules/civicrm_entity_contact_assign_rel_contact_field/civicrm_entity_contact_assign_rel_contact_field.module
+++ b/modules/civicrm_entity_contact_assign_rel_contact_field/civicrm_entity_contact_assign_rel_contact_field.module
@@ -708,3 +708,49 @@ function _civicrm_entity_contact_assign_rel_contact_field_remove_contact_relatio
 
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Alter the CiviCRM Entity enabled entities settings form
+ *
+ * Insure necessary entity types for this module remain enabled
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_entity_contact_assign_rel_contact_field_form_civicrm_entity_admin_settings_form_alter(&$form, &$form_state) {
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_relationship' => 'Relationship',
+  );
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if (empty($selected_entities[$drupal_entity_type])) {
+      $form['civicrm_entity_admin_enabled_entities'][$drupal_entity_type]['#disabled'] = TRUE;
+      $form['civicrm_entity_admin_enabled_entities'][$drupal_entity_type]['#default_value'] = 1;
+    }
+  }
+
+  $form['#validate'][] = 'civicrm_entity_contact_assign_rel_contact_field_admin_settings_form_validate';
+}
+
+/**
+ * Validation callback for the CiviCRM Entity Enabled Entities form at 'admin/structure/civicrm-entity/settings'
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_entity_contact_assign_rel_contact_field_admin_settings_form_validate($form, &$form_state) {
+  $selected_entities = $form_state['values']['civicrm_entity_admin_enabled_entities'];
+
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_relationship' => 'Relationship',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if (empty($selected_entities[$drupal_entity_type])) {
+      form_set_error('civicrm_entity_admin_enabled_entities][' . $drupal_entity_type, $entity_type_label . ' required by CiviCRM Entity Contact Assign Relationship to Contact Field module');
+    }
+  }
+}

--- a/modules/civicrm_entity_contact_assign_rel_type_list_field/civicrm_entity_contact_assign_rel_type_list_field.install
+++ b/modules/civicrm_entity_contact_assign_rel_type_list_field/civicrm_entity_contact_assign_rel_type_list_field.install
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Implements hook_enable().
+ */
+function civicrm_entity_contact_assign_rel_type_list_field_enable() {
+  $selected_entities = variable_get('civicrm_entity_admin_enabled_entities', array());
+  $update = FALSE;
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_relationship' => 'Relationship',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if(empty($selected_entities[$drupal_entity_type])) {
+      $update = TRUE;
+      $selected_entities[$drupal_entity_type] = $drupal_entity_type;
+    }
+  }
+
+  if ($update) {
+    variable_set('civicrm_entity_admin_enabled_entities', $selected_entities);
+    drupal_flush_all_caches();
+  }
+}
+
+/**
+ * Ensure required entities are configured in civicrm_entity settings
+ */
+function civicrm_entity_contact_assign_rel_type_list_field_update_7200() {
+  $selected_entities = variable_get('civicrm_entity_admin_enabled_entities', array());
+  $update = FALSE;
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_relationship' => 'Relationship',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if(empty($selected_entities[$drupal_entity_type])) {
+      $update = TRUE;
+      $selected_entities[$drupal_entity_type] = $drupal_entity_type;
+    }
+  }
+
+  if ($update) {
+    variable_set('civicrm_entity_admin_enabled_entities', $selected_entities);
+    drupal_flush_all_caches();
+  }
+}

--- a/modules/civicrm_entity_contact_assign_rel_type_list_field/civicrm_entity_contact_assign_rel_type_list_field.module
+++ b/modules/civicrm_entity_contact_assign_rel_type_list_field/civicrm_entity_contact_assign_rel_type_list_field.module
@@ -585,3 +585,49 @@ function _civicrm_entity_contact_assign_rel_type_list_field_remove_contact_relat
 
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Alter the CiviCRM Entity enabled entities settings form
+ *
+ * Insure necessary entity types for this module remain enabled
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_entity_contact_assign_rel_type_list_field_form_civicrm_entity_admin_settings_form_alter(&$form, &$form_state) {
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_relationship' => 'Relationship',
+  );
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if (empty($selected_entities[$drupal_entity_type])) {
+      $form['civicrm_entity_admin_enabled_entities'][$drupal_entity_type]['#disabled'] = TRUE;
+      $form['civicrm_entity_admin_enabled_entities'][$drupal_entity_type]['#default_value'] = 1;
+    }
+  }
+
+  $form['#validate'][] = 'civicrm_entity_contact_assign_rel_type_list_field_admin_settings_form_validate';
+}
+
+/**
+ * Validation callback for the CiviCRM Entity Enabled Entities form at 'admin/structure/civicrm-entity/settings'
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_entity_contact_assign_rel_type_list_field_admin_settings_form_validate($form, &$form_state) {
+  $selected_entities = $form_state['values']['civicrm_entity_admin_enabled_entities'];
+
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_relationship' => 'Relationship',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if (empty($selected_entities[$drupal_entity_type])) {
+      form_set_error('civicrm_entity_admin_enabled_entities][' . $drupal_entity_type, $entity_type_label . ' required by CiviCRM Entity Contact Assign Relationship Type module');
+    }
+  }
+}

--- a/modules/civicrm_entity_contact_group_assign_field/civicrm_entity_contact_group_assign_field.install
+++ b/modules/civicrm_entity_contact_group_assign_field/civicrm_entity_contact_group_assign_field.install
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Implements hook_enable().
+ */
+function civicrm_entity_contact_group_assign_field_enable() {
+  $selected_entities = variable_get('civicrm_entity_admin_enabled_entities', array());
+  $update = FALSE;
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_group' => 'Group',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if(empty($selected_entities[$drupal_entity_type])) {
+      $update = TRUE;
+      $selected_entities[$drupal_entity_type] = $drupal_entity_type;
+    }
+  }
+
+  if ($update) {
+    variable_set('civicrm_entity_admin_enabled_entities', $selected_entities);
+    drupal_flush_all_caches();
+  }
+}
+
+/**
+ * Ensure required entities are configured in civicrm_entity settings
+ */
+function civicrm_entity_contact_group_assign_field_update_7200() {
+  $selected_entities = variable_get('civicrm_entity_admin_enabled_entities', array());
+  $update = FALSE;
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_group' => 'Group',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if(empty($selected_entities[$drupal_entity_type])) {
+      $update = TRUE;
+      $selected_entities[$drupal_entity_type] = $drupal_entity_type;
+    }
+  }
+
+  if ($update) {
+    variable_set('civicrm_entity_admin_enabled_entities', $selected_entities);
+    drupal_flush_all_caches();
+  }
+}

--- a/modules/civicrm_entity_contact_group_assign_field/civicrm_entity_contact_group_assign_field.module
+++ b/modules/civicrm_entity_contact_group_assign_field/civicrm_entity_contact_group_assign_field.module
@@ -531,3 +531,49 @@ function _civicrm_entity_contact_group_assign_field_remove_contact_from_group($c
 
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Alter the CiviCRM Entity enabled entities settings form
+ *
+ * Insure necessary entity types for this module remain enabled
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_entity_contact_group_assign_field_form_civicrm_entity_admin_settings_form_alter(&$form, &$form_state) {
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_group' => 'Group',
+  );
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if (empty($selected_entities[$drupal_entity_type])) {
+      $form['civicrm_entity_admin_enabled_entities'][$drupal_entity_type]['#disabled'] = TRUE;
+      $form['civicrm_entity_admin_enabled_entities'][$drupal_entity_type]['#default_value'] = 1;
+    }
+  }
+
+  $form['#validate'][] = 'civicrm_entity_contact_group_assign_field_admin_settings_form_validate';
+}
+
+/**
+ * Validation callback for the CiviCRM Entity Enabled Entities form at 'admin/structure/civicrm-entity/settings'
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_entity_contact_group_assign_field_admin_settings_form_validate($form, &$form_state) {
+  $selected_entities = $form_state['values']['civicrm_entity_admin_enabled_entities'];
+
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_group' => 'Group',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if (empty($selected_entities[$drupal_entity_type])) {
+      form_set_error('civicrm_entity_admin_enabled_entities][' . $drupal_entity_type, $entity_type_label . ' required by CiviCRM Contact Group Assign Field module');
+    }
+  }
+}

--- a/modules/civicrm_entity_price_set_field/civicrm_entity_price_set_field.install
+++ b/modules/civicrm_entity_price_set_field/civicrm_entity_price_set_field.install
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Implements hook_enable().
+ */
+function civicrm_entity_price_set_field_enable() {
+  $selected_entities = variable_get('civicrm_entity_admin_enabled_entities', array());
+  $update = FALSE;
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_contribution' => 'Contribution',
+    'civicrm_event' => 'Event',
+    'civicrm_line_item' => 'Line Item',
+    'civicrm_participant' => 'Participant',
+    'civicrm_participant_payment' => 'Participant Payment',
+    'civicrm_price_set' => 'Price Set',
+    'civicrm_price_field' => 'Price Field',
+    'civicrm_price_field_value' => 'Price Field Value',
+    'civicrm_payment_processor' => 'Payment Processor',
+    'civicrm_payment_processor_type' => 'Payment Processor Type',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if(empty($selected_entities[$drupal_entity_type])) {
+      $update = TRUE;
+      $selected_entities[$drupal_entity_type] = $drupal_entity_type;
+    }
+  }
+
+  if ($update) {
+    variable_set('civicrm_entity_admin_enabled_entities', $selected_entities);
+    drupal_flush_all_caches();
+  }
+}
+
+/**
+ * Ensure required entities are configured in civicrm_entity settings
+ */
+function civicrm_entity_price_set_field_update_7200() {
+  $selected_entities = variable_get('civicrm_entity_admin_enabled_entities', array());
+  $update = FALSE;
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_contribution' => 'Contribution',
+    'civicrm_event' => 'Event',
+    'civicrm_line_item' => 'Line Item',
+    'civicrm_participant' => 'Participant',
+    'civicrm_participant_payment' => 'Participant Payment',
+    'civicrm_price_set' => 'Price Set',
+    'civicrm_price_field' => 'Price Field',
+    'civicrm_price_field_value' => 'Price Field Value',
+    'civicrm_payment_processor' => 'Payment Processor',
+    'civicrm_payment_processor_type' => 'Payment Processor Type',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if(empty($selected_entities[$drupal_entity_type])) {
+      $update = TRUE;
+      $selected_entities[$drupal_entity_type] = $drupal_entity_type;
+    }
+  }
+
+  if ($update) {
+    variable_set('civicrm_entity_admin_enabled_entities', $selected_entities);
+    drupal_flush_all_caches();
+  }
+}

--- a/modules/civicrm_entity_price_set_field/civicrm_entity_price_set_field.module
+++ b/modules/civicrm_entity_price_set_field/civicrm_entity_price_set_field.module
@@ -1141,3 +1141,67 @@ function civicrm_entity_price_set_field_field_formatter_view($entity_type, $enti
   return $element;
 }
 
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Alter the CiviCRM Entity enabled entities settings form
+ *
+ * Insure necessary entity types for this module remain enabled
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_entity_price_set_field_form_civicrm_entity_admin_settings_form_alter(&$form, &$form_state) {
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_contribution' => 'Contribution',
+    'civicrm_event' => 'Event',
+    'civicrm_line_item' => 'Line Item',
+    'civicrm_participant' => 'Participant',
+    'civicrm_participant_payment' => 'Participant Payment',
+    'civicrm_price_set' => 'Price Set',
+    'civicrm_price_field' => 'Price Field',
+    'civicrm_price_field_value' => 'Price Field Value',
+    'civicrm_payment_processor' => 'Payment Processor',
+    'civicrm_payment_processor_type' => 'Payment Processor Type',
+  );
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if (empty($selected_entities[$drupal_entity_type])) {
+      $form['civicrm_entity_admin_enabled_entities'][$drupal_entity_type]['#disabled'] = TRUE;
+      $form['civicrm_entity_admin_enabled_entities'][$drupal_entity_type]['#default_value'] = 1;
+    }
+  }
+
+  $form['#validate'][] = 'civicrm_entity_price_set_field_admin_settings_form_validate';
+}
+
+/**
+ * Validation callback for the CiviCRM Entity Enabled Entities form at 'admin/structure/civicrm-entity/settings'
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_entity_price_set_field_admin_settings_form_validate($form, &$form_state) {
+  $selected_entities = $form_state['values']['civicrm_entity_admin_enabled_entities'];
+
+  $required_entities = array(
+    'civicrm_contact' => 'Contact',
+    'civicrm_contribution' => 'Contribution',
+    'civicrm_event' => 'Event',
+    'civicrm_line_item' => 'Line Item',
+    'civicrm_participant' => 'Participant',
+    'civicrm_participant_payment' => 'Participant Payment',
+    'civicrm_price_set' => 'Price Set',
+    'civicrm_price_field' => 'Price Field',
+    'civicrm_price_field_value' => 'Price Field Value',
+    'civicrm_payment_processor' => 'Payment Processor',
+    'civicrm_payment_processor_type' => 'Payment Processor Type',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if (empty($selected_entities[$drupal_entity_type])) {
+      form_set_error('civicrm_entity_admin_enabled_entities][' . $drupal_entity_type, $entity_type_label . ' required by CiviCRM Entity Price Set Field module');
+    }
+  }
+}

--- a/modules/civicrm_entity_profile/civicrm_entity_profile.install
+++ b/modules/civicrm_entity_profile/civicrm_entity_profile.install
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Implements hook_enable().
+ */
+function civicrm_entity_profile_enable() {
+  $selected_entities = variable_get('civicrm_entity_admin_enabled_entities', array());
+  $update = FALSE;
+  $required_entities = array(
+    'civicrm_event' => 'Event',
+    'civicrm_uf_field' => 'UF Field',
+    'civicrm_uf_group' => 'UF Group',
+    'civicrm_uf_join' => 'UF Join',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if(empty($selected_entities[$drupal_entity_type])) {
+      $update = TRUE;
+      $selected_entities[$drupal_entity_type] = $drupal_entity_type;
+    }
+  }
+
+  if ($update) {
+    variable_set('civicrm_entity_admin_enabled_entities', $selected_entities);
+    drupal_flush_all_caches();
+  }
+}
+
+/**
+ * Ensure required entities are configured in civicrm_entity settings
+ */
+function civicrm_entity_profile_update_7200() {
+  $selected_entities = variable_get('civicrm_entity_admin_enabled_entities', array());
+  $update = FALSE;
+  $required_entities = array(
+    'civicrm_event' => 'Event',
+    'civicrm_uf_field' => 'UF Field',
+    'civicrm_uf_group' => 'UF Group',
+    'civicrm_uf_join' => 'UF Join',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if(empty($selected_entities[$drupal_entity_type])) {
+      $update = TRUE;
+      $selected_entities[$drupal_entity_type] = $drupal_entity_type;
+    }
+  }
+
+  if ($update) {
+    variable_set('civicrm_entity_admin_enabled_entities', $selected_entities);
+    drupal_flush_all_caches();
+  }
+}

--- a/modules/civicrm_entity_profile/civicrm_entity_profile.module
+++ b/modules/civicrm_entity_profile/civicrm_entity_profile.module
@@ -702,3 +702,53 @@ function _civicrm_entity_profile_remove_button_submit_handler($form, &$form_stat
 
   $form_state['rebuild'] = TRUE;
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Alter the CiviCRM Entity enabled entities settings form
+ *
+ * Insure necessary entity types for this module remain enabled
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_entity_profile_form_civicrm_entity_admin_settings_form_alter(&$form, &$form_state) {
+  $required_entities = array(
+    'civicrm_event' => 'Event',
+    'civicrm_uf_field' => 'UF Field',
+    'civicrm_uf_group' => 'UF Group',
+    'civicrm_uf_join' => 'UF Join',
+  );
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if (empty($selected_entities[$drupal_entity_type])) {
+      $form['civicrm_entity_admin_enabled_entities'][$drupal_entity_type]['#disabled'] = TRUE;
+      $form['civicrm_entity_admin_enabled_entities'][$drupal_entity_type]['#default_value'] = 1;
+    }
+  }
+
+  $form['#validate'][] = 'civicrm_entity_profile_admin_settings_form_validate';
+}
+
+/**
+ * Validation callback for the CiviCRM Entity Enabled Entities form at 'admin/structure/civicrm-entity/settings'
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civicrm_entity_profile_admin_settings_form_validate($form, &$form_state) {
+  $selected_entities = $form_state['values']['civicrm_entity_admin_enabled_entities'];
+
+  $required_entities = array(
+    'civicrm_event' => 'Event',
+    'civicrm_uf_field' => 'UF Field',
+    'civicrm_uf_group' => 'UF Group',
+    'civicrm_uf_join' => 'UF Join',
+  );
+
+  foreach ($required_entities as $drupal_entity_type => $entity_type_label) {
+    if (empty($selected_entities[$drupal_entity_type])) {
+      form_set_error('civicrm_entity_admin_enabled_entities][' . $drupal_entity_type, $entity_type_label . ' required by CiviCRM Entity Profile Field module');
+    }
+  }
+}

--- a/modules/civicrm_entity_reference_field/civicrm_entity_reference_field.module
+++ b/modules/civicrm_entity_reference_field/civicrm_entity_reference_field.module
@@ -480,7 +480,12 @@ function civicrm_entity_reference_field_field_formatter_prepare_view($entity_typ
   }
 
   if ($target_ids) {
-    $target_entities = entity_load($target_entity_type, $target_ids);
+    try {
+      $target_entities = entity_load($target_entity_type, $target_ids);
+    }
+    catch (Exception $e) {
+      return;
+    }
   }
   else {
     $target_entities = array();

--- a/modules/civicrm_entity_search_api/civicrm_entity_search_api.module
+++ b/modules/civicrm_entity_search_api/civicrm_entity_search_api.module
@@ -25,8 +25,8 @@ function civicrm_entity_search_api_civicrm_post($op, $objectName, $objectId, &$o
      $drupal_entity_type = 'civicrm_membership';
      break;
   }
-
-  if(!empty($drupal_entity_type)) {
+  $enabled_entities = _civicrm_entity_enabled_entities();
+  if(!empty($drupal_entity_type) && !empty($enabled_entities[$drupal_entity_type])) {
     switch ($op) {
       case 'create':
         search_api_track_item_insert($drupal_entity_type, array($objectId));

--- a/modules/civicrm_entity_views_extras/civicrm_entity_views_extras.module
+++ b/modules/civicrm_entity_views_extras/civicrm_entity_views_extras.module
@@ -18,361 +18,388 @@ function civicrm_entity_views_extras_views_api() {
  * Implements hook_views_data().
  */
 function civicrm_entity_views_extras_views_data() {
-  $data['civicrm_price_set_entity']['table']['group'] = t('CiviCRM Price Set Entities');
+  $enabled_entities = _civicrm_entity_enabled_entities();
 
-  $data['civicrm_price_set_entity']['table']['base'] = array(
-    'field' => 'id',
-    'title' => t('CiviCRM Price Set Entities'),
-    'help' => t("View displays CiviCRM Price Set to Entity mapping info"),
-  );
+  if (!empty($enabled_entities['civicrm_price_set'])) {
+    $data['civicrm_price_set_entity']['table']['group'] = t('CiviCRM Price Set Entities');
 
-  //----------------------------------------------------------------
-  // CIVICRM Price Set Entity - FIELDS
-  //----------------------------------------------------------------
+    $data['civicrm_price_set_entity']['table']['base'] = [
+      'field' => 'id',
+      'title' => t('CiviCRM Price Set Entities'),
+      'help'  => t("View displays CiviCRM Price Set to Entity mapping info"),
+    ];
 
-  // Numeric: Price Set ID
-  $data['civicrm_price_set_entity']['price_set_id'] = array(
-    'title' => t('Price Set ID'),
-    'help' => t('The numeric ID of the Price Set'),
-    'field' => array(
-      'handler' => 'views_handler_field_numeric',
-      'click sortable' => TRUE,
-    ),
-    'argument' => array(
-      'handler' => 'views_handler_argument_numeric',
-      'numeric' => TRUE,
-    ),
-    'filter' => array(
-      'handler' => 'views_handler_filter_numeric',
-    ),
-    'sort' => array(
-      'handler' => 'views_handler_sort',
-    ),
-  );
+    //----------------------------------------------------------------
+    // CIVICRM Price Set Entity - FIELDS
+    //----------------------------------------------------------------
 
-  // Entity Table
-  $data['civicrm_price_set_entity']['entity_table'] = array(
-    'title' => t('Entity Table'),
-    'help' => t('The entity table for the Price Set'),
-    'field' => array(
-      'handler' => 'views_handler_field',
-      'click sortable' => TRUE,
-    ),
-    'argument' => array(
-      'handler' => 'views_handler_argument_string',
-    ),
-    'filter' => array(
-      'handler' => 'views_handler_filter_string',
-      'allow empty' => TRUE,
-    ),
-    'sort' => array(
-      'handler' => 'views_handler_sort',
-    ),
-  );
+    // Numeric: Price Set ID
+    $data['civicrm_price_set_entity']['price_set_id'] = [
+      'title'    => t('Price Set ID'),
+      'help'     => t('The numeric ID of the Price Set'),
+      'field'    => [
+        'handler'        => 'views_handler_field_numeric',
+        'click sortable' => TRUE,
+      ],
+      'argument' => [
+        'handler' => 'views_handler_argument_numeric',
+        'numeric' => TRUE,
+      ],
+      'filter'   => [
+        'handler' => 'views_handler_filter_numeric',
+      ],
+      'sort'     => [
+        'handler' => 'views_handler_sort',
+      ],
+    ];
 
-  //----------------------------------------------------------------
-  // CIVICRM Price Set Entity - TABLE JOINS
-  //----------------------------------------------------------------
+    // Entity Table
+    $data['civicrm_price_set_entity']['entity_table'] = [
+      'title'    => t('Entity Table'),
+      'help'     => t('The entity table for the Price Set'),
+      'field'    => [
+        'handler'        => 'views_handler_field',
+        'click sortable' => TRUE,
+      ],
+      'argument' => [
+        'handler' => 'views_handler_argument_string',
+      ],
+      'filter'   => [
+        'handler'     => 'views_handler_filter_string',
+        'allow empty' => TRUE,
+      ],
+      'sort'     => [
+        'handler' => 'views_handler_sort',
+      ],
+    ];
 
-  $data['civicrm_price_set_entity']['table']['join'] = array(
-    // Directly links to event table.
-    'civicrm_event' => array(
-      'left_field' => 'id',
-      'field' => 'entity_id',
-    ),
+    //----------------------------------------------------------------
+    // CIVICRM Price Set Entity - TABLE JOINS
+    //----------------------------------------------------------------
 
-  );
+    $data['civicrm_price_set_entity']['table']['join'] = [
+      // Directly links to event table.
+      'civicrm_event' => [
+        'left_field' => 'id',
+        'field'      => 'entity_id',
+      ],
 
-  $data['civicrm_event']['table']['join']['civicrm_price_set_entity'] = array(
+    ];
 
-    'left_field' => 'entity_id',
-    'field' => 'id',
+    //----------------------------------------------------------------
+    // CIVICRM Price Set Entity - RELATIONSHIPS
+    //----------------------------------------------------------------
+    // Price Set
+    $data['civicrm_price_set_entity']['civicrm_price_set'] = array(
+      'title' => t('Price Set'),
+      'help' => t('Price Set for this Entity'),
+      'real field' => 'price_set_id',
+      'relationship' => array(
+        'base' => 'civicrm_price_set',
+        'base field' => 'id',
+        'handler' => 'views_handler_relationship',
+        'label' => t('Price Set'),
+      ),
+    );
 
-  );
+    if (!empty($enabled_entities['civicrm_event'])) {
+      $data['civicrm_event']['table']['join']['civicrm_price_set_entity'] = array(
+
+        'left_field' => 'entity_id',
+        'field' => 'id',
+
+      );
+    }
+
+    if (!empty($enabled_entities['civicrm_contribution_page'])) {
+      // Contribution page to price set entity
+      $data['civicrm_contribution_page']['civicrm_price_set_entity'] = array(
+        'title' => t('Price Set Entity'),
+        'help' => t('Price Set Entity'),
+        'real field' => 'id',
+        'relationship' => array(
+          'base' => 'civicrm_price_set_entity',
+          'base field' => 'entity_id',
+          'handler' => 'views_handler_relationship',
+          'label' => t('Price Set Entity'),
+        ),
+      );
+    }
+
+    if (!empty($enabled_entities['civicrm_price_field'])) {
+      $data['civicrm_price_set']['civicrm_price_field'] = array(
+        'group' => t('Price Field'),
+        'title' => t('CiviCRM Price field'),
+        'help' => t('Joins with the civicrm_price_field table'),
+        'relationship' => array(
+          'handler' => 'views_handler_relationship',
+          'label' => t('Price Field'),
+          'title' => t('Price Field'),
+          'base' => 'civicrm_price_field',
+          'base field' => 'price_set_id',
+          'relationship field' => 'id',
+        ),
+      );
 
 
-  //----------------------------------------------------------------
-  // CIVICRM Price Set Entity - RELATIONSHIPS
-  //----------------------------------------------------------------
+    }
+  } // end if !empty($enabled_entities['civicrm_price_set'])
 
-  // Contribution page to price set entity
-  $data['civicrm_contribution_page']['civicrm_price_set_entity'] = array(
-    'title' => t('Price Set Entity'),
-    'help' => t('Price Set Entity'),
-    'real field' => 'id',
-    'relationship' => array(
-      'base' => 'civicrm_price_set_entity',
-      'base field' => 'entity_id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('Price Set Entity'),
-    ),
-  );
+  if (!empty($enabled_entities['civicrm_price_field']) && !empty($enabled_entities['civicrm_price_field_value'])) {
+    // Price Field Value
+    $data['civicrm_price_field']['civicrm_price_field_value'] = array(
+      'title' => t('Price Field Value'),
+      'help' => t('Value(s) for this Price Field'),
+      'real field' => 'id',
+      'relationship' => array(
+        'base' => 'civicrm_price_field_value',
+        'base field' => 'price_field_id',
+        'handler' => 'views_handler_relationship',
+        'label' => t('Price Field Value'),
+      ),
+    );
+  }
 
-  // Price Set
-  $data['civicrm_price_set_entity']['civicrm_price_set'] = array(
-    'title' => t('Price Set'),
-    'help' => t('Price Set for this Entity'),
-    'real field' => 'price_set_id',
-    'relationship' => array(
-      'base' => 'civicrm_price_set',
-      'base field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('Price Set'),
-    ),
-  );
 
-  $data['civicrm_price_set']['civicrm_price_field'] = array(
-    'group' => t('Price Field'),
-    'title' => t('CiviCRM Price field'),
-    'help' => t('Joins with the civicrm_price_field table'),
-    'relationship' => array(
-      'handler' => 'views_handler_relationship',
-      'label' => t('Price Field'),
-      'title' => t('Price Field'),
-      'base' => 'civicrm_price_field',
-      'base field' => 'price_set_id',
-      'relationship field' => 'id',
-    ),
-  );
-
-  // Price Field Value
-  $data['civicrm_price_field']['civicrm_price_field_value'] = array(
-    'title' => t('Price Field Value'),
-    'help' => t('Value(s) for this Price Field'),
-    'real field' => 'id',
-    'relationship' => array(
-      'base' => 'civicrm_price_field_value',
-      'base field' => 'price_field_id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('Price Field Value'),
-    ),
-  );
 
   //----------------------------------------------------------------
   // CIVICRM Membership Payment - RELATIONSHIPS
   //----------------------------------------------------------------
+  if (!empty($enabled_entities['civicrm_membership_payment'])) {
+    // Membership
+    $data['civicrm_membership']['civicrm_membership_payment'] = [
+      'title'        => t('CiviCRM Membership Payment'),
+      'help'         => t('Relates Membership Payment to Membership'),
+      'real field'   => 'id',
+      'relationship' => [
+        'base'       => 'civicrm_membership_payment',
+        'base field' => 'membership_id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Membership Payment'),
+      ],
+    ];
 
-  // Membership
-  $data['civicrm_membership']['civicrm_membership_payment'] = array(
-    'title' => t('CiviCRM Membership Payment'),
-    'help' => t('Relates Membership Payment to Membership'),
-    'real field' => 'id',
-    'relationship' => array(
-      'base' => 'civicrm_membership_payment',
-      'base field' => 'membership_id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Membership Payment'),
-    ),
-  );
 
-
-  $data['civicrm_membership_payment']['civicrm_membership'] = array(
-    'title' => t('CiviCRM Membership'),
-    'help' => t('Relates Membership to Membership Payment'),
-    'real field' => 'membership_id',
-    'relationship' => array(
-      'base' => 'civicrm_membership',
-      'base field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Memberships'),
-    ),
-  );
-  // Contribution
-  $data['civicrm_membership_payment']['civicrm_contribution'] = array(
-    'title' => t('CiviCRM Contributions'),
-    'help' => t('Relates Contribution to Membership Payment'),
-    'real field' => 'contribution_id',
-    'relationship' => array(
-      'base' => 'civicrm_contribution',
-      'base field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Contributions'),
-    ),
-  );
+    $data['civicrm_membership_payment']['civicrm_membership'] = [
+      'title'        => t('CiviCRM Membership'),
+      'help'         => t('Relates Membership to Membership Payment'),
+      'real field'   => 'membership_id',
+      'relationship' => [
+        'base'       => 'civicrm_membership',
+        'base field' => 'id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Memberships'),
+      ],
+    ];
+    // Contribution
+    $data['civicrm_membership_payment']['civicrm_contribution'] = [
+      'title'        => t('CiviCRM Contributions'),
+      'help'         => t('Relates Contribution to Membership Payment'),
+      'real field'   => 'contribution_id',
+      'relationship' => [
+        'base'       => 'civicrm_contribution',
+        'base field' => 'id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Contributions'),
+      ],
+    ];
+  }
 
   //----------------------------------------------------------------
   // CIVICRM Participant Payment - RELATIONSHIPS
   //----------------------------------------------------------------
+  if (!empty($enabled_entities['civicrm_participant_payment'])) {
+    // Participant
+    $data['civicrm_participant']['civicrm_participant_payment'] = [
+      'title'        => t('CiviCRM Participant Payment'),
+      'help'         => t('Relates Participant Payment to Participant'),
+      'real field'   => 'id',
+      'relationship' => [
+        'base'       => 'civicrm_participant_payment',
+        'base field' => 'participant_id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Participant Payment'),
+      ],
+    ];
 
-  // Participant
-  $data['civicrm_participant']['civicrm_participant_payment'] = array(
-    'title' => t('CiviCRM Participant Payment'),
-    'help' => t('Relates Participant Payment to Participant'),
-    'real field' => 'id',
-    'relationship' => array(
-      'base' => 'civicrm_participant_payment',
-      'base field' => 'participant_id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Participant Payment'),
-    ),
-  );
-
-  $data['civicrm_participant_payment']['civicrm_participant'] = array(
-    'title' => t('CiviCRM Participant'),
-    'help' => t('Relates Participant to Participant Payment'),
-    'real field' => 'participant_id',
-    'relationship' => array(
-      'base' => 'civicrm_participant',
-      'base field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Participant'),
-    ),
-  );
-  // Contribution
-  $data['civicrm_participant_payment']['civicrm_contribution'] = array(
-    'title' => t('CiviCRM Contributions'),
-    'help' => t('Relates Contribution to Membership Payment'),
-    'real field' => 'contribution_id',
-    'relationship' => array(
-      'base' => 'civicrm_contribution',
-      'base field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Contributions'),
-    ),
-  );
+    $data['civicrm_participant_payment']['civicrm_participant'] = [
+      'title'        => t('CiviCRM Participant'),
+      'help'         => t('Relates Participant to Participant Payment'),
+      'real field'   => 'participant_id',
+      'relationship' => [
+        'base'       => 'civicrm_participant',
+        'base field' => 'id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Participant'),
+      ],
+    ];
+    // Contribution
+    $data['civicrm_participant_payment']['civicrm_contribution'] = [
+      'title'        => t('CiviCRM Contributions'),
+      'help'         => t('Relates Contribution to Membership Payment'),
+      'real field'   => 'contribution_id',
+      'relationship' => [
+        'base'       => 'civicrm_contribution',
+        'base field' => 'id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Contributions'),
+      ],
+    ];
+  }
 
 
   //----------------------------------------------------------------
   // CIVICRM Relationship - RELATIONSHIPS
   //----------------------------------------------------------------
-  $data['civicrm_relationship']['civicrm_relationship_type'] = array(
-    'title' => t('CiviCRM Relationship Type'),
-    'help' => t('Relates Relationship Type to Relationships'),
-    'real field' => 'relationship_type_id',
-    'relationship' => array(
-      'base' => 'civicrm_relationship_type',
-      'base field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Relationship Type'),
-    ),
-  );
+  if (!empty($enabled_entities['civicrm_entity_relationship_type'])) {
+    $data['civicrm_relationship']['civicrm_relationship_type'] = [
+      'title'        => t('CiviCRM Relationship Type'),
+      'help'         => t('Relates Relationship Type to Relationships'),
+      'real field'   => 'relationship_type_id',
+      'relationship' => [
+        'base'       => 'civicrm_relationship_type',
+        'base field' => 'id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Relationship Type'),
+      ],
+    ];
+  }
 
   //----------------------------------------------------------------
   // CIVICRM Contributions - RELATIONSHIPS
   //----------------------------------------------------------------
-  $data['civicrm_contribution']['civicrm_line_item'] = array(
-    'title' => t('CiviCRM Line Items'),
-    'help' => t('Relates Line Items to Contributions'),
-    'real field' => 'id',
-    'relationship' => array(
-      'base' => 'civicrm_line_item',
-      'base field' => 'contribution_id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Line Items'),
-    ),
-  );
+  if (!empty($enabled_entities['civicrm_line_item'])) {
+    $data['civicrm_contribution']['civicrm_line_item'] = [
+      'title'        => t('CiviCRM Line Items'),
+      'help'         => t('Relates Line Items to Contributions'),
+      'real field'   => 'id',
+      'relationship' => [
+        'base'       => 'civicrm_line_item',
+        'base field' => 'contribution_id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Line Items'),
+      ],
+    ];
+  }
 
-  $data['civicrm_contribution']['civicrm_entity_financial_trxn'] = array(
-    'title' => t('CiviCRM Line Items'),
-    'help' => t('Relates Entity Financial Trxn to Contributions'),
-    'real field' => 'id',
-    'relationship' => array(
-      'base' => 'civicrm_entity_financial_trxn',
-      'base field' => 'entity_id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Entity Financial Trxn'),
-    ),
-  );
-
+  if (!empty($enabled_entities['civicrm_entity_financial_trxn'])) {
+    $data['civicrm_contribution']['civicrm_entity_financial_trxn'] = [
+      'title'        => t('CiviCRM Line Items'),
+      'help'         => t('Relates Entity Financial Trxn to Contributions'),
+      'real field'   => 'id',
+      'relationship' => [
+        'base'       => 'civicrm_entity_financial_trxn',
+        'base field' => 'entity_id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Entity Financial Trxn'),
+      ],
+    ];
+  }
   //----------------------------------------------------------------
   // CIVICRM Entity Financial Trxn - RELATIONSHIPS
   //----------------------------------------------------------------
-
-  $data['civicrm_entity_financial_txrn']['civicrm_financial_trxn'] = array(
-    'title' => t('Financial Trxn'),
-    'help' => t('Relates Financial Trxn to Entity Financial Trxn'),
-    'real field' => 'financial_trxn_id',
-    'relationship' => array(
-      'base' => 'civicrm_financial_trxn',
-      'base field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Financial Txrn'),
-    ),
-  );
+  if (!empty($enabled_entities['civicrm_entity_financial_txrn']) && !empty($enabled_entities['civicrm_financial_trxn'])) {
+    $data['civicrm_entity_financial_txrn']['civicrm_financial_trxn'] = [
+      'title'        => t('Financial Trxn'),
+      'help'         => t('Relates Financial Trxn to Entity Financial Trxn'),
+      'real field'   => 'financial_trxn_id',
+      'relationship' => [
+        'base'       => 'civicrm_financial_trxn',
+        'base field' => 'id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Financial Txrn'),
+      ],
+    ];
+  }
 
   //----------------------------------------------------------------
   // CIVICRM Financial Trxn - RELATIONSHIPS
   //----------------------------------------------------------------
 
-  $data['civicrm_financial_txrn']['civicrm_payment_processor'] = array(
-    'title' => t('Payment Processor'),
-    'help' => t('Relates Payment Processor to Financial Trxn'),
-    'real field' => 'payment_processor_id',
-    'relationship' => array(
-      'base' => 'civicrm_payment_processor',
-      'base field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Payment Processor'),
-    ),
-  );
+  if (!empty($enabled_entities['civicrm_financial_txrn']) && !empty($enabled_entities['civicrm_payment_processor'])) {
+    $data['civicrm_financial_txrn']['civicrm_payment_processor'] = [
+      'title'        => t('Payment Processor'),
+      'help'         => t('Relates Payment Processor to Financial Trxn'),
+      'real field'   => 'payment_processor_id',
+      'relationship' => [
+        'base'       => 'civicrm_payment_processor',
+        'base field' => 'id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Payment Processor'),
+      ],
+    ];
+  }
 
-  $data['civicrm_financial_txrn']['civicrm_financial_account_from'] = array(
-    'title' => t('Financial Account (From)'),
-    'help' => t('Relates Financial Trxn to Financial Account (From)'),
-    'real field' => 'from_financial_account_id',
-    'relationship' => array(
-      'base' => 'civicrm_financial_account',
-      'base field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Financial Account (From)'),
-    ),
-  );
+  if (!empty($enabled_entities['civicrm_financial_txrn']) && !empty($enabled_entities['civicrm_financial_account'])) {
+    $data['civicrm_financial_txrn']['civicrm_financial_account_from'] = [
+      'title'        => t('Financial Account (From)'),
+      'help'         => t('Relates Financial Trxn to Financial Account (From)'),
+      'real field'   => 'from_financial_account_id',
+      'relationship' => [
+        'base'       => 'civicrm_financial_account',
+        'base field' => 'id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Financial Account (From)'),
+      ],
+    ];
 
-  $data['civicrm_financial_txrn']['civicrm_financial_account_to'] = array(
-    'title' => t('Financial Account (To)'),
-    'help' => t('Relates Financial Trxn to Financial Account (To)'),
-    'real field' => 'to_financial_account_id',
-    'relationship' => array(
-      'base' => 'civicrm_financial_account',
-      'base field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Financial Account (To)'),
-    ),
-  );
-
+    $data['civicrm_financial_txrn']['civicrm_financial_account_to'] = [
+      'title'        => t('Financial Account (To)'),
+      'help'         => t('Relates Financial Trxn to Financial Account (To)'),
+      'real field'   => 'to_financial_account_id',
+      'relationship' => [
+        'base'       => 'civicrm_financial_account',
+        'base field' => 'id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Financial Account (To)'),
+      ],
+    ];
+  }
   //----------------------------------------------------------------
   // CIVICRM Payment Processor - RELATIONSHIPS
   //----------------------------------------------------------------
-
-  $data['civicrm_payment_processor']['civicrm_payment_processor_type'] = array(
-    'title' => t('Payment Processor type'),
-    'help' => t('Relates Payment Processor Type to Payment Processor'),
-    'real field' => 'payment_processor_type_id',
-    'relationship' => array(
-      'base' => 'civicrm_payment_processor_type',
-      'base field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Payment Processor Type'),
-    ),
-  );
-
+  if (!empty($enabled_entities['civicrm_payment_processor']) && !empty($enabled_entities['civicrm_payment_processor_type'])) {
+    $data['civicrm_payment_processor']['civicrm_payment_processor_type'] = [
+      'title'        => t('Payment Processor type'),
+      'help'         => t('Relates Payment Processor Type to Payment Processor'),
+      'real field'   => 'payment_processor_type_id',
+      'relationship' => [
+        'base'       => 'civicrm_payment_processor_type',
+        'base field' => 'id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Payment Processor Type'),
+      ],
+    ];
+  }
   //----------------------------------------------------------------
   // CIVICRM Line Items - RELATIONSHIPS
   //----------------------------------------------------------------
-  $data['civicrm_line_item']['civicrm_price_field'] = array(
-    'title' => t('CiviCRM Price Fields'),
-    'help' => t('Relates Price Fields to Line Items'),
-    'real field' => 'price_field_id',
-    'relationship' => array(
-      'base' => 'civicrm_price_field',
-      'base field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Price Field'),
-    ),
-  );
-
-  $data['civicrm_line_item']['civicrm_price_field_value'] = array(
-    'title' => t('CiviCRM Price Field Value'),
-    'help' => t('Relates Price Field Values to Line Items'),
-    'real field' => 'price_field_value_id',
-    'relationship' => array(
-      'base' => 'civicrm_price_field_value',
-      'base field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Price Field Value'),
-    ),
-  );
-
+  if (!empty($enabled_entities['civicrm_line_item']) && !empty($enabled_entities['civicrm_price_field'])) {
+    $data['civicrm_line_item']['civicrm_price_field'] = [
+      'title'        => t('CiviCRM Price Fields'),
+      'help'         => t('Relates Price Fields to Line Items'),
+      'real field'   => 'price_field_id',
+      'relationship' => [
+        'base'       => 'civicrm_price_field',
+        'base field' => 'id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Price Field'),
+      ],
+    ];
+  }
+  if (!empty($enabled_entities['civicrm_line_item']) && !empty($enabled_entities['civicrm_price_field_value'])) {
+    $data['civicrm_line_item']['civicrm_price_field_value'] = [
+      'title'        => t('CiviCRM Price Field Value'),
+      'help'         => t('Relates Price Field Values to Line Items'),
+      'real field'   => 'price_field_value_id',
+      'relationship' => [
+        'base'       => 'civicrm_price_field_value',
+        'base field' => 'id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('CiviCRM Price Field Value'),
+      ],
+    ];
+  }
 //----------------------------------------------------------------
   // CIVICRM World Region
   //----------------------------------------------------------------
@@ -456,92 +483,95 @@ function civicrm_entity_views_extras_views_data() {
     ),
   );
 
-  //----------------------------------------------------------------
-  // CIVICRM IM
-  //----------------------------------------------------------------
-  $data['civicrm_im']['location_type'] = array(
-    'title' => t('Location Type'),
-    'real field' => 'location_type_id',
-    'help' => t('The location type for the IM'),
-    'field' => array(
-      'handler' => 'civicrm_handler_field_pseudo_constant',
-      'pseudo class' => 'CRM_Core_PseudoConstant',
-      'pseudo method' => 'get',
-      'dao class' => 'CRM_Core_DAO_IM',
-      'click sortable' => TRUE,
-    ),
-    'argument' => array(
-      'handler' => 'views_handler_argument',
-    ),
-    'filter' => array(
-      'handler' => 'civicrm_handler_filter_pseudo_constant',
-      'pseudo class' => 'CRM_Core_PseudoConstant',
-      'pseudo method' => 'get',
-      'dao class' => 'CRM_Core_DAO_IM',
-    ),
-    'sort' => array(
-      'handler' => 'views_handler_sort',
-    ),
-  );
+  if (!empty($enabled_entities['civicrm_im'])) {
+    //----------------------------------------------------------------
+    // CIVICRM IM
+    //----------------------------------------------------------------
+    $data['civicrm_im']['location_type'] = [
+      'title'      => t('Location Type'),
+      'real field' => 'location_type_id',
+      'help'       => t('The location type for the IM'),
+      'field'      => [
+        'handler'        => 'civicrm_handler_field_pseudo_constant',
+        'pseudo class'   => 'CRM_Core_PseudoConstant',
+        'pseudo method'  => 'get',
+        'dao class'      => 'CRM_Core_DAO_IM',
+        'click sortable' => TRUE,
+      ],
+      'argument'   => [
+        'handler' => 'views_handler_argument',
+      ],
+      'filter'     => [
+        'handler'       => 'civicrm_handler_filter_pseudo_constant',
+        'pseudo class'  => 'CRM_Core_PseudoConstant',
+        'pseudo method' => 'get',
+        'dao class'     => 'CRM_Core_DAO_IM',
+      ],
+      'sort'       => [
+        'handler' => 'views_handler_sort',
+      ],
+    ];
 
-  $data['civicrm_im']['provider'] = array(
-    'title' => t('Provider'),
-    'real field' => 'provider_id',
-    'help' => t('The provider for the IM'),
-    'field' => array(
-      'handler' => 'civicrm_handler_field_pseudo_constant',
-      'pseudo class' => 'CRM_Core_PseudoConstant',
-      'pseudo method' => 'get',
-      'dao class' => 'CRM_Core_DAO_IM',
-      'click sortable' => TRUE,
-    ),
-    'argument' => array(
-      'handler' => 'views_handler_argument',
-    ),
-    'filter' => array(
-      'handler' => 'civicrm_handler_filter_pseudo_constant',
-      'pseudo class' => 'CRM_Core_PseudoConstant',
-      'pseudo method' => 'get',
-      'dao class' => 'CRM_Core_DAO_IM',
-    ),
-    'sort' => array(
-      'handler' => 'views_handler_sort',
-    ),
-  );
+    $data['civicrm_im']['provider'] = [
+      'title'      => t('Provider'),
+      'real field' => 'provider_id',
+      'help'       => t('The provider for the IM'),
+      'field'      => [
+        'handler'        => 'civicrm_handler_field_pseudo_constant',
+        'pseudo class'   => 'CRM_Core_PseudoConstant',
+        'pseudo method'  => 'get',
+        'dao class'      => 'CRM_Core_DAO_IM',
+        'click sortable' => TRUE,
+      ],
+      'argument'   => [
+        'handler' => 'views_handler_argument',
+      ],
+      'filter'     => [
+        'handler'       => 'civicrm_handler_filter_pseudo_constant',
+        'pseudo class'  => 'CRM_Core_PseudoConstant',
+        'pseudo method' => 'get',
+        'dao class'     => 'CRM_Core_DAO_IM',
+      ],
+      'sort'       => [
+        'handler' => 'views_handler_sort',
+      ],
+    ];
 
-  $data['civicrm_contact']['civicrm_im'] = array(
-    'title' => t('IM'),
-    'help' => t('Instant Message Accounts'),
-    'real field' => 'id',
-    'relationship' => array(
-      'base' => 'civicrm_im',
-      'base field' => 'contact_id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('Contact IM'),
-    ),
-  );
-  $data['civicrm_im']['civicrm_contact'] = array(
-    'title' => t('Contact'),
-    'help' => t('Contact for the instant message account'),
-    'real field' => 'contact_id',
-    'relationship' => array(
-      'base' => 'civicrm_contact',
-      'base field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('Contact'),
-    ),
-  );
+    $data['civicrm_contact']['civicrm_im'] = [
+      'title'        => t('IM'),
+      'help'         => t('Instant Message Accounts'),
+      'real field'   => 'id',
+      'relationship' => [
+        'base'       => 'civicrm_im',
+        'base field' => 'contact_id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('Contact IM'),
+      ],
+    ];
+    $data['civicrm_im']['civicrm_contact'] = [
+      'title'        => t('Contact'),
+      'help'         => t('Contact for the instant message account'),
+      'real field'   => 'contact_id',
+      'relationship' => [
+        'base'       => 'civicrm_contact',
+        'base field' => 'id',
+        'handler'    => 'views_handler_relationship',
+        'label'      => t('Contact'),
+      ],
+    ];
+  }
   //----------------------------------------------------------------
   // CIVICRM Event Extras
   //----------------------------------------------------------------
-
-  $data['civicrm_event']['event_is_full'] = array(
-    'title' => t('Event Is Full'),
-    'help' => t('Provided by CiviCRM Entity: 1 if event is full 0 otherwise.'),
-    'field' => array(
-      'handler' => 'civicrm_entity_views_extras_handler_event_is_full',
-    ),
-  );
+  if (!empty($enabled_entities['civicrm_event'])) {
+    $data['civicrm_event']['event_is_full'] = [
+      'title' => t('Event Is Full'),
+      'help'  => t('Provided by CiviCRM Entity: 1 if event is full 0 otherwise.'),
+      'field' => [
+        'handler' => 'civicrm_entity_views_extras_handler_event_is_full',
+      ],
+    ];
+  }
 
   return $data;
 }
@@ -550,8 +580,11 @@ function civicrm_entity_views_extras_views_data() {
  * Implements hook_views_data_alter().
  */
 function civicrm_entity_views_extras_views_data_alter(&$data) {
-  if(!empty($data['civicrm_im'])) {
-    $data['civicrm_im']['provider_id']['title'] = 'Provider ID';
-    $data['civicrm_im']['location_type_id']['title'] = 'IM Location Type ID';
+  $enabled_entities = _civicrm_entity_enabled_entities();
+  if (!empty($enabled_entities['civicrm_im'])) {
+    if (!empty($data['civicrm_im'])) {
+      $data['civicrm_im']['provider_id']['title'] = 'Provider ID';
+      $data['civicrm_im']['location_type_id']['title'] = 'IM Location Type ID';
+    }
   }
 }


### PR DESCRIPTION
Pretty big commit here, adding a admin config page for CiviCRM Entity, allowing admins to disable entity integrations....All submodules packaged with CiviCRM Entity will automatically enable entity types as they are required. 

admin/structure/civicrm-entity/settings

