### PR TITLE
Do not generate dedicated table storage

### DIFF
--- a/src/Entity/Sql/CivicrmEntityStorageSchema.php
+++ b/src/Entity/Sql/CivicrmEntityStorageSchema.php
@@ -26,14 +26,6 @@ class CivicrmEntityStorageSchema extends SqlContentEntityStorageSchema {
    */
   public function onEntityTypeCreate(EntityTypeInterface $entity_type) {
     $this->checkEntityType($entity_type);
-
-    // Create dedicated field tables.
-    $table_mapping = $this->storage->getTableMapping();
-    foreach ($this->fieldStorageDefinitions as $field_storage_definition) {
-      if ($table_mapping->requiresDedicatedTableStorage($field_storage_definition)) {
-        $this->createDedicatedTableSchema($field_storage_definition);
-      }
-    }
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
When CiviCRM is in a separate database, the CiviCRM tables are still created. They are not used, but the existing entity schema creates them on the Drupal database.

Technical Details
----------------------------------------
During the original port, these lines were kept to help assist with custom fields. However, whenever this code executes, the only field storages are base fields and they end up generating a duplicate table that mimics the CiviCRM table.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_

Release notes snippet
----------------------------------------
_The notes to be added on the release_
