### PR TITLE
8.x 3.x

### DIFF
--- a/src/Entity/Sql/CivicrmEntityStorageSchema.php
+++ b/src/Entity/Sql/CivicrmEntityStorageSchema.php
@@ -14,13 +14,6 @@ use Drupal\Core\Entity\Sql\SqlContentEntityStorageSchema;
 class CivicrmEntityStorageSchema extends SqlContentEntityStorageSchema {
 
   /**
-   * The storage field definitions for this entity type.
-   *
-   * @var \Drupal\Core\Field\FieldStorageDefinitionInterface[]
-   */
-  protected $fieldStorageDefinitions;
-
-  /**
    * The storage object for the given entity type.
    *
    * @var \Drupal\civicrm_entity\CiviEntityStorage

--- a/src/SupportedEntities.php
+++ b/src/SupportedEntities.php
@@ -293,6 +293,19 @@ final class SupportedEntities {
       ],
     ];
 
+$civicrm_entity_info['civicrm_group_contact'] = [
+  'civicrm entity label' => t('Group Contact'),
+  'civicrm entity name' => 'group_contact',
+  'label property' => 'id',
+    'permissions' => [
+    'view' => ['edit groups'],
+    'edit' => ['edit groups'],
+    'update' => ['edit groups'],
+    'create' => ['edit groups'],
+    'delete' => ['edit groups', 'administer CiviCRM'],
+  ],
+];
+
     $civicrm_entity_info['civicrm_grant'] = [
       'civicrm entity label' => t('Grant'),
       'civicrm entity name' => 'grant',
@@ -602,7 +615,7 @@ final class SupportedEntities {
       ],
     ];
     $civicrm_entity_info['civicrm_custom_group'] = [
-      'civicrm entity label' => t('Group'),
+      'civicrm entity label' => t('Custom field group'),
       'civicrm entity name' => 'custom_group',
       'label property' => 'title',
       'permissions' => [


### PR DESCRIPTION
This PR adds the ability to filter a Civicrm Entity Contact View by whether the Contact is in a specified Group.

Adding the filter
![image](https://user-images.githubusercontent.com/52583757/89125253-23013800-d4ab-11ea-9536-61f408fe5fe8.png)

Configuring the filter
![image](https://user-images.githubusercontent.com/52583757/89125204-b8e89300-d4aa-11ea-8e20-da32cb229010.png)

How the filter looks in the filter list
![image](https://user-images.githubusercontent.com/52583757/89125215-ce5dbd00-d4aa-11ea-9e47-2f30cd9eff2a.png)

Back in April, I had a conversation with @jackrabbithanna on MatterMost (https://chat.civicrm.org/civicrm/channels/civicrm-entity/w1ujyodwobrz7d1dqwakybnbse) in which he showed me the magical incantation needed to add a new Civi entity filter and get Views support.  Specifically, my need was filtering Contacts based on Group membership.

This is not a very intuitive interface, requiring ID's to work, but I anticipate more is on the way, and for the moment this allows filtering contacts based on group membership which in my sites is a critical need.

My sincerest apologies to @jackrabbithanna for taking 4 months to do this.  It is not an indication of my appreciation for your excellent and kind assistance in a time of need.