### PR TITLE
Use default timezone from settings instead.

### DIFF
--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -411,7 +411,7 @@ class CiviEntityStorage extends SqlContentEntityStorage {
           }
           else {
             $datetime_format = $definition->getSetting('datetime_type') === DateTimeItem::DATETIME_TYPE_DATE ? DateTimeItemInterface::DATE_STORAGE_FORMAT : DateTimeItemInterface::DATETIME_STORAGE_FORMAT;
-            $default_timezone = \Drupal::config('system.date')->get('timezone.default');
+            $default_timezone = \Drupal::config('system.date')->get('timezone.default') ?? date_default_timezone_get();
             $datetime_value = (new \DateTime($item[$main_property_name], new \DateTimeZone($default_timezone)))->setTimezone(new \DateTimeZone('UTC'))->format($datetime_format);
             $item_values[$delta][$main_property_name] = $datetime_value;
           }

--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -411,10 +411,8 @@ class CiviEntityStorage extends SqlContentEntityStorage {
           }
           else {
             $datetime_format = $definition->getSetting('datetime_type') === DateTimeItem::DATETIME_TYPE_DATE ? DateTimeItemInterface::DATE_STORAGE_FORMAT : DateTimeItemInterface::DATETIME_STORAGE_FORMAT;
-            // CiviCRM gives us the datetime in the users timezone (or no
-            // timezone at all) but Drupal expects it in UTC. So, we need to
-            // convert from the users timezone into UTC.
-            $datetime_value = (new \DateTime($item[$main_property_name], new \DateTimeZone(date_default_timezone_get())))->setTimezone(new \DateTimeZone('UTC'))->format($datetime_format);
+            $default_timezone = \Drupal::config('system.date')->get('timezone.default');
+            $datetime_value = (new \DateTime($item[$main_property_name], new \DateTimeZone($default_timezone)))->setTimezone(new \DateTimeZone('UTC'))->format($datetime_format);
             $item_values[$delta][$main_property_name] = $datetime_value;
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------

Display of time is somewhat incorrect since it always changes depending on the logged in user's timezone setting.

I think it might be due to the change for `date_default_timezone_get()` wherein the default timezone is set depending on the [logged in user](https://api.drupal.org/api/drupal/core%21modules%21system%21src%21TimeZoneResolver.php/function/TimeZoneResolver%3A%3AgetTimeZone/8.8.x).

Before
----------------------------------------

Date fields on CiviCRM entities are changing values depending on the user's set timezone.

After
----------------------------------------

Date fields on CiviCRM entities are based on the default timezone settings and are only changed on a per user's timezone setting on display.