### PR TITLE
Fixes for invoking Drupal hook

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -186,6 +186,33 @@ function _civicrm_entity_get_entity_type_from_elements($elements) {
 }
 
 /**
+ * For stashing deleted entities until we need them later.
+ *
+ * @todo Convert hooks to a service and keep this in a member variable
+ *
+ * @param string $objectName
+ *   The CiviCRM entity type.
+ * @param int $id
+ *   The id.
+ * @param \Drupal\Core\Entity\Entity|null|string $entity
+ *   The entity.
+ *
+ * @return void|\Drupal\Core\Entity\Entity
+ */
+function _civicrm_entity_stash($objectName, $id, $entity = NULL) {
+  $cache =& drupal_static(__FUNCTION__, []);
+  if (empty($entity)) {
+    return isset($cache[$objectName][$id]) ? $cache[$objectName][$id] : NULL;
+  }
+  elseif ($entity === 'clear') {
+    unset($cache[$objectName][$id]);
+  }
+  else {
+    $cache[$objectName][$id] = $entity;
+  }
+}
+
+/**
  * Implements hook_civicrm_pre().
  */
 function civicrm_entity_civicrm_pre($op, $objectName, $id, &$params) {
@@ -207,12 +234,20 @@ function civicrm_entity_civicrm_pre($op, $objectName, $id, &$params) {
   if ($op == 'create') {
     $entity = $storage->create($params);
   }
+  elseif (empty($id)) {
+    // Sometimes 'delete' is called with an $id of NULL, but we can't really do
+    // anything with that in this context, so return.
+    return;
+  }
   else {
     // Special handling for EntityTag objects.
     if ($objectName == 'EntityTag') {
       $id = $storage->getEntityTagEntityId($params[0][0], $params[1]);
     }
     $entity = $storage->load($id);
+  }
+  if (!$entity) {
+    return;
   }
   if ($entity->id()) {
     $entity->original = $storage->loadUnchanged($entity->id());
@@ -225,6 +260,7 @@ function civicrm_entity_civicrm_pre($op, $objectName, $id, &$params) {
 
     case 'delete':
       $storage->civiPreDelete($entity);
+      _civicrm_entity_stash($objectName, $id, $entity);
       break;
 
     case 'restore':
@@ -256,25 +292,31 @@ function civicrm_entity_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   /** @var \Drupal\civicrm_entity\CiviEntityStorage $storage */
   $storage = \Drupal::entityTypeManager()->getStorage($entityType);
 
-  // Special handling for EntityTag objects.
-  if ($entityType == 'entity_tag') {
-    foreach ($objectRef[0] as $entityTag) {
-      $object = new CRM_Core_BAO_EntityTag();
-      $object->entity_id = $entityTag;
-      $object->entity_table = 'civicrm_contact';
-      $object->tag_id = $objectId;
-      if ($object->find(TRUE)) {
-        $entity = $storage->load($entityTag);
-        $entity->original = $storage->loadUnchanged($entity->id());
-        _civicrm_entity_post_invoke($op, $storage, $entity);
-      }
-    }
-    return;
+  if ($op == 'delete') {
+    $entity = _civicrm_entity_stash($objectName, $objectId);
   }
+  else {
+    // Special handling for EntityTag objects.
+    if ($entityType == 'entity_tag') {
+      foreach ($objectRef[0] as $entityTag) {
+        $object = new CRM_Core_BAO_EntityTag();
+        $object->entity_id = $entityTag;
+        $object->entity_table = 'civicrm_contact';
+        $object->tag_id = $objectId;
+        if ($object->find(TRUE)) {
+          $entity = $storage->load($entityTag);
+          $entity->original = $storage->loadUnchanged($entity->id());
+          _civicrm_entity_post_invoke($op, $storage, $entity);
+        }
+      }
+      return;
+    }
 
-  $entity = $storage->load($objectId);
-  $entity->original = $storage->loadUnchanged($entity->id());
+    $entity = $storage->load($objectId);
+    $entity->original = $storage->loadUnchanged($entity->id());
+  }
   _civicrm_entity_post_invoke($op, $storage, $entity);
+  _civicrm_entity_stash($objectName, $objectId, 'clear');
 }
 
 /**

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -292,6 +292,7 @@ function civicrm_entity_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   /** @var \Drupal\civicrm_entity\CiviEntityStorage $storage */
   $storage = \Drupal::entityTypeManager()->getStorage($entityType);
 
+  $entity = FALSE;
   if ($op == 'delete') {
     $entity = _civicrm_entity_stash($objectName, $objectId);
   }
@@ -312,10 +313,13 @@ function civicrm_entity_civicrm_post($op, $objectName, $objectId, &$objectRef) {
       return;
     }
 
-    $entity = $storage->load($objectId);
-    $entity->original = $storage->loadUnchanged($entity->id());
+    if ($entity = $storage->load($objectId)) {
+      $entity->original = $storage->loadUnchanged($entity->id());
+    }
   }
-  _civicrm_entity_post_invoke($op, $storage, $entity);
+  if ($entity) {
+    _civicrm_entity_post_invoke($op, $storage, $entity);
+  }
   _civicrm_entity_stash($objectName, $objectId, 'clear');
 }
 

--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -180,8 +180,10 @@ class CiviEntityStorage extends SqlContentEntityStorage implements DynamicallyFi
       $options['return'] = $field_names;
       $civicrm_entity = $this->civicrmApi->get($this->entityType->get('civicrm_entity'), $options);
       $civicrm_entity = reset($civicrm_entity);
-      $entity = $this->prepareLoadedEntity($civicrm_entity);
-      $entities[$entity->id()] = $entity;
+      if ($civicrm_entity) {
+        $entity = $this->prepareLoadedEntity($civicrm_entity);
+        $entities[$entity->id()] = $entity;
+      }
     }
     return $entities;
   }

--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -360,9 +360,14 @@ class CiviEntityStorage extends SqlContentEntityStorage implements DynamicallyFi
       elseif ($definition->getType() == 'datetime') {
         $item_values = $items->getValue();
         foreach ($item_values as $delta => $item) {
+          // On Contribution entities, there are dates sometimes set to the
+          // string value of 'null'.
+          if ($item[$main_property_name] === 'null') {
+            $item_values[$delta][$main_property_name] = NULL;
+          }
           // Handle if the value provided is a timestamp.
           // @note: This only occurred during test migrations.
-          if (is_numeric($item[$main_property_name])) {
+          elseif (is_numeric($item[$main_property_name])) {
             $item_values[$delta][$main_property_name] = (new \DateTime())->setTimestamp($item[$main_property_name])->format(DATETIME_DATETIME_STORAGE_FORMAT);
           }
           else {


### PR DESCRIPTION
This fixes some more issues with #166 that came up when testing on an actual live site!

The way this is implemented isn't ideal - I think we should be making a service for calling these hooks, so we can stash the temporary entities in a member variable, rather than a static variable. But as I've been fixing these progressively as they came up, I've been focusing on making the smallest possible changes to fix the bug. There's a `@todo` in there and we could refactor later.

I also suspect we'll encounter a few more of these! CiviCRM is kinda weird with these hooks for some entities in some situations :-)