### PR TITLE
Add workaround for textarea.

### DIFF
--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -785,4 +785,17 @@ class CivicrmEntityViewsData extends EntityViewsData {
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  protected function processViewsDataForTextLong($table, FieldDefinitionInterface $field_definition, array &$views_field, $field_column_name) {
+    if ($field_column_name === 'value') {
+      $views_field['real field'] = $field_definition->getName();
+    }
+
+    if ($field_column_name === 'format') {
+      $views_field = NULL;
+    }
+  }
+
 }


### PR DESCRIPTION
The textarea field in Drupal assumes that the database columns are "<field_name>__value" and "<field_name>__format".

No error is happening if you are just displaying the field since it uses a different method i.e. it doesn't do the "normal" way of querying the column. But when it comes to other queries that involves sorting, aggregation, filtering, etc, it uses the "normal" way of querying the column e.g. it does `WHERE CONCAT_WS(' ', civicrm_case.subject, ' ', civicrm_case.details__value) LIKE "%carol%"` in this case. `civicrm_case.details__value` doesn't exist in `civicrm_case` - only `civicrm_case.details`.

Workaround I added is to have CE specify a "real field" that will be used to get the value instead of how EntityViewsData determines the column. It also unsets the field for "format".