### PR TITLE
Fix import error.

### DIFF
--- a/civicrm_entity.services.yml
+++ b/civicrm_entity.services.yml
@@ -21,7 +21,7 @@ services:
   civicrm_entity.module_installer:
     class: Drupal\civicrm_entity\ModuleInstaller
     decorates: module_installer
-    public: false
+    public: true
     arguments: ['@civicrm_entity.module_installer.inner', '@app.root', '@module_handler', '@kernel']
     tags:
       - { name: service_collector, tag: 'module_install.uninstall_validator', call: addUninstallValidator }


### PR DESCRIPTION
Fix error when importing configuration from the UI:

> LogicException: The database connection is not serializable. This probably means you are serializing an object that has an indirect reference to the database connection. Adjust your code so that is not necessary. Alternatively, look at DependencySerializationTrait as a temporary solution. in Drupal\Core\Database\Connection->__sleep() (line 1546 of /var/www/web/uschess.org/web/core/lib/Drupal/Core/Database/Connection.php).