### PR TITLE
fix notice generating field metadata for text_long fields, handle non…

### DIFF
--- a/src/Entity/FieldDefinitionProvider.php
+++ b/src/Entity/FieldDefinitionProvider.php
@@ -256,7 +256,8 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
    *   The base field definition.
    */
   protected function getTextDefinition(array $civicrm_field) {
-    if (!empty($civicrm_field['html']) && $civicrm_field['html']['type'] == 'RichTextEditor') {
+    if ((!empty($civicrm_field['html']['type']) && $civicrm_field['html']['type'] == 'RichTextEditor') ||
+      (!empty($civicrm_field['html_type']) && $civicrm_field['html_type'] == 'RichTextEditor')) {
       $field_type = 'text_long';
     }
     elseif (!empty($civicrm_field['description']) && strpos($civicrm_field['description'], 'Text and html allowed.') !== FALSE) {


### PR DESCRIPTION
…-custom field and custom field cases

Users reported a notice on module install and cache clears. 

I had gotten a PR from somebody that fixed the issue somewhat, and later I realized we need to handle a few cases, because's CiviCRM's getfields API action returns inconsistent field data. 

This PR should handle all cases gracefully. 