### PR TITLE
Add uri callback to civicrm_contact entity type

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -24,6 +24,7 @@ use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\FieldConfigInterface;
 use Drupal\views\ViewExecutable;
@@ -79,6 +80,7 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
         'label' => $civicrm_entity_info['label property'],
       ],
       'base_table' => $entity_type_id,
+      'uri_callback' => 'entity_uri',
       'admin_permission' => 'administer civicrm entity',
       'permission_granularity' => 'entity_type',
       'handlers' => [
@@ -133,6 +135,18 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
 
     $entity_types[$entity_type_id] = new ContentEntityType($entity_type_info);
   }
+}
+
+/**
+ * Entity URI callback used in hook_entity_type_build().
+ */
+function entity_uri($entity) {
+  if ($entity->getEntityTypeId() == 'civicrm_contact') {
+    return Url::fromUri('internal:/civicrm/contact/view', [
+      'query' => ['cid' => $entity->id(), 'reset' => 1],
+    ]);
+  }
+  return NULL;
 }
 
 /**


### PR DESCRIPTION
I think it need to be discussed but it fixes the problem raised in https://github.com/eileenmcnaughton/civicrm_entity/issues/275

Links to the `entity_type` option is available on almost all entities?

Eg contact fields display 
![image](https://user-images.githubusercontent.com/5929648/113674808-3d458280-96d8-11eb-8911-3df5afa07be7.png)

Contribution fields eg source etc displays -

![image](https://user-images.githubusercontent.com/5929648/113674877-564e3380-96d8-11eb-9566-07a437e69421.png)

Currently, all of them fail to link to the entity. This PR fixes the problem for contact fields. 

For others, probably we should just replace the `if()` with `switch()` and handle it for all entity types?