### PR TITLE
Add support for bundles

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -125,8 +125,10 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
     if (!empty($civicrm_entity_info['bundle property'])) {
       $entity_type_info['entity_keys']['bundle'] = 'bundle';
       $entity_type_info['civicrm_bundle_property'] = $civicrm_entity_info['bundle property'];
-      $entity_type_info['links']['add-page'] = $entity_type_info['links']['add-form'];
-      $entity_type_info['links']['add-form'] = sprintf('%s/{%s}', $entity_type_info['links']['add-form'], $entity_type_info['entity_keys']['bundle']);
+      if (isset($entity_type_info['links'])) {
+        $entity_type_info['links']['add-page'] = $entity_type_info['links']['add-form'];
+        $entity_type_info['links']['add-form'] = sprintf('%s/{%s}', $entity_type_info['links']['add-form'], $entity_type_info['entity_keys']['bundle']);
+      }
     }
 
     $entity_types[$entity_type_id] = new ContentEntityType($entity_type_info);

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -83,17 +83,6 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
       ],
     ];
 
-    // If this entity has bundle support, we define the bundle field as "bundle"
-    // and will use the "bundle property" as the field to fetch field options
-    // from CiviCRM with.
-    //
-    // @see civicrm_entity_entity_bundle_info()
-    // @see \Drupal\civicrm_entity\Entity\CivicrmEntity::baseFieldDefinitions()
-    if (!empty($civicrm_entity_info['bundle property'])) {
-      $entity_type_info['entity_keys']['bundle'] = 'bundle';
-      $entity_type_info['civicrm_bundle_property'] = $civicrm_entity_info['bundle property'];
-    }
-
     if (in_array($entity_type_id, $enabled_entity_types)) {
       $entity_type_info = array_merge_recursive($entity_type_info, [
         'handlers' => [
@@ -120,6 +109,20 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
         'field_ui_base_route' => "entity.$entity_type_id.collection",
       ]);
     }
+
+    // If this entity has bundle support, we define the bundle field as "bundle"
+    // and will use the "bundle property" as the field to fetch field options
+    // from CiviCRM with.
+    //
+    // @see civicrm_entity_entity_bundle_info()
+    // @see \Drupal\civicrm_entity\Entity\CivicrmEntity::baseFieldDefinitions()
+    if (!empty($civicrm_entity_info['bundle property'])) {
+      $entity_type_info['entity_keys']['bundle'] = 'bundle';
+      $entity_type_info['civicrm_bundle_property'] = $civicrm_entity_info['bundle property'];
+      $entity_type_info['links']['add-page'] = $entity_type_info['links']['add-form'];
+      $entity_type_info['links']['add-form'] = sprintf('%s/{%s}', $entity_type_info['links']['add-form'], $entity_type_info['entity_keys']['bundle']);
+    }
+
     $entity_types[$entity_type_id] = new ContentEntityType($entity_type_info);
   }
 }

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -83,6 +83,18 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
         'storage_schema' => CivicrmEntityStorageSchema::class,
       ],
     ];
+
+    // If this entity has bundle support, we define the bundle field as "bundle"
+    // and will use the "bundle property" as the field to fetch field options
+    // from CiviCRM with.
+    //
+    // @see civicrm_entity_entity_bundle_info()
+    // @see \Drupal\civicrm_entity\Entity\CivicrmEntity::baseFieldDefinitions()
+    if (!empty($civicrm_entity_info['bundle property'])) {
+      $entity_type_info['entity_keys']['bundle'] = 'bundle';
+      $entity_type_info['civicrm_bundle_property'] = $civicrm_entity_info['bundle property'];
+    }
+
     if (in_array($entity_type_id, $enabled_entity_types)) {
       $entity_type_info = array_merge_recursive($entity_type_info, [
         'handlers' => [
@@ -117,20 +129,25 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
  * Implements hook_entity_bundle_info().
  */
 function civicrm_entity_entity_bundle_info() {
-  $bundles = [
-    'civicrm_activity' => [],
-  ];
-
   $transliteration = \Drupal::transliteration();
   /** @var \Drupal\civicrm_entity\CiviCrmApiInterface $civicrm_api */
   $civicrm_api = \Drupal::service('civicrm_entity.api');
-  $options = $civicrm_api->getOptions('activity', 'activity_type_id');
-  foreach ($options as $option) {
-    $machine_name = $transliteration->transliterate($option, LanguageInterface::LANGCODE_DEFAULT, '_');
-    $machine_name = mb_strtolower($machine_name);
-    $machine_name = preg_replace('/[^a-z0-9_]+/', '_', $machine_name);
-    $machine_name = preg_replace('/_+/', '_', $machine_name);
-    $bundles['civicrm_activity'][$machine_name]['label'] = $option;
+
+  $bundles = [];
+  $entity_types_with_bundles = array_filter(SupportedEntities::getInfo(), static function(array $civicrm_entity_info) {
+    return !empty($civicrm_entity_info['bundle property']);
+  });
+  foreach ($entity_types_with_bundles as $entity_type_id => $civicrm_entity_info) {
+    $bundles[$entity_type_id] = [];
+    $options = $civicrm_api->getOptions($civicrm_entity_info['civicrm entity name'], $civicrm_entity_info['bundle property']);
+    foreach ($options as $option) {
+      $machine_name = $transliteration->transliterate($option, LanguageInterface::LANGCODE_DEFAULT, '_');
+      $machine_name = mb_strtolower($machine_name);
+      $machine_name = preg_replace('/[^a-z0-9_]+/', '_', $machine_name);
+      $machine_name = preg_replace('/_+/', '_', $machine_name);
+
+      $bundles[$entity_type_id][$machine_name]['label'] = $option;
+    }
   }
   return $bundles;
 }

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -17,10 +17,15 @@ use Drupal\civicrm_entity\Routing\CiviCrmEntityRouteProvider;
 use Drupal\civicrm_entity\SupportedEntities;
 use Drupal\Core\Entity\ContentEntityDeleteForm;
 use Drupal\Core\Entity\ContentEntityType;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\FieldConfigInterface;
 use Drupal\views\ViewExecutable;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 
@@ -140,7 +145,13 @@ function civicrm_entity_entity_bundle_info() {
     return !empty($civicrm_entity_info['bundle property']);
   });
   foreach ($entity_types_with_bundles as $entity_type_id => $civicrm_entity_info) {
-    $bundles[$entity_type_id] = [];
+    // We keep a bundle that is the same as the entity type ID. This allows us
+    // to create fields as if this entity has no bundles.
+    $bundles[$entity_type_id] = [
+      $entity_type_id => [
+        'label' => $civicrm_entity_info['civicrm entity label'],
+      ],
+    ];
     $options = $civicrm_api->getOptions($civicrm_entity_info['civicrm entity name'], $civicrm_entity_info['bundle property']);
     foreach ($options as $option) {
       $machine_name = SupportedEntities::optionToMachineName($option, $transliteration);
@@ -148,6 +159,61 @@ function civicrm_entity_entity_bundle_info() {
     }
   }
   return $bundles;
+}
+
+/**
+ * Implements hook_entity_bundle_field_info().
+ *
+ * This ensures CiviCRM Entity entity types have their field config instances
+ * across all bundles. It's a copy of the Field module's logic, but clones
+ * field config definitions.
+ *
+ * @see field_entity_bundle_field_info().
+ */
+function civicrm_entity_entity_bundle_field_info(EntityTypeInterface $entity_type, $bundle, array $base_field_definitions) {
+  $result = [];
+  if ($entity_type->get('civicrm_entity_ui_exposed') && $entity_type->hasKey('bundle')) {
+    // Query by filtering on the ID as this is more efficient than filtering
+    // on the entity_type property directly.
+    $ids = \Drupal::entityQuery('field_config')
+      ->condition('id', $entity_type->id() . '.', 'STARTS_WITH')
+      ->execute();
+    // Fetch all fields and key them by field name.
+    $field_configs = FieldConfig::loadMultiple($ids);
+
+    // Clone the field configs, so that we can modify them and change the
+    // target bundle type without manipulating the statically cached entries
+    // in the entity storage;
+    $cloned_field_configs = array_map(static function (FieldConfigInterface $field) use ($bundle) {
+      $cloned = clone $field;
+      $cloned->set('bundle', $bundle);
+      return $cloned;
+    }, $field_configs);
+    foreach ($cloned_field_configs as $field_instance) {
+      $result[$field_instance->getName()] = $field_instance;
+    }
+  }
+  return $result;
+}
+
+/**
+ * Implements hook_entity_view_display_alter().
+ *
+ * There is no way to handle this in the entity type's view builder.
+ */
+function civicrm_entity_entity_view_display_alter(EntityViewDisplayInterface $display, array $context) {
+  $entity_type = \Drupal::entityTypeManager()->getDefinition($context['entity_type']);
+  assert($entity_type !== NULL);
+  if ($entity_type->get('civicrm_entity') && $entity_type->hasKey('bundle')) {
+    $entity_display_repository = \Drupal::service('entity_display.repository');
+    assert($entity_display_repository instanceof EntityDisplayRepositoryInterface);
+    $root_display = $entity_display_repository->getViewDisplay(
+      $entity_type->id(),
+      $entity_type->id()
+    );
+    $display->set('content', $root_display->get('content'));
+    $display->set('hidden', $root_display->get('hidden'));
+  }
 }
 
 /**

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -19,7 +19,6 @@ use Drupal\Core\Entity\ContentEntityDeleteForm;
 use Drupal\Core\Entity\ContentEntityType;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
-use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\views\ViewExecutable;
@@ -141,11 +140,7 @@ function civicrm_entity_entity_bundle_info() {
     $bundles[$entity_type_id] = [];
     $options = $civicrm_api->getOptions($civicrm_entity_info['civicrm entity name'], $civicrm_entity_info['bundle property']);
     foreach ($options as $option) {
-      $machine_name = $transliteration->transliterate($option, LanguageInterface::LANGCODE_DEFAULT, '_');
-      $machine_name = mb_strtolower($machine_name);
-      $machine_name = preg_replace('/[^a-z0-9_]+/', '_', $machine_name);
-      $machine_name = preg_replace('/_+/', '_', $machine_name);
-
+      $machine_name = SupportedEntities::optionToMachineName($option, $transliteration);
       $bundles[$entity_type_id][$machine_name]['label'] = $option;
     }
   }

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -19,6 +19,7 @@ use Drupal\Core\Entity\ContentEntityDeleteForm;
 use Drupal\Core\Entity\ContentEntityType;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\views\ViewExecutable;
@@ -110,6 +111,28 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
     }
     $entity_types[$entity_type_id] = new ContentEntityType($entity_type_info);
   }
+}
+
+/**
+ * Implements hook_entity_bundle_info().
+ */
+function civicrm_entity_entity_bundle_info() {
+  $bundles = [
+    'civicrm_activity' => [],
+  ];
+
+  $transliteration = \Drupal::transliteration();
+  /** @var \Drupal\civicrm_entity\CiviCrmApiInterface $civicrm_api */
+  $civicrm_api = \Drupal::service('civicrm_entity.api');
+  $options = $civicrm_api->getOptions('activity', 'activity_type_id');
+  foreach ($options as $option) {
+    $machine_name = $transliteration->transliterate($option, LanguageInterface::LANGCODE_DEFAULT, '_');
+    $machine_name = mb_strtolower($machine_name);
+    $machine_name = preg_replace('/[^a-z0-9_]+/', '_', $machine_name);
+    $machine_name = preg_replace('/_+/', '_', $machine_name);
+    $bundles['civicrm_activity'][$machine_name]['label'] = $option;
+  }
+  return $bundles;
 }
 
 /**

--- a/civicrm_entity.post_update.php
+++ b/civicrm_entity.post_update.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for CiviCRM Entity.
+ */
+
+/**
+ * Implements hook_post_update_NAME().
+ */
+function civicrm_entity_post_update_entity_bundles(&$sandbox) {
+  // An empty post_update hook triggers a cache rebuild, which ensures that
+  // our new hooks and route changes are discovered.
+}

--- a/civicrm_entity.post_update.php
+++ b/civicrm_entity.post_update.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Implements hook_post_update_NAME().
+ * Enable bundle support for CiviCRM Entity entity types.
  */
 function civicrm_entity_post_update_entity_bundles(&$sandbox) {
   // An empty post_update hook triggers a cache rebuild, which ensures that

--- a/civicrm_entity.services.yml
+++ b/civicrm_entity.services.yml
@@ -11,3 +11,9 @@ services:
     arguments: ['@civicrm_entity.api']
     tags:
       - { name: backend_overridable }
+
+  civicrm_entity.field_ui_route_subscriber:
+    class: Drupal\civicrm_entity\Routing\RouteSubscriber
+    arguments: [ '@entity_type.manager' ]
+    tags:
+      - { name: event_subscriber }

--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -229,10 +229,7 @@ class CiviEntityStorage extends SqlContentEntityStorage {
       $bundle = $options[$bundle_value];
 
       $transliteration = \Drupal::transliteration();
-      $bundle = $transliteration->transliterate($bundle, LanguageInterface::LANGCODE_DEFAULT, '_');
-      $bundle = mb_strtolower($bundle);
-      $bundle = preg_replace('/[^a-z0-9_]+/', '_', $bundle);
-      $bundle = preg_replace('/_+/', '_', $bundle);
+      $bundle = SupportedEntities::optionToMachineName($bundle, $transliteration);
     }
     $entity = new $this->entityClass([], $this->entityTypeId, $bundle);
     // Use initFieldValues to fix CiviCRM data array to Drupal.

--- a/src/CivicrmEntityListBuilder.php
+++ b/src/CivicrmEntityListBuilder.php
@@ -14,6 +14,13 @@ class CivicrmEntityListBuilder extends EntityListBuilder {
    * {@inheritdoc}
    */
   public function buildHeader() {
+    if ($this->entityType->hasKey('bundle')) {
+      return [
+          'id' => $this->t('ID'),
+          'bundle' => $this->entityType->getBundleLabel(),
+          'label' => $this->t('Label'),
+        ] + parent::buildHeader();
+    }
     return [
       'id' => $this->t('ID'),
       'label' => $this->t('Label'),
@@ -24,6 +31,13 @@ class CivicrmEntityListBuilder extends EntityListBuilder {
    * {@inheritdoc}
    */
   public function buildRow(EntityInterface $entity) {
+    if ($this->entityType->hasKey('bundle')) {
+      return [
+          'id' => $entity->id(),
+          'bundle' => $entity->bundle(),
+          'label' => $entity->toLink(),
+        ] + parent::buildRow($entity);
+    }
     return [
       'id' => $entity->id(),
       'label' => $entity->toLink(),

--- a/src/Controller/FieldUiController.php
+++ b/src/Controller/FieldUiController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\civicrm_entity\Controller;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\field_ui\FieldConfigListBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class FieldUiController implements ContainerInjectionInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private $entityTypeManager;
+
+  /**
+   * The entity type bundle info.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  private $entityTypeBundleInfo;
+
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new self(
+      $container->get('entity_type.manager'),
+      $container->get('entity_type.bundle.info')
+    );
+  }
+
+  /**
+   * Shows the 'Manage fields' page for CiviCRM entities.
+   *
+   * @param string $entity_type_id
+   *   The entity type.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   *
+   * @return array
+   *   A render array as expected by
+   *   \Drupal\Core\Render\RendererInterface::render().
+   */
+  public function fieldListing($entity_type_id) {
+    $list_builder = $this->entityTypeManager->getListBuilder('field_config');
+    assert($list_builder instanceof FieldConfigListBuilder);
+    $bundles = $this->entityTypeBundleInfo->getBundleInfo($entity_type_id);
+    // We replicate all field config across bundles, so take the first bundle
+    // name.
+    $bundle = key($bundles);
+
+    // Field UI provides parameter overrides.
+    return $list_builder->render($entity_type_id, $bundle);
+  }
+
+}

--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -3,6 +3,7 @@
 namespace Drupal\civicrm_entity\Entity;
 
 use Drupal\civicrm_entity\Plugin\Field\ActivityEndDateFieldItemList;
+use Drupal\civicrm_entity\Plugin\Field\BundleFieldItemList;
 use Drupal\civicrm_entity\SupportedEntities;
 use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityTypeInterface;
@@ -73,6 +74,16 @@ class CivicrmEntity extends ContentEntityBase {
     $civicrm_required_fields = !empty($civicrm_entity_info['required']) ? $civicrm_entity_info['required'] : [];
     $field_definition_provider = \Drupal::service('civicrm_entity.field_definition_provider');
     $civicrm_fields = \Drupal::service('civicrm_entity.api')->getFields($entity_type->get('civicrm_entity'), 'create');
+
+    if ($entity_type->hasKey('bundle')) {
+      // @todo needs a computed class to do same op as civicrm_entity_entity_bundle_info.
+      $fields[$entity_type->getKey('bundle')] = BaseFieldDefinition::create('string')
+        ->setLabel($entity_type->getBundleLabel())
+        ->setRequired(TRUE)
+        ->setReadOnly(TRUE)
+        ->setClass(BundleFieldItemList::class);
+    }
+
     foreach ($civicrm_fields as $civicrm_field) {
       // Apply any additional field data provided by the module.
       if (!empty($civicrm_entity_info['fields'][$civicrm_field['name']])) {

--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -79,7 +79,14 @@ class CivicrmEntity extends ContentEntityBase {
       /** @var \Drupal\civicrm_entity\CiviCrmApiInterface $civicrm_api */
       $civicrm_api = \Drupal::service('civicrm_entity.api');
       $options = $civicrm_api->getOptions($entity_type->get('civicrm_entity'), $bundle_property);
-      $raw_bundle_value = $values[$bundle_property];
+
+      if (isset($values[$entity_type->getKey('bundle')]) && $values[$entity_type->getKey('bundle')] === $entity_type->id()) {
+        $raw_bundle_value = key($options);
+      }
+      else {
+        $raw_bundle_value = $values[$bundle_property];
+      }
+
       $bundle_value = $options[$raw_bundle_value];
       $transliteration = \Drupal::transliteration();
       $machine_name = SupportedEntities::optionToMachineName($bundle_value, $transliteration);

--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -75,15 +75,6 @@ class CivicrmEntity extends ContentEntityBase {
     $field_definition_provider = \Drupal::service('civicrm_entity.field_definition_provider');
     $civicrm_fields = \Drupal::service('civicrm_entity.api')->getFields($entity_type->get('civicrm_entity'), 'create');
 
-    if ($entity_type->hasKey('bundle')) {
-      // @todo needs a computed class to do same op as civicrm_entity_entity_bundle_info.
-      $fields[$entity_type->getKey('bundle')] = BaseFieldDefinition::create('string')
-        ->setLabel($entity_type->getBundleLabel())
-        ->setRequired(TRUE)
-        ->setReadOnly(TRUE)
-        ->setClass(BundleFieldItemList::class);
-    }
-
     foreach ($civicrm_fields as $civicrm_field) {
       // Apply any additional field data provided by the module.
       if (!empty($civicrm_entity_info['fields'][$civicrm_field['name']])) {
@@ -96,6 +87,21 @@ class CivicrmEntity extends ContentEntityBase {
       if ($values = \Drupal::service('civicrm_entity.api')->getCustomFieldMetadata($civicrm_field['name'])) {
         $fields[$civicrm_field['name']]->setSetting('civicrm_entity_field_metadata', $values);
       }
+    }
+
+    // Placing the bundle field here is a bit of a hack work around.
+    // \Drupal\Core\Entity\ContentEntityStorageBase::initFieldValues will apply
+    // default values to all empty fields. The computed bundle field will
+    // provide a default value as well, for its related CiviCRM Entity field.
+    // By placing this field last, we avoid conflict on setting of the default
+    // value.
+    if ($entity_type->hasKey('bundle')) {
+      // @todo needs a computed class to do same op as civicrm_entity_entity_bundle_info.
+      $fields[$entity_type->getKey('bundle')] = BaseFieldDefinition::create('string')
+        ->setLabel($entity_type->getBundleLabel())
+        ->setRequired(TRUE)
+        ->setReadOnly(TRUE)
+        ->setClass(BundleFieldItemList::class);
     }
 
     // Provide a computed base field that takes the activity start time and

--- a/src/Form/CivicrmEntityForm.php
+++ b/src/Form/CivicrmEntityForm.php
@@ -5,6 +5,8 @@ namespace Drupal\civicrm_entity\Form;
 use Drupal\civicrm_entity\SupportedEntities;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -21,7 +23,7 @@ class CivicrmEntityForm extends ContentEntityForm {
   protected $currentUser;
 
   /**
-   * Constructs a NodeForm object.
+   * Constructs a CivicrmEntityForm object.
    *
    * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
    *   The entity repository service.
@@ -47,6 +49,25 @@ class CivicrmEntityForm extends ContentEntityForm {
       $container->get('datetime.time'),
       $container->get('current_user')
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * If this CiviCRM Entity type supports bundles, we hijack the loaded entity
+   * form display to be one for the root entity, not the bundle.
+   */
+  public function setFormDisplay(EntityFormDisplayInterface $form_display, FormStateInterface $form_state) {
+    $entity_type = $this->entity->getEntityType();
+    if ($entity_type->hasKey('bundle')) {
+      $entity_display_repository = \Drupal::service('entity_display.repository');
+      assert($entity_display_repository instanceof EntityDisplayRepositoryInterface);
+      $form_display = $entity_display_repository->getFormDisplay(
+        $entity_type->id(),
+        $entity_type->id()
+      );
+    }
+    return parent::setFormDisplay($form_display, $form_state);
   }
 
   /**

--- a/src/Plugin/Derivative/CivicrmEntityLocalAction.php
+++ b/src/Plugin/Derivative/CivicrmEntityLocalAction.php
@@ -54,8 +54,14 @@ class CivicrmEntityLocalAction extends DeriverBase implements ContainerDeriverIn
 
     /** @var \Drupal\Core\Entity\EntityTypeInterface $entity_type */
     foreach ($civicrm_entities as $entity_type_id => $entity_type) {
+      if ($entity_type->hasLinkTemplate('add-page')) {
+        $route_name = "entity.$entity_type_id.add_page";
+      } else {
+        $route_name = "entity.$entity_type_id.add_form";
+      }
+
       $this->derivatives["field_storage_config_add_$entity_type_id"] = [
-        'route_name' => "entity.$entity_type_id.add_form",
+        'route_name' => $route_name,
         'title' => $this->t('Add :label', [':label' => $entity_type->getLabel()]),
         'appears_on' => ["entity.$entity_type_id.collection"],
       ] + $base_plugin_definition;

--- a/src/Plugin/Field/BundleFieldItemList.php
+++ b/src/Plugin/Field/BundleFieldItemList.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\civicrm_entity\Plugin\Field;
+
+use Drupal\civicrm_entity\Entity\CivicrmEntity;
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\TypedData\ComputedItemListTrait;
+
+/**
+ * Computed field item list for the bundle property.
+ */
+class BundleFieldItemList extends FieldItemList {
+  use ComputedItemListTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function computeValue() {
+    $entity = $this->getEntity();
+    assert($entity instanceof CivicrmEntity);
+    $civicrm_bundle_property = $entity->getEntityType()->get('civicrm_bundle_property');
+    $civicrm_entity_name = $entity->getEntityType()->get('civicrm_entity');
+
+    $raw_bundle_value = $entity->get($civicrm_bundle_property)->value;
+
+    /** @var \Drupal\civicrm_entity\CiviCrmApiInterface $civicrm_api */
+    $civicrm_api = \Drupal::service('civicrm_entity.api');
+    $options = $civicrm_api->getOptions($civicrm_entity_name, $civicrm_bundle_property);
+    $bundle_value = $options[$raw_bundle_value];
+
+    $transliteration = \Drupal::transliteration();
+    $machine_name = $transliteration->transliterate($bundle_value, LanguageInterface::LANGCODE_DEFAULT, '_');
+    $machine_name = mb_strtolower($machine_name);
+    $machine_name = preg_replace('/[^a-z0-9_]+/', '_', $machine_name);
+    $machine_name = preg_replace('/_+/', '_', $machine_name);
+    $this->list[0] = $this->createItem(0, $machine_name);
+  }
+
+
+}

--- a/src/Plugin/Field/BundleFieldItemList.php
+++ b/src/Plugin/Field/BundleFieldItemList.php
@@ -34,5 +34,32 @@ class BundleFieldItemList extends FieldItemList {
     $this->list[0] = $this->createItem(0, $machine_name);
   }
 
+  /**
+   * {@inheritdoc}
+   *
+   * This sets the bundle property if Drupal sets a value to `bundle`, which
+   * means we have to transliterate the options and convert a machine name to
+   * the option key.
+   */
+  public function setValue($values, $notify = TRUE) {
+    $entity = $this->getEntity();
+    assert($entity instanceof CivicrmEntity);
+    $civicrm_bundle_property = $entity->getEntityType()->get('civicrm_bundle_property');
+    $civicrm_entity_name = $entity->getEntityType()->get('civicrm_entity');
+
+    /** @var \Drupal\civicrm_entity\CiviCrmApiInterface $civicrm_api */
+    $civicrm_api = \Drupal::service('civicrm_entity.api');
+    $options = $civicrm_api->getOptions($civicrm_entity_name, $civicrm_bundle_property);
+
+    $transliteration = \Drupal::transliteration();
+    $options = array_map(static function($value) use ($transliteration) {
+      return SupportedEntities::optionToMachineName($value, $transliteration);
+    }, $options);
+    $options = array_flip($options);
+
+    $entity->get($civicrm_bundle_property)->setValue($options[$values]);
+    parent::setValue($values, $notify);
+    $this->valueComputed = TRUE;
+  }
 
 }

--- a/src/Plugin/Field/BundleFieldItemList.php
+++ b/src/Plugin/Field/BundleFieldItemList.php
@@ -3,8 +3,8 @@
 namespace Drupal\civicrm_entity\Plugin\Field;
 
 use Drupal\civicrm_entity\Entity\CivicrmEntity;
+use Drupal\civicrm_entity\SupportedEntities;
 use Drupal\Core\Field\FieldItemList;
-use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\TypedData\ComputedItemListTrait;
 
 /**
@@ -30,10 +30,7 @@ class BundleFieldItemList extends FieldItemList {
     $bundle_value = $options[$raw_bundle_value];
 
     $transliteration = \Drupal::transliteration();
-    $machine_name = $transliteration->transliterate($bundle_value, LanguageInterface::LANGCODE_DEFAULT, '_');
-    $machine_name = mb_strtolower($machine_name);
-    $machine_name = preg_replace('/[^a-z0-9_]+/', '_', $machine_name);
-    $machine_name = preg_replace('/_+/', '_', $machine_name);
+    $machine_name = SupportedEntities::optionToMachineName($bundle_value, $transliteration);
     $this->list[0] = $this->createItem(0, $machine_name);
   }
 

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\civicrm_entity\Routing;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Drupal\Core\Routing\RoutingEvents;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Alters generated routes for CiviCRM Entity entity definitions.
+ */
+final class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private $entityTypeManager;
+
+  /**
+   * RouteSubscriber constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *    The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    foreach ($this->entityTypeManager->getDefinitions() as $entity_type_id => $entity_type) {
+      if (!$entity_type->get('civicrm_entity_ui_exposed')) {
+        continue;
+      }
+      if (!$entity_type->hasKey('bundle')) {
+        continue;
+      }
+
+      $field_ui_routes = [
+        "entity.{$entity_type_id}.field_ui_fields" => [
+          'bundle' => $entity_type_id,
+        ],
+        "entity.field_config.{$entity_type_id}_field_edit_form" => [
+          'bundle' => $entity_type_id,
+        ],
+        "entity.field_config.{$entity_type_id}_storage_edit_form" => [
+          'bundle' => $entity_type_id,
+        ],
+        "entity.field_config.{$entity_type_id}_field_delete_form" => [
+          'bundle' => $entity_type_id,
+        ],
+        "field_ui.field_storage_config_add_$entity_type_id" => [
+          'bundle' => $entity_type_id,
+        ],
+        "entity.entity_form_display.{$entity_type_id}.default" => [
+          'bundle' => $entity_type_id,
+        ],
+        "entity.entity_form_display.{$entity_type_id}.form_mode" => [
+          'bundle' => $entity_type_id,
+        ],
+        "entity.entity_view_display.{$entity_type_id}.default" => [
+          'bundle' => $entity_type_id,
+        ],
+        "entity.entity_view_display.{$entity_type_id}.view_mode" => [
+          'bundle' => $entity_type_id,
+        ],
+      ];
+      foreach ($field_ui_routes as $route_name => $defaults) {
+        $route = $collection->get($route_name);
+        assert($route !== NULL);
+        foreach ($defaults as $name => $default) {
+          $route->setDefault($name, $default);
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events = parent::getSubscribedEvents();
+    // Field UI's route subscriber runs at -100.
+    $events[RoutingEvents::ALTER] = ['onAlterRoutes', -200];
+    return $events;
+  }
+
+}

--- a/src/SupportedEntities.php
+++ b/src/SupportedEntities.php
@@ -2,6 +2,9 @@
 
 namespace Drupal\civicrm_entity;
 
+use Drupal\Component\Transliteration\TransliterationInterface;
+use Drupal\Core\Language\LanguageInterface;
+
 /**
  * Defines supported entities.
  *
@@ -857,6 +860,26 @@ $civicrm_entity_info['civicrm_group_contact'] = [
         'civicrm_alter_drupal_entities'
       );
     }
+  }
+
+  /**
+   * Transforms an option value to a machine name.
+   *
+   * This is leveraged to convert options into bundle names.
+   *
+   * @param string $value
+   *   The option value.
+   * @param \Drupal\Component\Transliteration\TransliterationInterface $transliteration
+   *   The transliteration service.
+   *
+   * @return string
+   */
+  public static function optionToMachineName($value, TransliterationInterface $transliteration) {
+    $value = $transliteration->transliterate($value, LanguageInterface::LANGCODE_DEFAULT, '_');
+    $value = mb_strtolower($value);
+    $value = preg_replace('/[^a-z0-9_]+/', '_', $value);
+    $value = preg_replace('/_+/', '_', $value);
+    return $value;
   }
 
 }

--- a/src/SupportedEntities.php
+++ b/src/SupportedEntities.php
@@ -47,6 +47,7 @@ final class SupportedEntities {
       'civicrm entity label' => t('Activity'),
       'civicrm entity name' => 'activity',
       'label property' => 'subject',
+      'bundle property' => 'activity_type_id',
       'permissions' => [
         'view' => ['view all activities'],
 
@@ -273,6 +274,7 @@ final class SupportedEntities {
       'civicrm entity label' => t('Event'),
       'civicrm entity name' => 'event',
       'label property' => 'title',
+      'bundle property' => 'event_type_id',
       'permissions' => [
         'view' => ['view event info'],
         'edit' => ['edit all events'],


### PR DESCRIPTION
We can have bundles on entities without there needing to be a UI for fields or anything else. 

Doing so would allow for some typical Drupal module integrations that expect bundles. For instance, with Fullcalendar View I can specify different colors per bundle.

This ties into #264 

<img width="1123" alt="Screen Shot 2021-01-08 at 10 30 34 PM" src="https://user-images.githubusercontent.com/3698644/104083110-87b28280-5201-11eb-8cfa-11643797ae20.png">
