### PR TITLE
Make civicrm entities themable and add a default civicrm-entity template

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -149,7 +149,22 @@ function template_preprocess_civicrm_entity(&$variables) {
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function civicrm_entity_theme_suggestions_civicrm_entity_alter(array &$suggestions, array $variables) {
-  $entity_type = $variables['elements']['#entity_type'];
+  $entity_type = NULL;
+  if (isset($variables['elements']['#entity_type'])) {
+    $entity_type = $variables['elements']['#entity_type'];
+  }
+
+  // Find the CivicrmEntity from elements if #entity_type is not set.
+  if (! $entity_type) {
+    foreach ($variables['elements'] as $element) {
+      if ($element instanceof CivicrmEntity) {
+        /** @var CivicrmEntity $element */
+        $entity_type = $element->getEntityTypeId();
+        break;
+      }
+    }
+  }
+
   $view_mode = $variables['elements']['#view_mode'];
   $hook = $variables['theme_hook_original'];
 

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -142,35 +142,40 @@ function template_preprocess_civicrm_entity(&$variables) {
   $variables['view_mode'] = $variables['elements']['#view_mode'];
 
   // Add the bundle to the template.
-  $variables['entity_type'] = $variables['elements']['#entity_type'];
+  $variables['entity_type'] = _civicrm_entity_get_entity_type_from_elements($variables['elements']);
 }
 
 /**
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function civicrm_entity_theme_suggestions_civicrm_entity_alter(array &$suggestions, array $variables) {
-  $entity_type = NULL;
-  if (isset($variables['elements']['#entity_type'])) {
-    $entity_type = $variables['elements']['#entity_type'];
-  }
-
-  // Find the CivicrmEntity from elements if #entity_type is not set.
-  if (! $entity_type) {
-    foreach ($variables['elements'] as $element) {
-      if ($element instanceof CivicrmEntity) {
-        /** @var CivicrmEntity $element */
-        $entity_type = $element->getEntityTypeId();
-        break;
-      }
-    }
-  }
-
   $view_mode = $variables['elements']['#view_mode'];
   $hook = $variables['theme_hook_original'];
 
   // Add a suggestion based on the entity type.
-  $suggestions[] = $hook . '__' . $entity_type;
+  if ($entity_type = _civicrm_entity_get_entity_type_from_elements($variables['elements'])) {
+    $suggestions[] = $hook . '__' . $entity_type;
 
-  // Add a suggestion based on the view mode.
-  $suggestions[] = $hook . '__' . $entity_type . '__' . $view_mode;
+    // Add a suggestion based on the view mode.
+    $suggestions[] = $hook . '__' . $entity_type . '__' . $view_mode;
+  }
+}
+
+/**
+ * Helper to find the entity type from $variables['elements'].
+ */
+function _civicrm_entity_get_entity_type_from_elements($elements) {
+  if (isset($elements['#entity_type'])) {
+    return $elements['#entity_type'];
+  }
+
+  // Find the CivicrmEntity from elements if #entity_type is not set.
+  foreach ($elements as $element) {
+    if ($element instanceof CivicrmEntity) {
+      /** @var CivicrmEntity $element */
+      return $element->getEntityTypeId();
+    }
+  }
+
+  return NULL;
 }

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -7,6 +7,7 @@
 
 use Drupal\civicrm_entity\CivicrmEntityAccessHandler;
 use Drupal\civicrm_entity\CivicrmEntityListBuilder;
+use Drupal\civicrm_entity\CiviCrmEntityViewBuilder;
 use Drupal\civicrm_entity\CivicrmEntityViewsData;
 use Drupal\civicrm_entity\CiviEntityStorage;
 use Drupal\civicrm_entity\Entity\CivicrmEntity;
@@ -18,6 +19,7 @@ use Drupal\Core\Entity\ContentEntityDeleteForm;
 use Drupal\Core\Entity\ContentEntityType;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Render\Element;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
@@ -27,6 +29,9 @@ function civicrm_entity_theme() {
   return [
     'civicrm_entity_entity_form' => [
       'render element' => 'form',
+    ],
+    'civicrm_entity' => [
+      'render element' => 'elements',
     ],
   ];
 }
@@ -72,6 +77,7 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
         'handlers' => [
           'storage' => CiviEntityStorage::class,
           'list_builder' => CivicrmEntityListBuilder::class,
+          'view_builder' => CiviCrmEntityViewBuilder::class,
           'route_provider' => [
             'default' => CiviCrmEntityRouteProvider::class,
           ],
@@ -120,4 +126,36 @@ function civicrm_entity_pseudoconstant_options(FieldStorageDefinitionInterface $
   $entity_type = \Drupal::entityTypeManager()->getDefinition($definition->getTargetEntityTypeId());
   $options = $civicrm_api->getOptions($entity_type->get('civicrm_entity'), $definition->getName());
   return $options;
+}
+
+/**
+ * Implements hook_preprocess().
+ */
+function template_preprocess_civicrm_entity(&$variables) {
+  // Add fields as content to template.
+  $variables += ['content' => []];
+  foreach (Element::children($variables['elements']) as $key) {
+    $variables['content'][$key] = $variables['elements'][$key];
+  }
+
+  // Add the view_mode to the template.
+  $variables['view_mode'] = $variables['elements']['#view_mode'];
+
+  // Add the bundle to the template.
+  $variables['entity_type'] = $variables['elements']['#entity_type'];
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ */
+function civicrm_entity_theme_suggestions_civicrm_entity_alter(array &$suggestions, array $variables) {
+  $entity_type = $variables['elements']['#entity_type'];
+  $view_mode = $variables['elements']['#view_mode'];
+  $hook = $variables['theme_hook_original'];
+
+  // Add a suggestion based on the entity type.
+  $suggestions[] = $hook . '__' . $entity_type;
+
+  // Add a suggestion based on the view mode.
+  $suggestions[] = $hook . '__' . $entity_type . '__' . $view_mode;
 }

--- a/src/CiviCrmEntityViewBuilder.php
+++ b/src/CiviCrmEntityViewBuilder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\civicrm_entity;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityViewBuilder;
+
+class CiviCrmEntityViewBuilder extends EntityViewBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getBuildDefaults(EntityInterface $entity, $view_mode) {
+    $defaults = parent::getBuildDefaults($entity, $view_mode);
+
+    // Set a default theme.
+    $defaults['#theme'] = 'civicrm_entity';
+
+    return $defaults;
+  }
+
+}

--- a/templates/civicrm-entity.html.twig
+++ b/templates/civicrm-entity.html.twig
@@ -7,7 +7,7 @@
 {%
   set classes = [
   'civicrm-entity',
-  'civicrm-entity--type-' ~ entity_type|clean_class,
+  entity_type ? 'civicrm-entity--type-' ~ entity_type|clean_class,
   view_mode ? 'civicrm-entity--view-mode-' ~ view_mode|clean_class,
 ]
 %}

--- a/templates/civicrm-entity.html.twig
+++ b/templates/civicrm-entity.html.twig
@@ -1,0 +1,16 @@
+{#
+/**
+ * @file
+ * Default template for a CiviCRM template.
+ */
+#}
+{%
+  set classes = [
+  'civicrm-entity',
+  'civicrm-entity--type-' ~ entity_type|clean_class,
+  view_mode ? 'civicrm-entity--view-mode-' ~ view_mode|clean_class,
+]
+%}
+<article{{ attributes.addClass(classes) }}>
+  {{ content }}
+</article>

--- a/templates/civicrm-entity.html.twig
+++ b/templates/civicrm-entity.html.twig
@@ -2,15 +2,23 @@
 /**
  * @file
  * Default template for a CiviCRM template.
+ *
+ * The following template suggestions are available:
+ *  - civicrm-entity--ENTITY-TYPE.html.twig
+ *  - civicrm-entity--ENTITY-TYPE--VIEW-MODE.html.twig
+ *
+ * Examples:
+ *  - civicrm-entity--civicrm-event.html.twig
+ *  - civicrm-entity--civicrm-event--teaser.html.twig
+ *
+ * @see template_preprocess_civicrm_entity()
  */
 #}
-{%
-  set classes = [
+{% set classes = [
   'civicrm-entity',
   entity_type ? 'civicrm-entity--type-' ~ entity_type|clean_class,
   view_mode ? 'civicrm-entity--view-mode-' ~ view_mode|clean_class,
-]
-%}
+] %}
 <article{{ attributes.addClass(classes) }}>
   {{ content }}
 </article>


### PR DESCRIPTION
CiviCRM entities are not themable so you cannot render them in a theme. This PR uses a ViewBuilder to add a default theme for CiviCRM entities and make them themable.