### PR TITLE
Fix html type RichTextEditor for custom fields

### DIFF
--- a/src/Entity/FieldDefinitionProvider.php
+++ b/src/Entity/FieldDefinitionProvider.php
@@ -256,7 +256,13 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
    *   The base field definition.
    */
   protected function getTextDefinition(array $civicrm_field) {
-    if (!empty($civicrm_field['html']) && $civicrm_field['html']['type'] == 'RichTextEditor') {
+
+    if (!empty($civicrm_field['html_type']) && $civicrm_field['html_type'] == 'RichTextEditor') {
+      // case of html type on custom fields
+      $field_type = 'text_long';
+    }
+    elseif (!empty($civicrm_field['html']) && $civicrm_field['html']['type'] == 'RichTextEditor') {
+      // case of html type on core fields
       $field_type = 'text_long';
     }
     elseif (!empty($civicrm_field['description']) && strpos($civicrm_field['description'], 'Text and html allowed.') !== FALSE) {


### PR DESCRIPTION
Civicrm custom fields using RichTextEditor are not displayed in HTML format in Drupal. The TextareaWidget with the configurated text format does not apply.
This is due to a difference in array keys returned by the getfields apiv3 between primary fields and custom fields.
$civicrm_field['html_type'] instead of $civicrm_field['html']['type']