### PR TITLE
Fixes a module loading fix in D7 (PHP 7.3 compatibility)

### DIFF
--- a/modules/civicrm_entity_price_set_field/includes/civicrm_entity_price_set_field.transaction.inc
+++ b/modules/civicrm_entity_price_set_field/includes/civicrm_entity_price_set_field.transaction.inc
@@ -123,7 +123,7 @@ function _civicrm_entity_price_set_field_calculate_total($price_set_data, $entit
                     $total['line_items'][$id][$pf_id][$pfv_id] = $line_item;
                   }
                 }
-                continue;
+                continue 2;
               }
               break;
             case 'Text':


### PR DESCRIPTION
This change fixes an issue when loading modules with Drupal 7, in our case, it was making the site's token module fall over.

> Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in require_once() (line 341 of /home/[redacted]/public_html/includes/module.inc).

Lead back to this module, and this file. Updating this line to be `continue 2` resolved the issue for us.