### PR TITLE
Adding First.Middle.Last to username format options

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -2981,6 +2981,9 @@ function civicrm_entity_action_create_user($contact, $is_active, $notify = FALSE
     case 'f.last':
       $params['name'] = _civicrm_entity_clean_login_name(substr($contact['first_name'], 0, 1) . "." . $contact['last_name']);
      break;
+    case 'first.middle.last':
+     $params['name'] = _civicrm_entity_clean_login_name($contact['first_name'] . "." . $contact['middle_name'] . "." . $contact['last_name']);
+     break;
     case 'email':
       $params['name'] = $params['email'];
       break;
@@ -3070,6 +3073,7 @@ function _civicrm_entity_options_username_format($field, $instance) {
     'firstlast' => t('FirstLast'),
     'first.last' => t('First.Last'),
     'f.last' => t('F.Last'),
+    'first.middle.last' => t('First.Middle.Last'),
     'email' => 'Use E-mail Address',
   );
   return $options;


### PR DESCRIPTION
In our organisation we had a need to include the middle name in the username format for the creation of a new linked drupal user account.
Since i'ts only a possible to select from a drop-down or use 1 of the data select fields we could not construct this via the ui. Hence we added it to the username format options.