### PR TITLE
Fix option display for entity reference pseudoconstants

### DIFF
--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -252,6 +252,16 @@ class CivicrmEntityViewsData extends EntityViewsData {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  protected function processViewsDataForEntityReference($table, FieldDefinitionInterface $field_definition, array &$views_field, $field_column_name) {
+    parent::processViewsDataForEntityReference($table, $field_definition, $views_field, $field_column_name);
+    if (!empty($field_definition->getItemDefinition()->getSetting('allowed_values_function'))) {
+      $this->processViewsDataForListString($table, $field_definition, $views_field, $field_column_name);
+    }
+  }
+
+  /**
    * Add views integration for custom fields.
    *
    * @param array $views_field

--- a/src/Entity/FieldDefinitionProvider.php
+++ b/src/Entity/FieldDefinitionProvider.php
@@ -36,6 +36,9 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
               $field = BaseFieldDefinition::create('entity_reference')
                 ->setSetting('target_type', $foreign_key_dao::getTableName())
                 ->setSetting('handler', 'default');
+              if (!empty($civicrm_field['pseudoconstant'])) {
+                $field->setSetting('allowed_values_function', 'civicrm_entity_pseudoconstant_options');
+              }
             }
             else {
               $field = $this->getIntegerDefinition($civicrm_field);


### PR DESCRIPTION
Overview
----------------------------------------
Fix option display for entity reference pseudo constants

Before
----------------------------------------
Entity Reference such as Membership Type ID, Financial Type ID, contribution Page id do not display any options in the view filters.

Financial Types -

![image](https://user-images.githubusercontent.com/5929648/121772340-798ed680-cb92-11eb-8988-e3936889eed8.png)


Membership Types -

![image](https://user-images.githubusercontent.com/5929648/121772333-654ad980-cb92-11eb-97ea-c54179c80c6d.png)

After
----------------------------------------
Options are displayed for entity reference fields

Financial Types -

![image](https://user-images.githubusercontent.com/5929648/121772247-e0f85680-cb91-11eb-813a-ee4e8a566211.png)

Membership Types -

![image](https://user-images.githubusercontent.com/5929648/121772312-464c4780-cb92-11eb-9ea1-ad94c49f7e0f.png)


