### PR TITLE
Prevent data loss on uninstall.

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -62,6 +62,7 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
       'class' => CivicrmEntity::class,
       'originalClass' => CivicrmEntity::class,
       'id' => $entity_type_id,
+      'component' => $civicrm_entity_info['component'] ?? NULL,
       'civicrm_entity' => $civicrm_entity_name,
       'civicrm_entity_ui_exposed' => in_array($entity_type_id, $enabled_entity_types),
       'label' => new TranslatableMarkup('CiviCRM :name', [':name' => $civicrm_entity_info['civicrm entity label']]),

--- a/civicrm_entity.services.yml
+++ b/civicrm_entity.services.yml
@@ -11,7 +11,6 @@ services:
     arguments: ['@civicrm_entity.api']
     tags:
       - { name: backend_overridable }
-
   civicrm_entity.module_installer:
     class: Drupal\civicrm_entity\ModuleInstaller
     decorates: module_installer

--- a/civicrm_entity.services.yml
+++ b/civicrm_entity.services.yml
@@ -11,3 +11,11 @@ services:
     arguments: ['@civicrm_entity.api']
     tags:
       - { name: backend_overridable }
+
+  civicrm_entity.module_installer:
+    class: Drupal\civicrm_entity\ModuleInstaller
+    decorates: module_installer
+    public: false
+    arguments: ['@civicrm_entity.module_installer.inner', '@app.root', '@module_handler', '@kernel']
+    tags:
+      - { name: service_collector, tag: 'module_install.uninstall_validator', call: addUninstallValidator }

--- a/src/CiviCrmApi.php
+++ b/src/CiviCrmApi.php
@@ -94,6 +94,15 @@ class CiviCrmApi implements CiviCrmApiInterface {
   /**
    * {@inheritdoc}
    */
+  public function getValue($entity, array $params = []) {
+    $this->initialize();
+    $result = civicrm_api3($entity, 'getvalue', $params);
+    return $result;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function civicrmInitialize() {
     $this->civicrm->initialize();
   }

--- a/src/CiviCrmApiInterface.php
+++ b/src/CiviCrmApiInterface.php
@@ -86,6 +86,19 @@ interface CiviCrmApiInterface {
   public function getCount($entity, array $params = []);
 
   /**
+   * Get values from the CiviCRM entity.
+   *
+   * @param string $entity
+   *   The entity name.
+   * @param array $params
+   *   Optional additional parameters.
+   *
+   * @return array
+   *   The array of values.
+   */
+  public function getValue($entity, array $params = []);
+
+  /**
    * Initialize the CiviCRM API.
    */
   public function civicrmInitialize();

--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -282,6 +282,11 @@ class CiviEntityStorage extends SqlContentEntityStorage {
    * {@inheritdoc}
    */
   public function hasData() {
+    if (($component = $this->entityType->get('component')) !== NULL) {
+      $components = $this->getCiviCrmApi()->getValue('Setting', ['name' => 'enable_components']);
+      return !in_array($component, $components) ? FALSE :
+        $this->getCiviCrmApi()->getCount($this->entityType->get('civicrm_entity')) > 0;
+    }
     return $this->getCiviCrmApi()->getCount($this->entityType->get('civicrm_entity')) > 0;
   }
   /**

--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -772,4 +772,11 @@ class CiviEntityStorage extends SqlContentEntityStorage {
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function onEntityTypeDelete(EntityTypeInterface $entity_type) {
+    // Don't do anything.
+  }
+
 }

--- a/src/Entity/ContentUninstallValidator.php
+++ b/src/Entity/ContentUninstallValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\civicrm_entity\Entity;
+
+use Drupal\Core\Entity\ContentUninstallValidator as EntityContentUninstallValidator;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleUninstallValidatorInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Class ContentUninstallValidator.
+ */
+class ContentUninstallValidator extends EntityContentUninstallValidator {
+
+  protected $contentUninstallValidator;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ModuleUninstallValidatorInterface $content_uninstall_validator, EntityTypeManagerInterface $entity_type_manager, TranslationInterface $string_translation) {
+    parent::__construct($entity_type_manager, $string_translation);
+    $this->contentUninstallValidator = $content_uninstall_validator;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($module) {
+    if ($module === 'civicrm_entity') {
+      return [];
+    }
+
+    return parent::validate($module);
+  }
+
+}

--- a/src/ModuleInstaller.php
+++ b/src/ModuleInstaller.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\civicrm_entity;
+
+use Drupal\Core\DrupalKernelInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Extension\ModuleInstaller as ExtensionModuleInstaller;
+use Drupal\Core\Extension\ModuleInstallerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Class ContentUninstallValidator.
+ */
+class ModuleInstaller extends ExtensionModuleInstaller {
+
+  /**
+   * The module installer.
+   *
+   * @var \Drupal\Core\Extension\ModuleInstallerInterface
+   */
+  protected $moduleInstaller;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ModuleInstallerInterface $module_installer, $root, ModuleHandlerInterface $module_handler, DrupalKernelInterface $kernel) {
+    parent::__construct($root, $module_handler, $kernel);
+    $this->moduleInstaller = $module_installer;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateUninstall(array $module_list) {
+    $reasons = parent::validateUninstall($module_list);
+
+    unset($reasons['civicrm_entity']);
+
+    return $reasons;
+  }
+
+}

--- a/src/SupportedEntities.php
+++ b/src/SupportedEntities.php
@@ -504,6 +504,7 @@ $civicrm_entity_info['civicrm_group_contact'] = [
         'create' => ['edit pledges'],
         'delete' => ['edit pledges', 'administer CiviCRM'],
       ],
+      'component' => 'CiviPledge',
     ];
     $civicrm_entity_info['civicrm_pledge_payment'] = [
       'civicrm entity label' => t('Pledge payment'),


### PR DESCRIPTION
This decorations `ModuleInstaller` although this removes all validators for `civicrm_entity`. I think it would be nice to be able to just have it ignore the `ContentUninstallValidator` instead since it's the only validator that is responsible for validating content existence for `civicrm_entity`.