### PR TITLE
Convert datetime fields back from UTC for CiviCRM.

### DIFF
--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -364,9 +364,10 @@ class CiviEntityStorage extends SqlContentEntityStorage implements DynamicallyFi
           if (is_numeric($item[$main_property_name])) {
             $item_values[$delta][$main_property_name] = (new \DateTime())->setTimestamp($item[$main_property_name])->format(DATETIME_DATETIME_STORAGE_FORMAT);
           }
-          // Date time formats from CiviCRM do not match the storage
-          // format for Drupal's date time fields. Add in missing "T" marker.
           else {
+            // CiviCRM gives us the datetime in the users timezone (or no
+            // timezone at all) but Drupal expects it in UTC. So, we need to
+            // convert from the users timezone into UTC.
             $item_values[$delta][$main_property_name] = (new \DateTime($item[$main_property_name], new \DateTimeZone(drupal_get_user_timezone())))->setTimezone(new \DateTimeZone('UTC'))->format(DATETIME_DATETIME_STORAGE_FORMAT);
           }
         }

--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -92,10 +92,9 @@ class CivicrmEntity extends ContentEntityBase {
       foreach ($items as $delta => $item) {
         $main_property = $item->get($main_property_name);
         if ($main_property instanceof DateTimeIso8601) {
-          $value = $main_property->getDateTime()->format('Y-m-d H:i:s');
-        }
-        elseif ($main_property instanceof Timestamp) {
-          $value = $main_property->getDateTime()->format('Y-m-d H:i:s');
+          // CiviCRM wants the datetime in the timezone of the user, but Drupal
+          // stores it in UTC.
+          $value = (new \DateTime($main_property->getValue(), new \DateTimeZone('UTC')))->setTimezone(new \DateTimeZone(\drupal_get_user_timezone()))->format('Y-m-d H:i:s');
         }
         else {
           $value = $main_property->getValue();


### PR DESCRIPTION
This is a follow-up to #169 which fixed loading entities by converting the dates to UTC, but didn't fix saving the entities, which need to have the dates converted back from UTC before saving via the CiviCRM API. That's what this PR does!

I also snuck in some updates to comments to make the code related to this a little easier to understand, and removed an unused `elseif` branch (we don't use Timestamp fields anymore per #170).