### PR TITLE
Fixes #195 CiviCRM Entity breaks in Drupal 8.8 - removes constructor,…

### DIFF
--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -2,55 +2,15 @@
 
 namespace Drupal\civicrm_entity;
 
-use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
+
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\views\EntityViewsData;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class CivicrmEntityViewsData extends EntityViewsData {
 
   use StringTranslationTrait;
-
-  /**
-   * Constructs an EntityViewsData object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
-   *   The entity type to provide views integration for.
-   * @param \Drupal\civicrm_entity\CiviEntityStorage $storage_controller
-   *   The storage handler used for this entity type.
-   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
-   *   The entity manager.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   * @param \Drupal\Core\StringTranslation\TranslationInterface $translation_manager
-   *   The translation manager.
-   */
-  public function __construct(EntityTypeInterface $entity_type, CiviEntityStorage $storage_controller, EntityManagerInterface $entity_manager, ModuleHandlerInterface $module_handler, TranslationInterface $translation_manager) {
-    $this->entityType = $entity_type;
-    $this->entityManager = $entity_manager;
-    $this->storage = $storage_controller;
-    $this->moduleHandler = $module_handler;
-    $this->setStringTranslation($translation_manager);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
-    return new static(
-      $entity_type,
-      $container->get('entity.manager')->getStorage($entity_type->id()),
-      $container->get('entity.manager'),
-      $container->get('module_handler'),
-      $container->get('string_translation'),
-      $container->get('typed_data_manager')
-    );
-  }
-
 
   public function getViewsData() {
     $data = [];


### PR DESCRIPTION
… and createInstance as code was duplicated from parent, and had been updated in a breaking way in the parent.

As well as removes a few not unused "use ..." statements.

I'm not sure why this code was duplicated in the first place. The only reason I can see is that the constructor did enforce a more specific subclass on the Data store - CiviEntityStorage - However I can't get the code to run easily by keeping this and it does appear to work without it.

Additionally I've removed a heap of "use" statements that appear to only be used for the constructor.

