### PR TITLE
Civi 5.* Composer Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "civicrm/civicrm-core": "4.7.*",
+        "civicrm/civicrm-core": "4.7 - 5",
         "civicrm/civicrm-drupal": "dev-8.x-master"
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
Adjustment to `composer.json` to allow the module to be used with Civi 5.*
