### PR TITLE
Use passed tag_id to find civicrm tag entities

### DIFF
--- a/civicrm_entity_controller.inc
+++ b/civicrm_entity_controller.inc
@@ -78,8 +78,19 @@ class CivicrmEntityController extends EntityAPIController {
         }
         if (!empty($ids)) {
           foreach ($ids as $id) {
+            if ($this->entityInfo['description'] == 'entity_tag') {
+              // When removing tags in the civicrm contact tag editor, we get passed the tag ID here, not the entity table ID.
+              $entityParams = [
+                'tag_id' => $id,
+              ];
+            }
+            else {
+              $entityParams = [
+                'id' => $id,
+              ];
+            }
             // we can't rely on civicrm api accepting the 'IN' => array(1,5,6) for all entities
-            $queried_entities += $this->loadEntities(array('id' => $id));
+            $queried_entities += $this->loadEntities($entityParams);
           }
         }
       } catch (Exception $e) {


### PR DESCRIPTION
This was a real pain to track down... and I'm not completely sure this is the right way to fix as I'm not really familiar with civicrm_entity module and it's interaction with Drupal. However...

One particular site had created some additional tags (with CiviCRM tag IDs 31,32).  Using the contact "tag" tab it was possible to add them to the contact.
BUT, attempting to remove them caused an exception on the resulting entitytag.delete API call because the ID 31 was being looked up by civicrm_entity as the "entity ID" (ie. the unique primary key for the civicrm_entity_tag table) and not the tag ID.  This meant the call would fail if civicrm_entity_tag.id=31 did not exist, even though that entry linked to a completely different tag ID (civicrm_entity_tag.tag_id=X).

This PR looks up using `tag_id` if entity is "entity_tag" and using `id` otherwise (which was the default before).

I saw a similar specific override for entity_tag at line 3500 of civicrm_entity.module (https://github.com/eileenmcnaughton/civicrm_entity/blob/7.x-2.x/civicrm_entity.module#L3500) which inspired this patch.