### PR TITLE
getCount: allow optional params

### DIFF
--- a/src/CiviCrmApi.php
+++ b/src/CiviCrmApi.php
@@ -85,7 +85,7 @@ class CiviCrmApi implements CiviCrmApiInterface {
   /**
    * {@inheritdoc}
    */
-  public function getCount($entity, array $params) {
+  public function getCount($entity, array $params = []) {
     $this->initialize();
     $result = civicrm_api3($entity, 'getcount', $params);
     return is_int($result) ? $result : $result['result'];

--- a/src/CiviCrmApiInterface.php
+++ b/src/CiviCrmApiInterface.php
@@ -83,6 +83,6 @@ interface CiviCrmApiInterface {
    * @return int
    *   The number of entities.
    */
-  public function getCount($entity, array $params);
+  public function getCount($entity, array $params = []);
 
 }


### PR DESCRIPTION
This makes the `getCount` params optional.

I initially encountered this while trying to uninstall the module. The `hasData` calls `getCount` on the various entities, without any params. Instead of providing an empty array from hasData, I think it makes sense to make the function argument optional.