### PR TITLE
Include Option Value as a supported entity

### DIFF
--- a/src/SupportedEntities.php
+++ b/src/SupportedEntities.php
@@ -625,6 +625,17 @@ final class SupportedEntities {
         'delete' => ['delete contacts'],
       ],
     ];
+    $civicrm_entity_info['civicrm_option_value'] = [
+      'civicrm entity label' => t('Option Value'),
+      'civicrm entity name' => 'option_value',
+      'label property' => 'label',
+      'permissions' => [
+        'view' => [],
+        'update' => [],
+        'create' => [],
+        'delete' => [],
+      ],
+    ];
 
     static::alterEntityInfo($civicrm_entity_info);
 


### PR DESCRIPTION
ping @jackrabbithanna 

The use case was I was building a search form in an app and using graphql to pull out the option values for a specific option group, without this couldn't query the option values