### PR TITLE
Readme & Version constraint fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ For example:
        "civicrm/civicrm-drupal-8": "^5.19",
 ```
 
-By default the **RoundEarth** method uses `dev-master` for `civicrm/civicrm-drupal-8` - this is dangerous and not recommended!
+By default the **RoundEarth** method uses `dev-master` for `civicrm/civicrm-drupal-8` - this is [dangerous and not recommended](https://lab.civicrm.org/dev/drupal/issues/87#note_23534)!

--- a/README.md
+++ b/README.md
@@ -10,3 +10,16 @@ To get CiviCRM Entity installed with composer the following steps will work:
     `composer config repositories.civicrm_entity vcs https://github.com/eileenmcnaughton/civicrm_entity`
 2. Require CiviCRM Entity's `8.x-3.x` git branch:  
     `composer require drupal/civicrm_entity:dev-8.x-3.x`
+    
+**Note:**
+
+You should ensure that your `composer.json` file has versioned requirements for both `civicrm/civicrm-core` and `civicrm/civicrm-drupal-8`.
+
+For example:
+
+``` json
+       "civicrm/civicrm-core": "^5.19",
+       "civicrm/civicrm-drupal-8": "^5.19",
+```
+
+By default the **RoundEarth** method uses `dev-master` for `civicrm/civicrm-drupal-8` - this is dangerous and not recommended!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
-CiviCRM Entity Drupal 8 version notes go here.
+# CiviCRM Entity for Drupal 8
 
-We're just getting started.
+## Composer Installation
+
+Due to a [bug](https://www.drupal.org/project/project_composer/issues/3051746) with Drupal.org's composer facade. It's not possible to simply `composer require drupal/civicrm_entity` without some preparation.
+
+To get CiviCRM Entity installed with composer the following steps will work:
+    
+1. Add the CiviCRM Entity repository to your composer.json:  
+    `composer config repositories.civicrm_entity vcs https://github.com/eileenmcnaughton/civicrm_entity`
+2. Require CiviCRM Entity's `8.x-3.x` git branch:  
+    `composer require drupal/civicrm_entity:dev-8.x-3.x`

--- a/composer.json
+++ b/composer.json
@@ -4,19 +4,9 @@
     "description": "Expose CiviCRM entities as Drupal entities.",
     "homepage": "http://drupal.org/project/civicrm_entity",
     "license": "GPL-2.0+",
-    "repositories": {
-        "civicrm-core": {
-            "type": "vcs",
-            "url": "https://github.com/civicrm/civicrm-core.git"
-        },
-        "civicrm-drupal": {
-            "type": "vcs",
-            "url": "https://github.com/civicrm/civicrm-drupal.git"
-        }
-    },
     "require": {
-        "civicrm/civicrm-core": "4.7 - 5",
-        "civicrm/civicrm-drupal-8": "dev-master"
+        "civicrm/civicrm-core": "~5.19",
+        "civicrm/civicrm-drupal-8": "~5.19"
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "homepage": "http://drupal.org/project/civicrm_entity",
     "license": "GPL-2.0+",
     "require": {
-        "civicrm/civicrm-core": "~5.19",
-        "civicrm/civicrm-drupal-8": "~5.19"
+        "civicrm/civicrm-core": "~5.0",
+        "civicrm/civicrm-drupal-8": "~5.0"
     },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
Two changes here for composer.json:

1. Changes the composer.json file to remove the repository information - this isn't referenced except in the "root/project" composer.json file. 
2. Adds appropriate version constraints to composer.json to enable composer based installation when using `civicrm/civicrm-drupal-8` with a version (which you really should be doing - using dev-master is dangerous!)

Adds a basic readme with composer installation steps.