### PR TITLE
Fix for case where objectId not set in civicrm post hook

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -292,7 +292,16 @@ function civicrm_entity_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   /** @var \Drupal\civicrm_entity\CiviEntityStorage $storage */
   $storage = \Drupal::entityTypeManager()->getStorage($entityType);
 
-  $entity = FALSE;
+  // Fix because $objectId is not set for participant payments, possibly other
+  // entity types.
+  if (!$objectId) {
+    // If we cannot determine the id, bail.
+    if (empty($objectRef->id)) {
+      return;
+    }
+    $objectId = $objectRef->id;
+  }
+
   if ($op == 'delete') {
     $entity = _civicrm_entity_stash($objectName, $objectId);
   }


### PR DESCRIPTION
The `$objectId` variable is `NULL` for `ParticipantPayment` data in `hook_civicrm_post`. This causes issues when the value trickles down to Drupal's entity handling code and throws errors due to an array key being null.

This fix attempts to use the `::id` property from the object, if available.

I also deleted the `$entity` variable which was unused, as it's set later in the code.