### PR TITLE
Conditional if middle name is empty

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -2980,10 +2980,14 @@ function civicrm_entity_action_create_user($contact, $is_active, $notify = FALSE
       break;
     case 'f.last':
       $params['name'] = _civicrm_entity_clean_login_name(substr($contact['first_name'], 0, 1) . "." . $contact['last_name']);
-     break;
+      break;
     case 'first.middle.last':
-     $params['name'] = _civicrm_entity_clean_login_name($contact['first_name'] . "." . $contact['middle_name'] . "." . $contact['last_name']);
-     break;
+      if (!empty($contact['middle_name'])) {
+        $params['name'] = _civicrm_entity_clean_login_name($contact['first_name'] . "." . $contact['middle_name'] . "." . $contact['last_name']);
+      } else {
+        $params['name'] = _civicrm_entity_clean_login_name($contact['first_name'] . "." . $contact['last_name']);
+      }
+      break;
     case 'email':
       $params['name'] = $params['email'];
       break;


### PR DESCRIPTION
In my previous PR (https://github.com/eileenmcnaughton/civicrm_entity/pull/126) added a new option to be able to create to new linked drupal user account with the syntax firstname.middlename.lastname I forgot to add a mechanism in case the middle name is empty. So we ended up in usernames like firstname..lastname (note the 2 dots). Therefor this new PR.