### PR TITLE
Fix to use config_translations and only show enabled entities in entity reference field

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -39,47 +39,49 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
       continue;
     }
 
-    $entity_types[$entity_type_id] = new ContentEntityType([
-      'provider' => 'civicrm_entity',
-      'class' => \Drupal\civicrm_entity\Entity\CivicrmEntity::class,
-      'originalClass' => \Drupal\civicrm_entity\Entity\CivicrmEntity::class,
-      'id' => $entity_type_id,
-      'civicrm_entity' => $civicrm_entity_name,
-      'civicrm_entity_ui_exposed' => in_array($entity_type_id, $enabled_entity_types),
-      'label' => new TranslatableMarkup('CiviCRM :name', [':name' => $civicrm_entity_info['civicrm entity label']]),
-      // @todo add label_singular
-      // @todo add label_plural
-      // @todo add label_count
-      'entity_keys' => [
-        'id' => 'id',
-        'label' => $civicrm_entity_info['label property'],
-      ],
-      'admin_permission' => 'administer civicrm entity',
-      'permission_granularity' => 'entity_type',
-      'handlers' => [
-        'storage' => \Drupal\civicrm_entity\CiviEntityStorage::class,
-        'list_builder' => \Drupal\civicrm_entity\CivicrmEntityListBuilder::class,
-        'route_provider' => [
-          'default' => \Drupal\civicrm_entity\Routing\CiviCrmEntityRouteProvider::class,
+    if (in_array($entity_type_id, $enabled_entity_types)) {
+      $entity_types[$entity_type_id] = new ContentEntityType([
+        'provider' => 'civicrm_entity',
+        'class' => \Drupal\civicrm_entity\Entity\CivicrmEntity::class,
+        'originalClass' => \Drupal\civicrm_entity\Entity\CivicrmEntity::class,
+        'id' => $entity_type_id,
+        'civicrm_entity' => $civicrm_entity_name,
+        'civicrm_entity_ui_exposed' => in_array($entity_type_id, $enabled_entity_types),
+        'label' => new TranslatableMarkup('CiviCRM :name', [':name' => $civicrm_entity_info['civicrm entity label']]),
+        // @todo add label_singular
+        // @todo add label_plural
+        // @todo add label_count
+        'entity_keys' => [
+          'id' => 'id',
+          'label' => $civicrm_entity_info['label property'],
         ],
-        'access' => \Drupal\civicrm_entity\CivicrmEntityAccessHandler::class,
-        'form' => [
-          'default' => \Drupal\civicrm_entity\Form\CivicrmEntityForm::class,
-          'add' => \Drupal\civicrm_entity\Form\CivicrmEntityForm::class,
-          'edit' => \Drupal\civicrm_entity\Form\CivicrmEntityForm::class,
-          'delete' => \Drupal\Core\Entity\ContentEntityDeleteForm::class,
+        'admin_permission' => 'administer civicrm entity',
+        'permission_granularity' => 'entity_type',
+        'handlers' => [
+          'storage' => \Drupal\civicrm_entity\CiviEntityStorage::class,
+          'list_builder' => \Drupal\civicrm_entity\CivicrmEntityListBuilder::class,
+          'route_provider' => [
+            'default' => \Drupal\civicrm_entity\Routing\CiviCrmEntityRouteProvider::class,
+          ],
+          'access' => \Drupal\civicrm_entity\CivicrmEntityAccessHandler::class,
+          'form' => [
+            'default' => \Drupal\civicrm_entity\Form\CivicrmEntityForm::class,
+            'add' => \Drupal\civicrm_entity\Form\CivicrmEntityForm::class,
+            'edit' => \Drupal\civicrm_entity\Form\CivicrmEntityForm::class,
+            'delete' => \Drupal\Core\Entity\ContentEntityDeleteForm::class,
+          ],
         ],
-      ],
-      // Generate route paths.
-      'links' => [
-        'canonical' => sprintf('/%s/{%s}', $clean_entity_type_id, $entity_type_id),
-        'delete-form' => sprintf('/%s/{%s}/delete', $clean_entity_type_id, $entity_type_id),
-        'edit-form' => sprintf('/%s/{%s}/edit', $clean_entity_type_id, $entity_type_id),
-        'add-form' => sprintf('/%s/add', $clean_entity_type_id, $entity_type_id),
-        'collection' => sprintf('/admin/structure/civicrm-entity/%s', $clean_entity_type_id),
-      ],
-      'field_ui_base_route' => "entity.$entity_type_id.collection",
-    ]);
+        // Generate route paths.
+        'links' => [
+          'canonical' => sprintf('/%s/{%s}', $clean_entity_type_id, $entity_type_id),
+          'delete-form' => sprintf('/%s/{%s}/delete', $clean_entity_type_id, $entity_type_id),
+          'edit-form' => sprintf('/%s/{%s}/edit', $clean_entity_type_id, $entity_type_id),
+          'add-form' => sprintf('/%s/add', $clean_entity_type_id, $entity_type_id),
+          'collection' => sprintf('/admin/structure/civicrm-entity/%s', $clean_entity_type_id),
+        ],
+        'field_ui_base_route' => "entity.$entity_type_id.collection",
+      ]);
+    }
   }
 }
 


### PR DESCRIPTION
When trying to use config_translation module, this module produces an error on the routes as it always parses all the entities and not only the enabled ones.

So this commit fixes that only the enabled entities are parsed when the config_translation module is enabled and also only shows the enabled entities to be shown in a entity reference field.