### PR TITLE
Remove add_page, simplify adding bundle supported entities, Layout Builder fixess

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -126,7 +126,9 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
       $entity_type_info['entity_keys']['bundle'] = 'bundle';
       $entity_type_info['civicrm_bundle_property'] = $civicrm_entity_info['bundle property'];
       if (isset($entity_type_info['links'])) {
-        $entity_type_info['links']['add-page'] = $entity_type_info['links']['add-form'];
+        // For entities with bundles that are exposed, add the `bundle` key to
+        // the add-form route. In CiviCrmEntityRouteProvider::getAddFormRoute
+        // we default the value, so that it isn't actually required in the URL.
         $entity_type_info['links']['add-form'] = sprintf('%s/{%s}', $entity_type_info['links']['add-form'], $entity_type_info['entity_keys']['bundle']);
       }
     }

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -26,6 +26,7 @@ use Drupal\Core\Render\Element;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\FieldConfigInterface;
+use Drupal\layout_builder\Entity\LayoutBuilderEntityViewDisplay;
 use Drupal\views\ViewExecutable;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 
@@ -218,6 +219,13 @@ function civicrm_entity_entity_view_display_alter(EntityViewDisplayInterface $di
     );
     $display->set('content', $root_display->get('content'));
     $display->set('hidden', $root_display->get('hidden'));
+
+    if ($root_display instanceof LayoutBuilderEntityViewDisplay) {
+      $layout_builder_settings = $root_display->getThirdPartySettings('layout_builder');
+      foreach ($layout_builder_settings as $setting_key => $setting) {
+        $display->setThirdPartySetting('layout_builder', $setting_key, $setting);
+      }
+    }
   }
 }
 

--- a/civicrm_entity.services.yml
+++ b/civicrm_entity.services.yml
@@ -14,7 +14,7 @@ services:
 
   civicrm_entity.field_ui_route_subscriber:
     class: Drupal\civicrm_entity\Routing\RouteSubscriber
-    arguments: [ '@entity_type.manager' ]
+    arguments: [ '@entity_type.manager', '@module_handler' ]
     tags:
       - { name: event_subscriber }
 

--- a/src/Plugin/Derivative/CivicrmEntityLocalAction.php
+++ b/src/Plugin/Derivative/CivicrmEntityLocalAction.php
@@ -49,22 +49,21 @@ class CivicrmEntityLocalAction extends DeriverBase implements ContainerDeriverIn
     $this->derivatives = [];
 
     $civicrm_entities = array_filter($this->entityTypeManager->getDefinitions(), function (EntityTypeInterface $type) {
-      return $type->getProvider() == 'civicrm_entity' && $type->get('civicrm_entity_ui_exposed');
+      return $type->getProvider() === 'civicrm_entity' && $type->get('civicrm_entity_ui_exposed');
     });
 
     /** @var \Drupal\Core\Entity\EntityTypeInterface $entity_type */
     foreach ($civicrm_entities as $entity_type_id => $entity_type) {
-      if ($entity_type->hasLinkTemplate('add-page')) {
-        $route_name = "entity.$entity_type_id.add_page";
-      } else {
-        $route_name = "entity.$entity_type_id.add_form";
-      }
-
-      $this->derivatives["field_storage_config_add_$entity_type_id"] = [
-        'route_name' => $route_name,
+      $this->derivatives["civicrm_entity_add_$entity_type_id"] = [
+        'route_name' => "entity.$entity_type_id.add_form",
         'title' => $this->t('Add :label', [':label' => $entity_type->getLabel()]),
         'appears_on' => ["entity.$entity_type_id.collection"],
       ] + $base_plugin_definition;
+      if ($entity_type->hasKey('bundle')) {
+        $this->derivatives["civicrm_entity_add_$entity_type_id"]['route_parameters'] = [
+          $entity_type->getKey('bundle') => $entity_type_id,
+        ];
+      }
     }
 
     return $this->derivatives;

--- a/src/Routing/CiviCrmEntityRouteProvider.php
+++ b/src/Routing/CiviCrmEntityRouteProvider.php
@@ -18,9 +18,24 @@ class CiviCrmEntityRouteProvider extends AdminHtmlRouteProvider {
     if ($entity_type->get('civicrm_entity_ui_exposed')) {
       return parent::getRoutes($entity_type);
     }
-    else {
-      return new RouteCollection();
+
+    return new RouteCollection();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getAddFormRoute(EntityTypeInterface $entity_type) {
+    $has_bundles = $entity_type->hasKey('bundle');
+    $entity_add_form_route = parent::getAddFormRoute($entity_type);
+    if ($has_bundles) {
+      // This ensures the form receives a default bundle from the
+      // CivicrmEntity::preCreate method, avoiding the need for the `add_page`
+      // route for selecting a bundle.
+      assert($entity_add_form_route !== NULL);
+      $entity_add_form_route->setDefault('bundle', $entity_type->id());
     }
+    return $entity_add_form_route;
   }
 
 }

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -48,6 +48,8 @@ final class RouteSubscriber extends RouteSubscriberBase {
     if (!$this->moduleHandler->moduleExists('field_ui')) {
       return;
     }
+
+    $has_layout_builder = $this->moduleHandler->moduleExists('layout_builder');
     foreach ($this->entityTypeManager->getDefinitions() as $entity_type_id => $entity_type) {
       if (!$entity_type->get('civicrm_entity_ui_exposed')) {
         continue;
@@ -85,6 +87,20 @@ final class RouteSubscriber extends RouteSubscriberBase {
           'bundle' => $entity_type_id,
         ],
       ];
+
+      if ($has_layout_builder) {
+        // @todo we should iterate over the section storage definitions.
+        //   that means we'd need to conditionally inject the manage service.
+        // @see \Drupal\layout_builder\Plugin\SectionStorage\DefaultsSectionStorage::buildRoutes
+        $field_ui_routes["layout_builder.defaults.$entity_type_id.view"] = [
+          'bundle' => $entity_type_id,
+        ];
+        // @see \Drupal\layout_builder\Plugin\SectionStorage\OverridesSectionStorage::buildRoutes
+        $field_ui_routes["layout_builder.overrides.$entity_type_id.view"] = [
+          'bundle' => $entity_type_id,
+        ];
+      }
+
       foreach ($field_ui_routes as $route_name => $defaults) {
         $route = $collection->get($route_name);
         assert($route !== NULL);

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -3,6 +3,7 @@
 namespace Drupal\civicrm_entity\Routing;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Routing\RouteSubscriberBase;
 use Drupal\Core\Routing\RoutingEvents;
 use Symfony\Component\Routing\RouteCollection;
@@ -20,19 +21,33 @@ final class RouteSubscriber extends RouteSubscriberBase {
   private $entityTypeManager;
 
   /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
    * RouteSubscriber constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *    The entity type manager.
+   *   The entity type manager.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler) {
     $this->entityTypeManager = $entity_type_manager;
+    $this->moduleHandler = $module_handler;
   }
 
   /**
    * {@inheritdoc}
    */
   protected function alterRoutes(RouteCollection $collection) {
+    // Only run if Field UI is installed.
+    if (!$this->moduleHandler->moduleExists('field_ui')) {
+      return;
+    }
     foreach ($this->entityTypeManager->getDefinitions() as $entity_type_id => $entity_type) {
       if (!$entity_type->get('civicrm_entity_ui_exposed')) {
         continue;


### PR DESCRIPTION
Addresses items 1 & 2 from #285. There is no longer an `add_page` which lists all of the bundles.