### PR TITLE
5.37 had been released; 5.38 is rc now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           - drupal: '^9.1'
             civicrm: '~5.36'
           - drupal: '^9.1'
-            civicrm: '5.37.x-dev'
+            civicrm: '5.38.x-dev'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
       mysql:


### PR DESCRIPTION
Overview
----------------------------------------
Edit the Github Actions test matrix -> 5.37 had been released; 5.38 is rc now

Before
----------------------------------------
Testing 5.37.x-dev

After
----------------------------------------
Testing 5.38.x-dev

