### PR TITLE
Add PR and issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+Problem/Motivation
+----------------------------------------
+_A brief description of what the problem is or the feature to be added._
+
+Steps to reproduce
+----------------------------------------
+_Steps in order to reproduce the bug._
+
+Proposed resolution
+----------------------------------------
+_Suggestions to fix the bug or a resolution for the problem._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+Overview
+----------------------------------------
+_A brief description of the pull request. Try to keep it non-technical._
+
+Before
+----------------------------------------
+_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+After
+----------------------------------------
+_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+Technical Details
+----------------------------------------
+_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
+
+Comments
+----------------------------------------
+_Anything else you would like the reviewer to note_
+
+Release notes snippet
+----------------------------------------
+_The notes to be added on the release_


### PR DESCRIPTION
This adds PR and issue templates. The PR template is similar to https://github.com/colemanw/webform_civicrm.

An example PR is https://github.com/puresyntax71/civicrm_entity/pull/3.

The issue created is https://github.com/puresyntax71/civicrm_entity/issues/new.