### PR TITLE
Fix logic for how to declare entity type when enabled or disabled

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -55,41 +55,45 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
       continue;
     }
 
+    $entity_type_info = [
+      'provider' => 'civicrm_entity',
+      'class' => CivicrmEntity::class,
+      'originalClass' => CivicrmEntity::class,
+      'id' => $entity_type_id,
+      'civicrm_entity' => $civicrm_entity_name,
+      'civicrm_entity_ui_exposed' => in_array($entity_type_id, $enabled_entity_types),
+      'label' => new TranslatableMarkup('CiviCRM :name', [':name' => $civicrm_entity_info['civicrm entity label']]),
+      // @todo add label_singular
+      // @todo add label_plural
+      // @todo add label_count
+      'entity_keys' => [
+        'id' => 'id',
+        'label' => $civicrm_entity_info['label property'],
+      ],
+      'base_table' => $entity_type_id,
+      'admin_permission' => 'administer civicrm entity',
+      'permission_granularity' => 'entity_type',
+      'handlers' => [
+        'storage' => CiviEntityStorage::class,
+        'access' => CivicrmEntityAccessHandler::class,
+        'views_data' => CivicrmEntityViewsData::class,
+        'storage_schema' => CivicrmEntityStorageSchema::class,
+      ],
+    ];
     if (in_array($entity_type_id, $enabled_entity_types)) {
-      $entity_types[$entity_type_id] = new ContentEntityType([
-        'provider' => 'civicrm_entity',
-        'class' => CivicrmEntity::class,
-        'originalClass' => CivicrmEntity::class,
-        'id' => $entity_type_id,
-        'civicrm_entity' => $civicrm_entity_name,
-        'civicrm_entity_ui_exposed' => in_array($entity_type_id, $enabled_entity_types),
-        'label' => new TranslatableMarkup('CiviCRM :name', [':name' => $civicrm_entity_info['civicrm entity label']]),
-        // @todo add label_singular
-        // @todo add label_plural
-        // @todo add label_count
-        'entity_keys' => [
-          'id' => 'id',
-          'label' => $civicrm_entity_info['label property'],
-        ],
-        'base_table' => $entity_type_id,
-        'admin_permission' => 'administer civicrm entity',
-        'permission_granularity' => 'entity_type',
+      $entity_type_info = array_merge_recursive($entity_type_info, [
         'handlers' => [
-          'storage' => CiviEntityStorage::class,
           'list_builder' => CivicrmEntityListBuilder::class,
           'view_builder' => CiviCrmEntityViewBuilder::class,
           'route_provider' => [
             'default' => CiviCrmEntityRouteProvider::class,
           ],
-          'access' => CivicrmEntityAccessHandler::class,
           'form' => [
             'default' => CivicrmEntityForm::class,
             'add' => CivicrmEntityForm::class,
             'edit' => CivicrmEntityForm::class,
             'delete' => ContentEntityDeleteForm::class,
           ],
-          'views_data' => CivicrmEntityViewsData::class,
-          'storage_schema' => CivicrmEntityStorageSchema::class,
         ],
         // Generate route paths.
         'links' => [
@@ -102,6 +106,7 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
         'field_ui_base_route' => "entity.$entity_type_id.collection",
       ]);
     }
+    $entity_types[$entity_type_id] = new ContentEntityType($entity_type_info);
   }
 }
 


### PR DESCRIPTION
This is a follow-up to #166

Using the latest on a live site, we discovered that it broke user registration. The error was:

```
Uncaught PHP Exception Drupal\Core\Entity\EntityStorageException: "The "civicrm_email" entity type does not exist." at /web/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php line 829
```

Basically, this came down to the logic for how we declare an entity type when enable or disabled didn't match how the new code decided that a Drupal entity type was available. The new logic is correct, it looks like the older code didn't match what I remember deciding!

Anyway, this PR fixes it in my testing