### PR TITLE
Fix entity permission for related contact

### DIFF
--- a/src/CivicrmEntityAccessHandler.php
+++ b/src/CivicrmEntityAccessHandler.php
@@ -72,6 +72,13 @@ class CivicrmEntityAccessHandler extends EntityAccessControlHandler {
     if (!empty($this->civicrmEntityInfo[$this->entityTypeId]['permissions'][$operation])) {
       $permissions = $this->civicrmEntityInfo[$this->entityTypeId]['permissions'][$operation];
     }
+    if ($this->entityTypeId == 'civicrm_contact' && in_array($operation, ['view', 'edit'])) {
+      \Drupal::service('civicrm')->initialize();
+      $op = $operation == 'view' ? \CRM_Core_Permission::VIEW : \CRM_Core_Permission::EDIT;
+      if (\CRM_Contact_BAO_Contact_Permission::allow($entity->id(), $op)) {
+        return AccessResult::allowed();
+      }
+    }
     return AccessResult::allowedIfHasPermissions($account, $permissions, 'OR');
   }
 

--- a/src/CivicrmEntityAccessHandler.php
+++ b/src/CivicrmEntityAccessHandler.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\civicrm_entity\CiviCrmApiInterface;
 
 /**
  * Entity access handler for CiviCRM entities.
@@ -72,10 +73,22 @@ class CivicrmEntityAccessHandler extends EntityAccessControlHandler {
     if (!empty($this->civicrmEntityInfo[$this->entityTypeId]['permissions'][$operation])) {
       $permissions = $this->civicrmEntityInfo[$this->entityTypeId]['permissions'][$operation];
     }
-    if ($this->entityTypeId == 'civicrm_contact' && in_array($operation, ['view', 'edit'])) {
+    if (in_array($operation, ['view', 'edit'])) {
       \Drupal::service('civicrm')->initialize();
+      $contactID = NULL;
+      if ($this->entityTypeId == 'civicrm_contact') {
+        $contactID = $entity->id();
+      }
+      elseif ($this->entityTypeId == 'civicrm_membership') {
+        $membership = \Drupal::service('civicrm_entity.api')->get('Membership', ['id' => $entity->id()]);
+        $contactID = $membership[$entity->id()]['contact_id'] ?? NULL;
+      }
+
+      if (empty($contactID)) {
+        return AccessResult::allowedIfHasPermissions($account, $permissions, 'OR');
+      }
       $op = $operation == 'view' ? \CRM_Core_Permission::VIEW : \CRM_Core_Permission::EDIT;
-      if (\CRM_Contact_BAO_Contact_Permission::allow($entity->id(), $op)) {
+      if (\CRM_Contact_BAO_Contact_Permission::allow($contactID, $op)) {
         return AccessResult::allowed();
       }
     }


### PR DESCRIPTION
Views having related contact does not respect view my contact + relationship permission. 

To replicate

- Build a view on CiviCRM Contact.
- Add a relationship to civicrm_relationship table and display the related contact B on the view result.
- Add a contextual filter for current user id (contact A).
- Make sure contact A only has `view my contact` permission + civi relationship permission to view and update contact B.
- Login as contact A and navigate to the view result. The contact B is not displayed to the user even if it has the required permission. 

Here's the view config from our setup - https://gist.githubusercontent.com/jitendrapurohit/9e35965342e76b5f39f3d8074aceb4c5/raw/ddab9936487f5bb880fac770740e711738e95276/relationship-view-config