### PR TITLE
Changing 'civicrm' to 'default'

### DIFF
--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -61,7 +61,7 @@ class CivicrmEntityViewsData extends EntityViewsData {
       'title' => $this->entityType->getLabel(),
       'cache_contexts' => $this->entityType->getListCacheContexts(),
       // If we're in a test site, use the civicrm_test database connection.
-      'database' => drupal_valid_test_ua() ? 'civicrm_test' : 'civicrm',
+      'database' => drupal_valid_test_ua() ? 'civicrm_test' : 'default',
       // Specify our own views query plugin, to support ensuring the CiviCRM
       // database connection exists in Drupal.
       // @see \Drupal\views\Plugin\views\display\DisplayPluginBase::getPlugin


### PR DESCRIPTION
Makes PR 306 work D8/two db-s and setting.php prefixes and relationships involving both drupal and civicrm tables. Want to see if the test fails!