### PR TITLE
Add initial functional JS testing

### DIFF
--- a/civicrm_entity.info.yml
+++ b/civicrm_entity.info.yml
@@ -6,4 +6,5 @@ core_version_requirement: ^8.8 || ^9
 dependencies:
   - civicrm
   - drupal:datetime
+  - drupal:filter
   - drupal:options

--- a/tests/src/FunctionalJavascript/CivicrmEntitySettingsFormTest.php
+++ b/tests/src/FunctionalJavascript/CivicrmEntitySettingsFormTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\Tests\civicrm_entity\FunctionalJavascript;
+
+use Drupal\Core\Url;
+use Drupal\filter\Entity\FilterFormat;
+
+/**
+ * Tests the settings form for the module.
+ *
+ * @group civicrm_entity
+ */
+final class CivicrmEntitySettingsFormTest extends CivicrmEntityTestBase {
+
+  /**
+   * Tests enabling entity types.
+   */
+  public function testEnableNewEntityTypes() {
+    $admin_user = $this->createUser([
+      'administer civicrm entity'
+    ]);
+    $this->drupalLogin($admin_user);
+    $this->enableCivicrmEntityTypes(['civicrm_event', 'civicrm_activity']);
+    $this->drupalGet(Url::fromRoute('civicrm_entity.admin'));
+    $this->assertSession()->linkExists('CiviCRM Activity');
+    $this->assertSession()->linkExists('CiviCRM Event');
+  }
+
+  /**
+   * Tests that the filter can be configured.
+   */
+  public function testConfigureDefaultFilterFormat() {
+    $basic_html_format = FilterFormat::create([
+      'format' => 'basic_html',
+      'name' => 'Basic HTML',
+      'filters' => [
+        'filter_html' => [
+          'status' => 1,
+          'settings' => [
+            'allowed_html' => '<p> <br> <strong> <a> <em>',
+          ],
+        ],
+      ],
+    ]);
+    $basic_html_format->save();
+
+    $admin_user = $this->createUser([
+      'administer filters',
+      'administer civicrm entity'
+    ]);
+    $this->drupalLogin($admin_user);
+
+    $this->drupalGet(Url::fromRoute('civicrm_entity.admin'));
+    $this->clickLink('Settings');
+    $this->getSession()->getPage()->selectFieldOption('filter_format', $basic_html_format->id());
+    $this->getSession()->getPage()->pressButton('Save configuration');
+    $this->assertSession()->pageTextContains('The configuration options have been saved.');
+  }
+
+}

--- a/tests/src/FunctionalJavascript/CivicrmEntityTestBase.php
+++ b/tests/src/FunctionalJavascript/CivicrmEntityTestBase.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\Tests\civicrm_entity\FunctionalJavascript;
+
+use Drupal\Core\Url;
+use Drupal\Tests\civicrm\FunctionalJavascript\CiviCrmTestBase;
+
+abstract class CivicrmEntityTestBase extends CiviCrmTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'civicrm_entity',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Enable CiviCRM Entity types.
+   *
+   * @param array $entity_types
+   *   The entity type Ids
+   */
+  protected function enableCivicrmEntityTypes(array $entity_types): void {
+    $this->drupalGet(Url::fromRoute('civicrm_entity.settings'));
+    $this->htmlOutput();
+    $page = $this->getSession()->getPage();
+    foreach ($entity_types as $entity_type) {
+      $page->checkField("enabled_entity_types[$entity_type]");
+    }
+    $page->pressButton('Save configuration');
+    $this->assertSession()->pageTextContains('The configuration options have been saved.');
+  }
+
+}

--- a/tests/src/FunctionalJavascript/CivicrmEntityViewsTest.php
+++ b/tests/src/FunctionalJavascript/CivicrmEntityViewsTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\Tests\civicrm_entity\FunctionalJavascript;
+
+use Drupal\Core\Url;
+
+final class CivicrmEntityViewsTest extends CivicrmEntityTestBase {
+
+  protected static $modules = [
+    'views',
+    'views_ui',
+  ];
+
+  public function testConfigureSource() {
+    $admin_user = $this->createUser([
+      'administer civicrm entity',
+      'administer views',
+    ]);
+    $this->drupalLogin($admin_user);
+    $this->enableCivicrmEntityTypes(['civicrm_event', 'civicrm_activity']);
+    $this->drupalGet(Url::fromRoute('views_ui.add'));
+
+    $page = $this->getSession()->getPage();
+    $page->fillField('label', 'event view');
+
+    $page->selectFieldOption('show[wizard_key]', 'standard:civicrm_event');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    // All
+    $this->assertSession()->optionExists('show[type]', 'civicrm_event');
+    // Specifics
+    $this->assertSession()->optionExists('show[type]', 'conference');
+    $this->assertSession()->optionExists('show[type]', 'workshop');
+
+    $page->selectFieldOption('show[wizard_key]', 'standard:civicrm_activity');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    // All
+    $this->assertSession()->optionExists('show[type]', 'civicrm_activity');
+    // Specifics
+    $this->assertSession()->optionExists('show[type]', 'meeting');
+    $this->assertSession()->optionExists('show[type]', 'email');
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds a test for configuring the settings form:
* Verifies you can enable entity types and see links for their collection list
* Verifies you can modify filters

Adds a basic Views test
* Verifies the entities that show up on the setup wizard
* Verifies bundles render as part of the list.