### PR TITLE
Use filter_xss in the entity property metadata info sanitize key

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -2246,7 +2246,7 @@ function _civicrm_entity_getproperties($civicrm_entity, $context = '') {
       $info[$fieldname] = array(
         'label' => $label,
         'type' => $types[$field_specs['type']],
-        'sanitize' => 'check_plain',
+        'sanitize' => 'filter_xss',
         'setter callback' => 'entity_property_verbatim_set',
       );
 


### PR DESCRIPTION
Although the API should provide the security, we can do something at the Drupal level for protecting from improper data entry from drupal forms and rules, and developers that use CiviCRM Entity as an API to build other Drupally things.