### PR TITLE
Add missing routes.

### DIFF
--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -99,6 +99,14 @@ final class RouteSubscriber extends RouteSubscriberBase {
         $field_ui_routes["layout_builder.overrides.$entity_type_id.view"] = [
           'bundle' => $entity_type_id,
         ];
+
+        $field_ui_routes["layout_builder.defaults.$entity_type_id.discard_changes"] = [
+          'bundle' => $entity_type_id,
+        ];
+
+        $field_ui_routes["layout_builder.defaults.$entity_type_id.disable"] = [
+          'bundle' => $entity_type_id,
+        ];
       }
 
       foreach ($field_ui_routes as $route_name => $defaults) {


### PR DESCRIPTION
There are 404 pages when going through "Discard changes" and disabling Layout builder for entity types with bundles such as CiviCRM event.

To reproduce:

1. Go to /admin/structure/civicrm-entity/civicrm-event/display.
2. Tick "Use Layout Builder" and "Save".
3. Click on "Manage layout".
4. Click on "Save layout".
5. Click on "Manage layout".
6. Click on "Discard changes" and "Confirm". (Originally goes to a 404 page.)
7. Untick "Use Layout Builder", "Save", and "Confirm". (Originally goes to a 404 page.)