### PR TITLE
Convert all times from the current timezone to UTC

### DIFF
--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -367,7 +367,7 @@ class CiviEntityStorage extends SqlContentEntityStorage implements DynamicallyFi
           // Date time formats from CiviCRM do not match the storage
           // format for Drupal's date time fields. Add in missing "T" marker.
           else {
-            $item_values[$delta][$main_property_name] = str_replace(' ', 'T', $item[$main_property_name]);
+            $item_values[$delta][$main_property_name] = (new \DateTime($item[$main_property_name], new \DateTimeZone(drupal_get_user_timezone())))->setTimezone(new \DateTimeZone('UTC'))->format(DATETIME_DATETIME_STORAGE_FORMAT);
           }
         }
         $items->setValue($item_values);


### PR DESCRIPTION
CiviCRM provides no timezone handling on datetime columns (for example, event start and end times) - the data is just in the time it's in, which I guess is assumed to be the timezone the organization operates in?

Anyway, Drupal always assumes datetime fields are stored in UTC, and converts to the site or user timezone when showing them. This means that currently, if your user account uses the London timezone and an event was set to start at 1pm in CiviCRM, Drupal will show the event starting at 2pm, because it's currently BST in London, which is +0100.

This PR counteracts that by assuming any data from a datetime field is given in the current user's timezone and converts it into UTC for the field value, so Drupal's timezone handling can work more-or-less normally.

I considered using the 'timezone_override' option on the field formatter, but this problem also affects the edit form, where we don't have any way to override the timezone used by the widget.