### PR TITLE
Fix fatal error on modules/uninstall.

### DIFF
--- a/src/CiviCrmApi.php
+++ b/src/CiviCrmApi.php
@@ -85,7 +85,7 @@ class CiviCrmApi implements CiviCrmApiInterface {
   /**
    * {@inheritdoc}
    */
-  public function getCount($entity, array $params) {
+  public function getCount($entity, array $params = []) {
     $this->initialize();
     $result = civicrm_api3($entity, 'getcount', $params);
     return is_int($result) ? $result : $result['result'];

--- a/src/CiviCrmApiInterface.php
+++ b/src/CiviCrmApiInterface.php
@@ -83,6 +83,6 @@ interface CiviCrmApiInterface {
    * @return int
    *   The number of entities.
    */
-  public function getCount($entity, array $params);
+  public function getCount($entity, array $params = []);
 
 }

--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -258,7 +258,13 @@ class CiviEntityStorage extends SqlContentEntityStorage {
    * {@inheritdoc}
    */
   public function hasData() {
-    return $this->getCiviCrmApi()->getCount($this->entityTypeId, []) > 0;
+    if (!$this->civicrmApi) {
+      $this->civicrmApi = $this->getCiviCrmApi();
+    }
+    if (substr($this->entityTypeId, 0, 8) == 'civicrm_') {
+      return $this->civicrmApi->getCount(substr($this->entityTypeId, 8)) > 0;
+     }
+    return $this->civicrmApi->getCount($this->entityTypeId) > 0;
   }
   /**
    * {@inheritdoc}

--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -261,10 +261,7 @@ class CiviEntityStorage extends SqlContentEntityStorage {
     if (!$this->civicrmApi) {
       $this->civicrmApi = $this->getCiviCrmApi();
     }
-    if (substr($this->entityTypeId, 0, 8) == 'civicrm_') {
-      return $this->civicrmApi->getCount(substr($this->entityTypeId, 8)) > 0;
-     }
-    return $this->civicrmApi->getCount($this->entityTypeId) > 0;
+    return $this->civicrmApi->getCount($this->entityType->get('civicrm_entity')) > 0;
   }
   /**
    * {@inheritdoc}

--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -258,10 +258,7 @@ class CiviEntityStorage extends SqlContentEntityStorage {
    * {@inheritdoc}
    */
   public function hasData() {
-    if (!$this->civicrmApi) {
-      $this->civicrmApi = $this->getCiviCrmApi();
-    }
-    return $this->civicrmApi->getCount($this->entityType->get('civicrm_entity')) > 0;
+    return $this->getCiviCrmApi()->getCount($this->entityType->get('civicrm_entity')) > 0;
   }
   /**
    * {@inheritdoc}


### PR DESCRIPTION
**Before:**
Can not uninstall modules via the GUI. 

**After:**
Can uninstall modules via the GUI.

**Steps to reproduce:**
Navigate to Extend -> Uninstall 
Observe Fatal Error

This PR replaces (and adds onto) https://github.com/eileenmcnaughton/civicrm_entity/pull/183

Note: I'm sure there is a better place to initialize 
`      $this->civicrmApi = $this->getCiviCrmApi();
`

But this works and admins can use the GUI again to uninstall modules
