### PR TITLE
8.x 3.x - D9 Compatibility

### DIFF
--- a/civicrm_entity.info.yml
+++ b/civicrm_entity.info.yml
@@ -3,6 +3,7 @@ type: module
 description: 'Expose CiviCRM entities as Drupal entities.'
 package: CiviCRM
 core: 8.x
+core_version_requirement: ^8.7.7 || ^9
 dependencies:
   - civicrm
   - drupal:datetime

--- a/civicrm_entity.info.yml
+++ b/civicrm_entity.info.yml
@@ -2,7 +2,7 @@ name: CiviCRM Entity
 type: module
 description: 'Expose CiviCRM entities as Drupal entities.'
 package: CiviCRM
-core_version_requirement: ^8.7.7 || ^9
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - civicrm
   - drupal:datetime

--- a/civicrm_entity.info.yml
+++ b/civicrm_entity.info.yml
@@ -2,7 +2,6 @@ name: CiviCRM Entity
 type: module
 description: 'Expose CiviCRM entities as Drupal entities.'
 package: CiviCRM
-core: 8.x
 core_version_requirement: ^8.7.7 || ^9
 dependencies:
   - civicrm

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -196,10 +196,10 @@ function _civicrm_entity_get_entity_type_from_elements($elements) {
  *   The CiviCRM entity type.
  * @param int $id
  *   The id.
- * @param \Drupal\Core\Entity\Entity|null|string $entity
+ * @param \Drupal\Core\Entity\EntityBase|null|string $entity
  *   The entity.
  *
- * @return void|\Drupal\Core\Entity\Entity
+ * @return void|\Drupal\Core\Entity\EntityBase
  */
 function _civicrm_entity_stash($objectName, $id, $entity = NULL) {
   $cache =& drupal_static(__FUNCTION__, []);

--- a/civicrm_entity.views.inc
+++ b/civicrm_entity.views.inc
@@ -17,8 +17,8 @@ use Drupal\field\FieldStorageConfigInterface;
  * @see views_views_data_alter()
  */
 function civicrm_entity_views_data_alter(&$data) {
-  $entity_manager = \Drupal::entityManager();
-  if (!$entity_manager->hasDefinition('field_storage_config')) {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  if (!$entity_type_manager->hasDefinition('field_storage_config')) {
     return;
   }
 
@@ -30,7 +30,7 @@ function civicrm_entity_views_data_alter(&$data) {
   $module_handler = \Drupal::moduleHandler();
 
   /** @var \Drupal\field\FieldStorageConfigInterface $field_storage */
-  foreach ($entity_manager->getStorage('field_storage_config')->loadMultiple() as $field_storage) {
+  foreach ($entity_type_manager->getStorage('field_storage_config')->loadMultiple() as $field_storage) {
     if (_civicrm_entity_field_get_entity_type_storage($field_storage)) {
       $result = (array) $module_handler->invoke($field_storage->getTypeProvider(), 'field_views_data', [$field_storage]);
       if (empty($result)) {
@@ -50,7 +50,7 @@ function civicrm_entity_views_data_alter(&$data) {
   // Start: views_views_data_alter() snippet.
 
   /** @var \Drupal\field\FieldStorageConfigInterface $field_storage */
-  foreach ($entity_manager->getStorage('field_storage_config')->loadMultiple() as $field_storage) {
+  foreach ($entity_type_manager->getStorage('field_storage_config')->loadMultiple() as $field_storage) {
     if (_civicrm_entity_field_get_entity_type_storage($field_storage)) {
       $function = $field_storage->getTypeProvider() . '_field_views_data_views_data_alter';
       if (function_exists($function)) {
@@ -131,9 +131,9 @@ function civicrm_entity_field_default_views_data(FieldStorageConfigInterface $fi
 
   // Grab information about the entity type tables.
   // We need to join to both the base table and the data table, if available.
-  $entity_manager = \Drupal::entityManager();
+  $entity_type_manager = \Drupal::entityTypeManager();
   $entity_type_id = $field_storage->getTargetEntityTypeId();
-  $entity_type = $entity_manager->getDefinition($entity_type_id);
+  $entity_type = $entity_type_manager->getDefinition($entity_type_id);
   // EDIT: We ensure the base table is set to the entity type ID, which matches
   // the CiviCRM table pattern of `civicrm_*`
   if (!$base_table = $entity_type->getBaseTable()) {

--- a/modules/civicrm_entity_leaflet/civicrm_entity_leaflet.info.yml
+++ b/modules/civicrm_entity_leaflet/civicrm_entity_leaflet.info.yml
@@ -2,6 +2,7 @@ name: 'CiviCRM Entity Leaflet'
 type: module
 description: 'Provides a Views style for Leaflet Maps that uses CiviCRM Address lon and lat'
 core: 8.x
+core_version_requirement: ^8.7.7 || ^9
 package: 'CiviCRM'
 
 dependencies:

--- a/modules/civicrm_entity_leaflet/civicrm_entity_leaflet.info.yml
+++ b/modules/civicrm_entity_leaflet/civicrm_entity_leaflet.info.yml
@@ -1,7 +1,6 @@
 name: 'CiviCRM Entity Leaflet'
 type: module
 description: 'Provides a Views style for Leaflet Maps that uses CiviCRM Address lon and lat'
-core: 8.x
 core_version_requirement: ^8.7.7 || ^9
 package: 'CiviCRM'
 

--- a/modules/civicrm_entity_leaflet/civicrm_entity_leaflet.info.yml
+++ b/modules/civicrm_entity_leaflet/civicrm_entity_leaflet.info.yml
@@ -1,7 +1,7 @@
 name: 'CiviCRM Entity Leaflet'
 type: module
 description: 'Provides a Views style for Leaflet Maps that uses CiviCRM Address lon and lat'
-core_version_requirement: ^8.7.7 || ^9
+core_version_requirement: ^8.8 || ^9
 package: 'CiviCRM'
 
 dependencies:

--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Sql\DefaultTableMapping;
 use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
+use Drupal\Core\Entity\Sql\SqlContentEntityStorageSchema;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Language\LanguageInterface;
@@ -622,7 +623,7 @@ class CiviEntityStorage extends SqlContentEntityStorage {
             if (!empty($attributes['serialize'])) {
               $value = serialize($value);
             }
-            $record[$column_name] = drupal_schema_get_field_value($attributes, $value);
+            $record[$column_name] = SqlContentEntityStorageSchema::castValue($attributes, $value);
           }
           $query->values($record);
           if ($this->entityType->isRevisionable()) {

--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -373,7 +373,7 @@ class CiviEntityStorage extends SqlContentEntityStorage {
             // CiviCRM gives us the datetime in the users timezone (or no
             // timezone at all) but Drupal expects it in UTC. So, we need to
             // convert from the users timezone into UTC.
-            $datetime_value = (new \DateTime($item[$main_property_name], new \DateTimeZone(drupal_get_user_timezone())))->setTimezone(new \DateTimeZone('UTC'))->format($datetime_format);
+            $datetime_value = (new \DateTime($item[$main_property_name], new \DateTimeZone(date_default_timezone_get())))->setTimezone(new \DateTimeZone('UTC'))->format($datetime_format);
             $item_values[$delta][$main_property_name] = $datetime_value;
           }
         }

--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -94,7 +94,7 @@ class CivicrmEntityViewsData extends EntityViewsData {
 
     // Load all typed data definitions of all fields. This should cover each of
     // the entity base, revision, data tables.
-    $field_definitions = $this->entityManager->getBaseFieldDefinitions($this->entityType->id());
+    $field_definitions = $this->entityFieldManager->getBaseFieldDefinitions($this->entityType->id());
     /** @var \Drupal\Core\Entity\Sql\DefaultTableMapping $table_mapping */
     $table_mapping = $this->storage->getTableMapping();
     if ($table_mapping) {
@@ -106,7 +106,7 @@ class CivicrmEntityViewsData extends EntityViewsData {
           // the field.
           if ($field_definition->getType() === 'entity_reference') {
             $target_entity_type_id = $field_definition->getFieldStorageDefinition()->getSetting('target_type');
-            $target_entity_type = $this->entityManager->getDefinition($target_entity_type_id);
+            $target_entity_type = $this->entityTypeManager->getDefinition($target_entity_type_id);
             assert($target_entity_type !== NULL);
             $target_base_table = $target_entity_type->getDataTable() ?: $target_entity_type->getBaseTable();
 

--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -113,7 +113,7 @@ class CivicrmEntityViewsData extends EntityViewsData {
             $field_name = $field_definition->getName();
             $pseudo_field_name = 'reverse__' . $this->entityType->id() . '__' . $field_name;
             $args = [
-              '@label' => $target_entity_type->getLowercaseLabel(),
+              '@label' => $target_entity_type->getSingularLabel(),
               '@field_name' => $field_name,
               '@entity' => $this->entityType->getLabel(),
             ];

--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -141,7 +141,7 @@ class CivicrmEntity extends ContentEntityBase {
         if ($main_property instanceof DateTimeIso8601 && !is_array($main_property->getValue())) {
           // CiviCRM wants the datetime in the timezone of the user, but Drupal
           // stores it in UTC.
-          $value = (new \DateTime($main_property->getValue(), new \DateTimeZone('UTC')))->setTimezone(new \DateTimeZone(\drupal_get_user_timezone()))->format('Y-m-d H:i:s');
+          $value = (new \DateTime($main_property->getValue(), new \DateTimeZone('UTC')))->setTimezone(new \DateTimeZone(date_default_timezone_get()))->format('Y-m-d H:i:s');
         }
         else {
           $value = $main_property->getValue();

--- a/src/Form/CivicrmEntityForm.php
+++ b/src/Form/CivicrmEntityForm.php
@@ -5,7 +5,6 @@ namespace Drupal\civicrm_entity\Form;
 use Drupal\civicrm_entity\SupportedEntities;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\ContentEntityForm;
-use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -23,7 +22,7 @@ class CivicrmEntityForm extends ContentEntityForm {
   /**
    * Constructs a NodeForm object.
    *
-   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
    *   The entity manager.
    * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
    *   The entity type bundle service.
@@ -32,8 +31,8 @@ class CivicrmEntityForm extends ContentEntityForm {
    * @param \Drupal\Core\Session\AccountInterface $current_user
    *   The current user.
    */
-  public function __construct(EntityManagerInterface $entity_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, TimeInterface $time, AccountInterface $current_user) {
-    parent::__construct($entity_manager, $entity_type_bundle_info, $time);
+  public function __construct(EntityRepositoryInterface $entity_repository, EntityTypeBundleInfoInterface $entity_type_bundle_info, TimeInterface $time, AccountInterface $current_user) {
+    parent::__construct($entity_repository, $entity_type_bundle_info, $time);
     $this->currentUser = $current_user;
   }
 

--- a/src/Form/CivicrmEntityForm.php
+++ b/src/Form/CivicrmEntityForm.php
@@ -107,10 +107,10 @@ class CivicrmEntityForm extends ContentEntityForm {
 
     $t_args = ['%title' => $this->entity->toLink()->toString()];
     if ($insert) {
-      drupal_set_message($this->t('%title has been created.', $t_args));
+      \Drupal::messanger()->addMessage($this->t('%title has been created.', $t_args));
     }
     else {
-      drupal_set_message($this->t('%title has been updated.', $t_args));
+      \Drupal::messanger()->addMessage($this->t('%title has been updated.', $t_args));
     }
     $form_state->setRedirect(
       "entity.{$this->entity->getEntityTypeId()}.canonical",

--- a/src/Plugin/views/field/CustomEntityField.php
+++ b/src/Plugin/views/field/CustomEntityField.php
@@ -285,7 +285,7 @@ class CustomEntityField extends EntityField {
     switch ($definition->getType()) {
       case 'datetime':
         $datetime_format = $definition->getSetting('datetime_type') === DateTimeItem::DATETIME_TYPE_DATE ? DateTimeItemInterface::DATE_STORAGE_FORMAT : DateTimeItemInterface::DATETIME_STORAGE_FORMAT;
-        return (new \DateTime($value, new \DateTimeZone(drupal_get_user_timezone())))->setTimezone(new \DateTimeZone('UTC'))->format($datetime_format);
+        return (new \DateTime($value, new \DateTimeZone(date_default_timezone_get())))->setTimezone(new \DateTimeZone('UTC'))->format($datetime_format);
     }
 
     return $value;

--- a/tests/modules/civicrm_entity_test/civicrm_entity_test.info.yml
+++ b/tests/modules/civicrm_entity_test/civicrm_entity_test.info.yml
@@ -3,6 +3,7 @@ type: module
 description: 'Test module for CiviCRM.'
 package: CiviCRM
 core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - civicrm
   - civicrm_entity

--- a/tests/modules/civicrm_entity_test/civicrm_entity_test.info.yml
+++ b/tests/modules/civicrm_entity_test/civicrm_entity_test.info.yml
@@ -2,7 +2,6 @@ name: CiviCRM Entity Test
 type: module
 description: 'Test module for CiviCRM.'
 package: CiviCRM
-core: 8.x
 core_version_requirement: ^8.8 || ^9
 dependencies:
   - civicrm


### PR DESCRIPTION
Summary of changes:

Bumps drupal core version to 8.8^ and changes to core_version_requirement syntax.

Removes depreciated functions and classes replacing these appropriately