### PR TITLE
Add in operator.

### DIFF
--- a/src/Plugin/views/filter/InOperator.php
+++ b/src/Plugin/views/filter/InOperator.php
@@ -111,8 +111,6 @@ class InOperator extends BaseInOperator {
     else {
       switch ($this->operator) {
         case 'in':
-          $condition = new Condition('OR');
-
           $values = array_map(function($value) {
             return \CRM_Core_DAO::VALUE_SEPARATOR . $value . \CRM_Core_DAO::VALUE_SEPARATOR;
           }, $values);

--- a/src/Plugin/views/filter/InOperator.php
+++ b/src/Plugin/views/filter/InOperator.php
@@ -113,11 +113,13 @@ class InOperator extends BaseInOperator {
         case 'in':
           $condition = new Condition('OR');
 
-          foreach ($values as $value) {
-            $condition->condition($field, '%' . $this->connection->escapeLike($value) . '%', 'LIKE');
-          }
+          $values = array_map(function($value) {
+            return \CRM_Core_DAO::VALUE_SEPARATOR . $value . \CRM_Core_DAO::VALUE_SEPARATOR;
+          }, $values);
 
-          $this->query->addWhere($this->options['group'], $condition);
+          $this
+            ->query
+            ->addWhereExpression($this->options['group'], "CAST({$field} AS BINARY) RLIKE BINARY :arg1", [':arg1' => implode('|', $values)]);
           break;
 
         case 'not in':

--- a/src/Plugin/views/filter/InOperator.php
+++ b/src/Plugin/views/filter/InOperator.php
@@ -118,6 +118,7 @@ class InOperator extends BaseInOperator {
           $this
             ->query
             ->addWhereExpression($this->options['group'], "CAST({$field} AS BINARY) RLIKE BINARY :arg1", [':arg1' => implode('|', $values)]);
+
           break;
 
         case 'not in':


### PR DESCRIPTION
Originally the `InOperator` plugin uses the following query when a custom field accepts multiple values:

```sql
...WHERE <table> LIKE "%<value>%";
```

This was a workaround since multi-value custom fields store values in the database using `\CRM_Core_DAO::VALUE_SEPARATOR` e.g. `\CRM_Core_DAO::VALUE_SEPARATOR1\CRM_Core_DAO::VALUE_SEPARATOR2\CRM_Core_DAO::VALUE_SEPARATOR`. It wasn't a good solution though.

Patch modifies the query so it's the same as how CiviCRM does it similar to this:

```mysql
...WHERE CAST(civicrm_value_contact_detai_2.roc_6 AS BINARY) RLIKE BINARY '1|3';
```

It still needs a workaround for "not in" operator though.