### PR TITLE
Prefer matching against Individuals, but if not, match as previously.

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -3052,7 +3052,9 @@ function civicrm_entity_action_create_user($contact, $is_active, $notify = FALSE
   //
   // Note that we 'pretend' to be logging in to make it do a ufmatch
   // on just the email.
-  CRM_Core_BAO_UFMatch::synchronizeUFMatch($user_object, $user_object->uid, $contact['email'], 'drupal', NULL, NULL, TRUE);
+  // Try to match Individuals, failing that, anything
+  CRM_Core_BAO_UFMatch::synchronizeUFMatch($user_object, $user_object->uid, $contact['email'], 'drupal', NULL, 'Individual', TRUE)
+   || CRM_Core_BAO_UFMatch::synchronizeUFMatch($user_object, $user_object->uid, $contact['email'], 'drupal', NULL, NULL, TRUE);
   drupal_set_message('User with username, ' . $params['cms_name'] . ', has been created.');
 
   // If selected in action configuration, automatically sign in the


### PR DESCRIPTION
If an Individual and Organisation have the same email address, the match
fails as it is not unique. Drupal logins should normally be linked to
Individuals, so look for those first.