### PR TITLE
Warning: in_array() expects parameter 2 to be array, null given

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -29,7 +29,9 @@ function civicrm_entity_theme() {
 function civicrm_entity_entity_type_build(array &$entity_types) {
   $logger = \Drupal::logger('civicrm-entity');
   $supported_entities = SupportedEntities::getInfo();
-  $enabled_entity_types = \Drupal::config('civicrm_entity.settings')->get('enabled_entity_types');
+  $enabled_entity_types = !empty(\Drupal::config('civicrm_entity.settings')->get('enabled_entity_types'))
+    ? \Drupal::config('civicrm_entity.settings')->get('enabled_entity_types')
+    : [];
   foreach ($supported_entities as $entity_type_id => $civicrm_entity_info) {
     $clean_entity_type_id = str_replace('_', '-', $entity_type_id);
     $civicrm_entity_name = $civicrm_entity_info['civicrm entity name'];

--- a/config/install/civicrm_entity.settings.yml
+++ b/config/install/civicrm_entity.settings.yml
@@ -1,0 +1,1 @@
+enabled_entity_types: {}


### PR DESCRIPTION
When the module is installed or the settings page for Civicrm Entity is viewed, and the settings are not saved yet, you will get a PHP warning:

Warning: in_array() expects parameter 2 to be array, null given in civicrm_entity_entity_type_build() (regel 48 van ../civicrm_entity/civicrm_entity.module)