### PR TITLE
Bklaver d871

### DIFF
--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -52,14 +52,18 @@ class CiviEntityStorage extends SqlContentEntityStorage implements DynamicallyFi
    *   The entity type definition.
    * @param \Drupal\Core\Database\Connection $database
    *   The database connection.
-   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
-   *   The entity manager.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The entity field manager.
    * @param \Drupal\Core\Cache\CacheBackendInterface $cache
    *   The cache backend to be used.
    * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
    *   The language manager.
    * @param \Drupal\civicrm_entity\CiviCrmApiInterface $civicrm_api
    *   The CiviCRM API.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle info.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
    */
   public function __construct(EntityTypeInterface $entity_type, Connection $database, EntityManagerInterface $entity_manager, CacheBackendInterface $cache, LanguageManagerInterface $language_manager, CiviCrmApiInterface $civicrm_api, ConfigFactoryInterface $config_factory) {
     parent::__construct($entity_type, $database, $entity_manager, $cache, $language_manager);
@@ -74,14 +78,15 @@ class CiviEntityStorage extends SqlContentEntityStorage implements DynamicallyFi
     return new static(
       $entity_type,
       $container->get('database'),
-      $container->get('entity.manager'),
+      $container->get('entity_field.manager'),
       $container->get('cache.entity'),
       $container->get('language_manager'),
-      $container->get('civicrm_entity.api'),
-      $container->get('config.factory')
+      $container->get('entity.memory_cache'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('entity_type.manager')
     );
   }
-
+/
   /**
    * Initializes table name variables.
    */

--- a/src/Entity/Sql/CivicrmEntityStorageSchema.php
+++ b/src/Entity/Sql/CivicrmEntityStorageSchema.php
@@ -5,9 +5,12 @@ namespace Drupal\civicrm_entity\Entity\Sql;
 use Drupal\civicrm_entity\CiviEntityStorage;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\ContentEntityTypeInterface;
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Sql\SqlContentEntityStorageSchema;
+use Drupal\Core\Entity\Sql\TableMappingInterface;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
 
 /**
  * Implementation of the SqlContentEntityStorageSchema for CiviCRM entities.
@@ -34,21 +37,29 @@ class CivicrmEntityStorageSchema extends SqlContentEntityStorageSchema {
   /**
    * Constructs a CivicrmEntityStorageSchema.
    *
-   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
-   *   The entity manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
    * @param \Drupal\Core\Entity\ContentEntityTypeInterface $entity_type
    *   The entity type.
    * @param \Drupal\civicrm_entity\CiviEntityStorage $storage
    *   The storage of the entity type. This must be an SQL-based storage.
    * @param \Drupal\Core\Database\Connection $database
    *   The database connection to be used.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The entity field manager.
    */
-  public function __construct(EntityManagerInterface $entity_manager, ContentEntityTypeInterface $entity_type, CiviEntityStorage $storage, Connection $database) {
-    $this->entityManager = $entity_manager;
-    $this->entityType = $entity_type;
-    $this->fieldStorageDefinitions = $entity_manager->getFieldStorageDefinitions($entity_type->id());
-    $this->storage = $storage;
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, ContentEntityTypeInterface $entity_type, CiviEntityStorage $storage, Connection $database, EntityFieldManagerInterface $entity_field_manager = NULL) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->storage = clone $storage;
     $this->database = $database;
+    if (!$entity_field_manager) {
+      @trigger_error('Calling SqlContentEntityStorageSchema::__construct() with the $entity_field_manager argument is supported in drupal:8.7.0 and will be required before drupal:9.0.0. See https://www.drupal.org/node/2549139.', E_USER_DEPRECATED);
+      $entity_field_manager = \Drupal::service('entity_field.manager');
+    }
+    $this->entityFieldManager = $entity_field_manager;
+
+    $this->entityType = $entity_type_manager->getActiveDefinition($entity_type->id());
+    $this->fieldStorageDefinitions = $entity_field_manager->getActiveFieldStorageDefinitions($entity_type->id());
   }
 
   /**
@@ -81,12 +92,26 @@ class CivicrmEntityStorageSchema extends SqlContentEntityStorageSchema {
     return FALSE;
   }
 
+
   /**
    * {@inheritdoc}
+   This will get rid of the "Mismatched entity and/or field definitions
+The following changes were detected in the entity type and field definitions." 
+Message on the status page. I don't think it should be left in though.
+
+  public function requiresFieldStorageSchemaChanges(FieldStorageDefinitionInterface $storage_definition, FieldStorageDefinitionInterface $original) {
+    return false;
+  }
+  */
+
+  /**
+   * @param \Drupal\Core\Entity\Sql\TableMappingInterface $table_mapping
+   *   A table mapping object.
    *
-   * The entity table schema is managed by CiviCRM.
+   * @return array
+   *   The entity table schema is managed by CiviCRM.
    */
-  protected function getEntitySchemaTables() {
+  protected function getEntitySchemaTables(TableMappingInterface $table_mapping) {
     return [];
   }
 


### PR DESCRIPTION
I don't actually want this to be merged right away, but thought I'd share my work.

I updated to Drupal 8.7.1 and received this message:

TypeError: Argument 1 passed to Drupal\civicrm_entity\Entity\Sql\CivicrmEntityStorageSchema::__construct() must implement
      interface Drupal\Core\Entity\EntityManagerInterface
, instance of Drupal\Core\Entity\EntityTypeManager given, called in htdocs/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php on line 292 in Drupal\civicrm_entity\Entity\Sql\CivicrmEntityStorageSchema->__construct() (line 46 of htdocs/modules/civicrm_entity/src/Entity/Sql/CivicrmEntityStorageSchema.php) #0 htdocs/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php(292): Drupal\civicrm_entity\Entity\Sql\CivicrmEntityStorageSchema->__construct(Object(Drupal\Core\Entity\EntityTypeManager), Object(Drupal\Core\Entity\ContentEntityType), Object(Drupal\civicrm_entity\CiviEntityStorage), Object(Drupal\Core\Database\Driver\mysql\Connection), Object(Drupal\Core\Entity\EntityManager))

I think this is because the constructor arguments were changed for the parent class here: https://git.drupalcode.org/project/drupal/blob/5d3322ebdab9c36ad1d06435c3ade0d8fa1e8f0a/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorageSchema.php

I tried updating these classes to reflect the changes in their parents.  With very light testing, my site was still performing as before, but I'm pretty sure there's a problem I haven't found yet.  

I started this work, but have to hit pause.  Going to keep Drupal at 8.6.x for now.  Hopefully it helps someone. 