### PR TITLE
Set ID on New Entity

### DIFF
--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -91,7 +91,12 @@ class CiviEntityStorage extends ContentEntityStorageBase {
       }
     }
 
-    $this->civicrmApi->save($this->entityType->get('civicrm_entity'), $params);
+    $result = $this->civicrmApi->save($this->entityType->get('civicrm_entity'), $params);
+
+    if ($entity->isNew()) {
+      $entity->{$this->idKey} = (string) $result['id'];
+    }
+
     return $return;
   }
 


### PR DESCRIPTION
This change sets the ID on a newly-created entity. Otherwise the ID will be `NULL` until the next time the entity is loaded which causes issues with subsequent operations that utilize the ID.