### PR TITLE
Add a computed end date for activities

### DIFF
--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -316,6 +316,15 @@ class CivicrmEntityViewsData extends EntityViewsData {
             'click sortable' => FALSE,
           ],
         ];
+        $views_field[$base_table]['activity_end_datetime'] = [
+          'title' => $this->t('Activity End Date'),
+          'help' => $this->t('The calculated end date and time, for calendar integrations.'),
+          'field' => [
+            'id' => 'civicrm_entity_activity_end_datetime',
+            'field_name' => 'activity_end_datetime',
+            'click sortable' => FALSE,
+          ],
+        ];
 
         $views_field[$base_table]['contact'] = [
           'title' => $this->t('Contact'),

--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -8,7 +8,6 @@ use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\TypedData\Plugin\DataType\DateTimeIso8601;
-use Drupal\Core\TypedData\Plugin\DataType\Timestamp;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItem;
 use Symfony\Component\Validator\ConstraintViolation;
 

--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -2,12 +2,14 @@
 
 namespace Drupal\civicrm_entity\Entity;
 
+use Drupal\civicrm_entity\Plugin\Field\ActivityEndDateFieldItemList;
 use Drupal\civicrm_entity\SupportedEntities;
 use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\TypedData\Plugin\DataType\DateTimeIso8601;
 use Drupal\Core\TypedData\Plugin\DataType\Timestamp;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItem;
 use Symfony\Component\Validator\ConstraintViolation;
 
 /**
@@ -84,6 +86,21 @@ class CivicrmEntity extends ContentEntityBase {
       if ($values = \Drupal::service('civicrm_entity.api')->getCustomFieldMetadata($civicrm_field['name'])) {
         $fields[$civicrm_field['name']]->setSetting('civicrm_entity_field_metadata', $values);
       }
+    }
+
+    // Provide a computed base field that takes the activity start time and
+    // appends the duration to calculated and end time.
+    if ($entity_type->id() === 'civicrm_activity') {
+      $fields['activity_end_datetime'] = BaseFieldDefinition::create('datetime')
+        ->setLabel(t('Activity End Date'))
+        ->setSetting('datetime_type', DateTimeItem::DATETIME_TYPE_DATETIME)
+        ->setComputed(TRUE)
+        ->setDisplayOptions('view', [
+          'type' => 'datetime_default',
+          'weight' => 0,
+        ])
+        ->setDisplayConfigurable('form', FALSE)
+        ->setClass(ActivityEndDateFieldItemList::class);
     }
 
     return $fields;

--- a/src/Plugin/Field/ActivityEndDateFieldItemList.php
+++ b/src/Plugin/Field/ActivityEndDateFieldItemList.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\civicrm_entity\Plugin\Field;
+
+use Drupal\civicrm_entity\Entity\CivicrmEntity;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\TypedData\ComputedItemListTrait;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+
+/**
+ * A computed field item list for Activities to provide an end date and time.
+ */
+class ActivityEndDateFieldItemList extends FieldItemList {
+  use ComputedItemListTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function computeValue() {
+    $entity = $this->getEntity();
+    assert($entity instanceof CivicrmEntity);
+    $activity_date_time = $entity->get('activity_date_time')->value;
+    $duration = $entity->get('duration')->value;
+    if (!$activity_date_time) {
+      return;
+    }
+    // If there was no duration entered, set the value as the start time.
+    if (!$duration || !is_numeric($duration)) {
+      $this->list[0] = $this->createItem(0, $activity_date_time);
+    }
+    else {
+      $date = new DrupalDateTime($activity_date_time);
+      $date->modify("+$duration minutes");
+      $this->list[0] = $this->createItem(0, $date->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Recalculate the activities duration if the end date has been changed.
+   */
+  public function onChange($delta) {
+    $entity = $this->getEntity();
+    assert($entity instanceof CivicrmEntity);
+    $activity_date_time = strtotime($entity->get('activity_date_time')->value);
+    $new_end_date = strtotime($this->get($delta)->value);
+    $diff = $new_end_date - $activity_date_time;
+    // Update the duration of the activity.
+    $minutes = $diff / 60;
+    $entity->get('duration')->setValue($minutes);
+    parent::onChange($delta);
+  }
+
+}

--- a/src/Plugin/views/field/ActivityEndDatetime.php
+++ b/src/Plugin/views/field/ActivityEndDatetime.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\civicrm_entity\Plugin\views\field;
+
+use Drupal\views\Plugin\views\field\EntityField;
+
+/**
+ * Display an activities computed end date.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsField("civicrm_entity_activity_end_datetime")
+ */
+class ActivityEndDatetime extends EntityField {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function usesGroupBy() {
+    return FALSE;
+  }
+
+  public function query($use_groupby = FALSE) {
+    // There is no query operation.
+  }
+
+}


### PR DESCRIPTION
This adds a computed field to provide an end date for Activities. This takes the start date and time and adds the duration to make a computed value. This has been tested with the [Fullcalendar View](https://www.drupal.org/project/fullcalendar_view). 

This also supports updating the duration with Fullcalendar when the event length is dragged.