### PR TITLE
Created Drupal username does not get trimmed well

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -2970,22 +2970,22 @@ function civicrm_entity_action_create_user($contact, $is_active, $notify = FALSE
 
   switch ($username_format) {
     case 'first last':
-      $params['name'] = _civicrm_entity_clean_login_name($contact['first_name'] . " " . $contact['last_name']);
+      $params['name'] = _civicrm_entity_clean_login_name(trim($contact['first_name']) . " " . trim($contact['last_name']));
       break;
     case 'firstlast':
-      $params['name'] = _civicrm_entity_clean_login_name($contact['first_name'] . " " . $contact['last_name']);
+      $params['name'] = _civicrm_entity_clean_login_name(trim($contact['first_name']) . " " . trim($contact['last_name']));
       break;
     case 'first.last':
-      $params['name'] = _civicrm_entity_clean_login_name($contact['first_name'] . "." . $contact['last_name']);
+      $params['name'] = _civicrm_entity_clean_login_name(trim($contact['first_name']) . "." . trim($contact['last_name']));
       break;
     case 'f.last':
-      $params['name'] = _civicrm_entity_clean_login_name(substr($contact['first_name'], 0, 1) . "." . $contact['last_name']);
+      $params['name'] = _civicrm_entity_clean_login_name(substr(trim($contact['first_name']), 0, 1) . "." . trim($contact['last_name']));
       break;
     case 'first.middle.last':
       if (!empty($contact['middle_name'])) {
-        $params['name'] = _civicrm_entity_clean_login_name($contact['first_name'] . "." . $contact['middle_name'] . "." . $contact['last_name']);
+        $params['name'] = _civicrm_entity_clean_login_name(trim($contact['first_name']) . "." . trim($contact['middle_name']) . "." . trim($contact['last_name']));
       } else {
-        $params['name'] = _civicrm_entity_clean_login_name($contact['first_name'] . "." . $contact['last_name']);
+        $params['name'] = _civicrm_entity_clean_login_name(trim($contact['first_name']) . "." . trim($contact['last_name']));
       }
       break;
     case 'email':


### PR DESCRIPTION
When a user enters a first,middle or lastname with an extra space in front or at the end the it will be replaces by a _ in the final username. Like for instance firstname_.lastname

I solved this with this PR
`$params['name'] = _civicrm_entity_clean_login_name(trim($contact['first_name']) . "." . trim($contact['last_name']));`
I'm not sure if my solution is the most efficient way of doing this.
Another option maybe would be to use the clean function on all subparts like this:
`$params['name'] = _civicrm_entity_clean_login_name($contact['first_name'] . "." . _civicrm_entity_clean_login_name($contact['last_name']));`