### PR TITLE
Fix for not empty time on end date field

### DIFF
--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -123,7 +123,7 @@ class CivicrmEntity extends ContentEntityBase {
       /** @var \Drupal\Core\Field\FieldItemInterface $item */
       foreach ($items as $delta => $item) {
         $main_property = $item->get($main_property_name);
-        if ($main_property instanceof DateTimeIso8601) {
+        if ($main_property instanceof DateTimeIso8601 && !is_array($main_property->getValue())) {
           // CiviCRM wants the datetime in the timezone of the user, but Drupal
           // stores it in UTC.
           $value = (new \DateTime($main_property->getValue(), new \DateTimeZone('UTC')))->setTimezone(new \DateTimeZone(\drupal_get_user_timezone()))->format('Y-m-d H:i:s');


### PR DESCRIPTION
**Before:**
Got an error when try to save an event when end date partially filled

**After:**
Get a message specifying you need to fill both date and time in order to save the event

**Steps to reproduce:**
Admin -> Content -> Add Content -> Event
Fill all required fields including start date
Fill only date and leave time empty on end date.
Try to save the event.

**About the change:**
When end date is partially filled is an array,  but if field is totally filled is a string
