### PR TITLE
Fix triggering Drupal hooks when entity updated in Civi

### DIFF
--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -23,6 +23,17 @@ use Symfony\Component\Validator\ConstraintViolation;
 class CivicrmEntity extends ContentEntityBase {
 
   /**
+   * Flag to denote if the entity is currently going through Drupal CRUD hooks.
+   *
+   * We need to trigger the Drupal CRUD hooks when entities are edited in Civi,
+   * but we need a way to ensure they aren't double triggered when already
+   * going through the Drupal CRUD process.
+   *
+   * @var bool
+   */
+  public $drupal_crud = FALSE;
+
+  /**
    * {@inheritdoc}
    */
   public function save() {
@@ -70,7 +81,6 @@ class CivicrmEntity extends ContentEntityBase {
       $fields[$civicrm_field['name']] = $field_definition_provider->getBaseFieldDefinition($civicrm_field);
       $fields[$civicrm_field['name']]->setRequired(isset($civicrm_required_fields[$civicrm_field['name']]));
     }
-    $fields['drupal_crud'] = BaseFieldDefinition::create('boolean')->setComputed(TRUE);
     return $fields;
   }
 


### PR DESCRIPTION
I'm not entirely sure when/how this got broken, but it might be from a Drupal core change. In any case, Drupal hooks are no longer being fired when an entity is updated via CiviCRM. We noticed this primarily with caching: a user would update a Civi Event in the Civi admin, but the Drupal display page wouldn't change.

It looks like the problem comes from the magic that Drupal adds to Entity objects to access Drupal fields as properties. We were making 'drupal_crud' be a computed Drupal field, but then checking it via `!empty($entity->drupal_crud)` which is now always evaluating as TRUE.

The change in this PR is making it a normal public property, and not a computed Drupal field, and then everything goes back to working as it should.

I tested this by CRUD'ing (creating, reading, updating, deleting) a Civi Event from both the Civi admin and Drupal, and everything seems to be working.