### PR TITLE
Add integration tests with Fullcalendar View

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,10 @@ jobs:
         run: |
           cd ~/drupal
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/civicrm_entity *@dev
+      - name: Install integration test modules
+        run: |
+          cd ~/drupal
+          COMPOSER_MEMORY_LIMIT=-1 composer require drupal/leaflet drupal/fullcalendar_view
       - uses: nanasess/setup-chromedriver@master
       - name: Run chromedriver
         run: chromedriver &

--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,9 @@
     "require": {
         "civicrm/civicrm-drupal-8": "*"
     },
+    "require-dev": {
+        "drupal/fullcalendar_view": "^5.0",
+        "drupal/leaflet": "^2"
+    },
     "minimum-stability": "dev"
 }

--- a/tests/modules/civicrm_entity_fullcalendar_test/civicrm_entity_fullcalendar_test.info.yml
+++ b/tests/modules/civicrm_entity_fullcalendar_test/civicrm_entity_fullcalendar_test.info.yml
@@ -5,6 +5,7 @@ package: CiviCRM
 core_version_requirement: ^8.8 || ^9
 dependencies:
   - drupal:datetime
+  - drupal:taxonomy
   - drupal:views
   - civicrm:civicrm
   - civicrm_entity:civicrm_entity

--- a/tests/modules/civicrm_entity_fullcalendar_test/civicrm_entity_fullcalendar_test.info.yml
+++ b/tests/modules/civicrm_entity_fullcalendar_test/civicrm_entity_fullcalendar_test.info.yml
@@ -1,0 +1,11 @@
+name: CiviCRM Entity Fullcalendar Test
+type: module
+description: 'Test module for CiviCRM Entity and Fullcalendar View.'
+package: CiviCRM
+core_version_requirement: ^8.8 || ^9
+dependencies:
+  - drupal:datetime
+  - drupal:views
+  - civicrm:civicrm
+  - civicrm_entity:civicrm_entity
+  - fullcalendar_view:fullcalendar_view

--- a/tests/modules/civicrm_entity_fullcalendar_test/config/install/field.field.user.user.field_tags.yml
+++ b/tests/modules/civicrm_entity_fullcalendar_test/config/install/field.field.user.user.field_tags.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_tags
+  module:
+    - user
+id: user.user.field_tags
+field_name: field_tags
+entity_type: user
+bundle: user
+label: Tags
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings: {  }
+field_type: entity_reference

--- a/tests/modules/civicrm_entity_fullcalendar_test/config/install/field.field.user.user.field_test_field.yml
+++ b/tests/modules/civicrm_entity_fullcalendar_test/config/install/field.field.user.user.field_test_field.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_test_field
+  module:
+    - user
+id: user.user.field_test_field
+field_name: field_test_field
+entity_type: user
+bundle: user
+label: 'Test Field'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/tests/modules/civicrm_entity_fullcalendar_test/config/install/field.storage.user.field_tags.yml
+++ b/tests/modules/civicrm_entity_fullcalendar_test/config/install/field.storage.user.field_tags.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+    - user
+id: user.field_tags
+field_name: field_tags
+entity_type: user
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/modules/civicrm_entity_fullcalendar_test/config/install/field.storage.user.field_test_field.yml
+++ b/tests/modules/civicrm_entity_fullcalendar_test/config/install/field.storage.user.field_test_field.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_test_field
+field_name: field_test_field
+entity_type: user
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/modules/civicrm_entity_fullcalendar_test/config/install/taxonomy.vocabulary.tags.yml
+++ b/tests/modules/civicrm_entity_fullcalendar_test/config/install/taxonomy.vocabulary.tags.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: Tags
+vid: tags
+description: 'Use tags to group articles on similar topics into categories.'
+weight: 0

--- a/tests/modules/civicrm_entity_fullcalendar_test/config/install/views.view.activity_fullcalendar.yml
+++ b/tests/modules/civicrm_entity_fullcalendar_test/config/install/views.view.activity_fullcalendar.yml
@@ -5,6 +5,7 @@ dependencies:
     - civicrm_entity
     - datetime
     - fullcalendar_view
+    - user
 id: activity_fullcalendar
 label: 'Activity Fullcalendar'
 module: views
@@ -67,7 +68,7 @@ display:
           updateConfirm: 1
           defaultLanguage: en
           languageSelector: 0
-          dialogWindow: 0
+          dialogWindow: 1
           openEntityInNewTab: 1
           createEventLink: 0
           eventLimit: '2'
@@ -310,13 +311,170 @@ display:
           field_api_classes: 0
           entity_type: civicrm_activity
           plugin_id: civicrm_entity_activity_end_datetime
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: user
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: "<p>{{ subject }}</p>\r\n\r\n<p>{{ activity_date_time }}  - {{ activity_end_datetime }}</p>\r\n\r\n<p>{{ name }}</p>"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+          plugin_id: custom
       filters: {  }
       sorts: {  }
       title: 'Activity Fullcalendar'
       header: {  }
       footer: {  }
       empty: {  }
-      relationships: {  }
+      relationships:
+        contact:
+          id: contact
+          table: civicrm_activity
+          field: contact
+          relationship: none
+          group_type: group
+          admin_label: 'Contact (Assignee)'
+          required: false
+          record_type_id: '1'
+          entity_type: civicrm_activity
+          plugin_id: civicrm_entity_activity_contact
+        contact_1:
+          id: contact_1
+          table: civicrm_activity
+          field: contact
+          relationship: none
+          group_type: group
+          admin_label: 'Contact (Target)'
+          required: false
+          record_type_id: '3'
+          entity_type: civicrm_activity
+          plugin_id: civicrm_entity_activity_contact
+        contact_2:
+          id: contact_2
+          table: civicrm_activity
+          field: contact
+          relationship: none
+          group_type: group
+          admin_label: 'Contact (Source)'
+          required: false
+          record_type_id: '2'
+          entity_type: civicrm_activity
+          plugin_id: civicrm_entity_activity_contact
+        user:
+          id: user
+          table: civicrm_contact
+          field: user
+          relationship: contact_2
+          group_type: group
+          admin_label: User
+          required: false
+          entity_type: civicrm_contact
+          plugin_id: civicrm_entity_civicrm_contact_user
       arguments: {  }
       display_extenders: {  }
     cache_metadata:

--- a/tests/modules/civicrm_entity_fullcalendar_test/config/install/views.view.activity_fullcalendar.yml
+++ b/tests/modules/civicrm_entity_fullcalendar_test/config/install/views.view.activity_fullcalendar.yml
@@ -1,0 +1,341 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - civicrm_entity
+    - datetime
+    - fullcalendar_view
+id: activity_fullcalendar
+label: 'Activity Fullcalendar'
+module: views
+description: ''
+tag: ''
+base_table: civicrm_activity
+base_field: id
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 10
+          offset: 0
+      style:
+        type: fullcalendar_view_display
+        options:
+          default_date_source: now
+          defaultDate: ''
+          start: activity_date_time
+          end: activity_end_datetime
+          title: subject
+          left_buttons: 'prev,next today'
+          right_buttons: 'dayGridMonth,timeGridWeek,timeGridDay,listYear'
+          default_view: dayGridMonth
+          firstDay: '0'
+          nav_links: 1
+          timeFormat: 'hh:mm a'
+          allowEventOverlap: 1
+          updateAllowed: 1
+          updateConfirm: 1
+          defaultLanguage: en
+          languageSelector: 0
+          dialogWindow: 0
+          openEntityInNewTab: 1
+          createEventLink: 0
+          eventLimit: '2'
+          tax_field: ''
+          vocabularies: ''
+          color_bundle:
+            civicrm_activity: '#3a87ad'
+            meeting: '#3a87ad'
+            phone_call: '#3a87ad'
+            email: '#3a87ad'
+            outbound_sms: '#3a87ad'
+            event_registration: '#3a87ad'
+            contribution: '#3a87ad'
+            membership_signup: '#3a87ad'
+            membership_renewal: '#3a87ad'
+            tell_a_friend: '#3a87ad'
+            inbound_email: '#3a87ad'
+            membership_renewal_reminder: '#3a87ad'
+            bulk_email: '#3a87ad'
+            print_merge_document: '#3a87ad'
+            mass_sms: '#3a87ad'
+            change_membership_status: '#3a87ad'
+            change_membership_type: '#3a87ad'
+            cancel_recurring_contribution: '#3a87ad'
+            update_recurring_contribution_billing_details: '#3a87ad'
+            update_recurring_contribution: '#3a87ad'
+            reminder_sent: '#3a87ad'
+            export_accounting_batch: '#3a87ad'
+            create_batch: '#3a87ad'
+            edit_batch: '#3a87ad'
+            sms_delivery: '#3a87ad'
+            inbound_sms: '#3a87ad'
+            payment: '#3a87ad'
+            refund: '#3a87ad'
+            change_registration: '#3a87ad'
+            downloaded_invoice: '#3a87ad'
+            emailed_invoice: '#3a87ad'
+            contact_merged: '#3a87ad'
+            contact_deleted_by_merge: '#3a87ad'
+            failed_payment: '#3a87ad'
+          rrule: ''
+          duration: ''
+          bundle_type: ''
+          classes: ''
+      row:
+        type: fields
+      fields:
+        subject:
+          table: civicrm_activity
+          field: subject
+          id: subject
+          entity_type: null
+          entity_field: subject
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        activity_date_time:
+          id: activity_date_time
+          table: civicrm_activity
+          field: activity_date_time
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: datetime_default
+          settings:
+            timezone_override: ''
+            format_type: medium
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: civicrm_activity
+          entity_field: activity_date_time
+          plugin_id: field
+        activity_end_datetime:
+          id: activity_end_datetime
+          table: civicrm_activity
+          field: activity_end_datetime
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: datetime_default
+          settings:
+            timezone_override: ''
+            format_type: medium
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: 0
+          entity_type: civicrm_activity
+          plugin_id: civicrm_entity_activity_end_datetime
+      filters: {  }
+      sorts: {  }
+      title: 'Activity Fullcalendar'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: activity-fullcalendar
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+      tags: {  }

--- a/tests/src/FunctionalJavascript/Views/ActivityFullcalendarViewTest.php
+++ b/tests/src/FunctionalJavascript/Views/ActivityFullcalendarViewTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\Tests\civicrm_entity\FunctionalJavascript\Views;
+
+use Drupal\Tests\civicrm_entity\FunctionalJavascript\CivicrmEntityTestBase;
+
+/**
+ * @requires module fullcalendar_view
+ */
+final class ActivityFullcalendarViewTest extends CivicrmEntityTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'fullcalendar_view',
+  ];
+
+  /**
+   * {@inheritdoc}
+   *
+   * @todo needs more data.
+   */
+  public function setUp(): void {
+    parent::setUp();
+    $civicrm_api = $this->container->get('civicrm_entity.api');
+    $result = $civicrm_api->save('Contact', [
+      'contact_type' => 'Individual',
+      'first_name' => 'Johnny',
+      'last_name' => 'Appleseed',
+      'email' => 'johnny@example.com',
+    ]);
+    $contact_id = $result['id'];
+    $civicrm_api->save('Activity', [
+      'source_contact_id' => $contact_id,
+      'activity_type_id' => 'Meeting',
+      'subject' => 'Meeting about new seeds',
+      'activity_date_time' => '2011-06-02 14:36:13',
+      'status_id' => 2,
+      'priority_id' => 1,
+      'duration' => 120,
+      'location' => 'Pennsylvania',
+      'details' => 'We need to find more seeds!',
+    ]);
+  }
+
+}

--- a/tests/src/FunctionalJavascript/Views/ActivityFullcalendarViewTest.php
+++ b/tests/src/FunctionalJavascript/Views/ActivityFullcalendarViewTest.php
@@ -85,11 +85,11 @@ final class ActivityFullcalendarViewTest extends CivicrmEntityTestBase {
       ->save();
   }
 
-  public function testFullcalendarDisplay() {
+  public function testFullcalendarDisplay(): void {
     $this->drupalGet('/activity-fullcalendar');
     $this->createScreenshot('../calendar.png');
     $fullcalendar = $this->assertSession()->elementExists('css', '.js-drupal-fullcalendar');
-    $this->assertSession()->elementExists('css', '.fc-event-container', $fullcalendar);
+    $this->assertSession()->waitForElement('css', '.fc-event-container');
     $this->assertSession()->elementTextContains('css', '.fc-event-container .fc-time', '12:00 pm');
     $this->assertSession()->elementTextContains('css', '.fc-event-container .fc-title', 'Meeting about new seeds');
 
@@ -100,13 +100,13 @@ final class ActivityFullcalendarViewTest extends CivicrmEntityTestBase {
   /**
    * @group debug
    */
-  public function testActivityDragAndUpdate() {
+  public function testActivityDragAndUpdate(): void {
     $previous_day = new DrupalDateTime('-1 day');
     $previous_day_formatted = $previous_day->format('Y-m-d');
 
     $this->drupalGet('/activity-fullcalendar');
     $fullcalendar = $this->assertSession()->elementExists('css', '.js-drupal-fullcalendar');
-    $event = $this->assertSession()->elementExists('css', '.fc-event-container .fc-event', $fullcalendar);
+    $event = $this->assertSession()->waitForElement('css', '.fc-event-container .fc-event');
     $destination = $this->assertSession()->elementExists('css', ".fc-bg [data-date='$previous_day_formatted']", $fullcalendar);
 
     // Using dragTo causes exceptions due to an alert appearing during the
@@ -128,7 +128,10 @@ final class ActivityFullcalendarViewTest extends CivicrmEntityTestBase {
     $driver = $this->getSession()->getDriver();
     assert($driver instanceof DrupalSelenium2Driver);
     $alert_text = $driver->getWebDriverSession()->getAlert_text();
-    $this->assertEquals('Meeting about new seeds start is now 2021-10-18 12:00:00 and end is now 2021-10-18 14:00:00 - Do you want to save this change?', $alert_text);
+    self::assertMatchesRegularExpression(
+      '/^Meeting about new seeds start is now ([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9]) (2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9]) and end is now ([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9]) (2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9]) - Do you want to save this change\?$/',
+      $alert_text
+    );
     $driver->getWebDriverSession()->accept_alert();
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->createScreenshot('../calendar.png');

--- a/tests/src/FunctionalJavascript/Views/ActivityFullcalendarViewTest.php
+++ b/tests/src/FunctionalJavascript/Views/ActivityFullcalendarViewTest.php
@@ -25,15 +25,12 @@ final class ActivityFullcalendarViewTest extends CivicrmEntityTestBase {
    */
   private $activityId;
 
-
   /**
    * {@inheritdoc}
    */
   protected static $modules = [
     'civicrm_entity_fullcalendar_test',
   ];
-
-
 
   /**
    * {@inheritdoc}
@@ -128,7 +125,10 @@ final class ActivityFullcalendarViewTest extends CivicrmEntityTestBase {
     $driver = $this->getSession()->getDriver();
     assert($driver instanceof DrupalSelenium2Driver);
     $alert_text = $driver->getWebDriverSession()->getAlert_text();
-    self::assertMatchesRegularExpression(
+    // @todo deprecated in Drupal 9.2 PHPUnit bump.
+    // Change to assertMatchesRegularExpression for PHPUnit 10.
+    // @see https://www.drupal.org/project/drupal/issues/3217709
+    $this->assertRegExp(
       '/^Meeting about new seeds start is now ([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9]) (2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9]) and end is now ([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9]) (2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9]) - Do you want to save this change\?$/',
       $alert_text
     );

--- a/tests/src/FunctionalJavascript/Views/ActivityFullcalendarViewTest.php
+++ b/tests/src/FunctionalJavascript/Views/ActivityFullcalendarViewTest.php
@@ -92,11 +92,27 @@ final class ActivityFullcalendarViewTest extends CivicrmEntityTestBase {
 
     // @todo The dialog opened is extremely difficult to target.
     $this->click('.fc-event-container .fc-event');
+    $this->assertSession()->waitForElement('css', '.jsframe-titlebar-focused');
+    $this->assertSession()->elementTextContains('css', '.jsframe-titlebar-focused', 'Meeting about new seeds');
+
+    $modal = $this->assertSession()->elementExists('css', 'div[id^="window_"][id$="_canvas"]');
+    self::assertNotNull($modal);
+    $this->assertSession()->elementTextContains('css', 'div[id^="window_"][id$="_canvas"]', 'Meeting about new seeds');
+    $this->assertSession()->elementTextContains('css', 'div[id^="window_"][id$="_canvas"]','johnny');
+
+    $civicrm_api = $this->container->get('civicrm_entity.api');
+    $activity = $civicrm_api->get('activity', [
+      'id' => $this->activityId,
+    ]);
+
+    $date = new DrupalDateTime($activity[$this->activityId]['activity_date_time']);
+    $duration = $activity[$this->activityId]['duration'];
+    $start_formatted = $date->format('D, m/d/Y - H:i');
+    $date->add(new \DateInterval("PT{$duration}M"));
+    $end_formatted = $date->format('D, m/d/Y - H:i');
+    $this->assertSession()->pageTextContains($start_formatted . ' - ' . $end_formatted);
   }
 
-  /**
-   * @group debug
-   */
   public function testActivityDragAndUpdate(): void {
     $previous_day = new DrupalDateTime('-1 day');
     $previous_day_formatted = $previous_day->format('Y-m-d');
@@ -134,7 +150,6 @@ final class ActivityFullcalendarViewTest extends CivicrmEntityTestBase {
     );
     $driver->getWebDriverSession()->accept_alert();
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->createScreenshot('../calendar.png');
 
     $civicrm_api = $this->container->get('civicrm_entity.api');
     $activity = $civicrm_api->get('activity', [

--- a/tests/src/FunctionalJavascript/Views/ActivityFullcalendarViewTest.php
+++ b/tests/src/FunctionalJavascript/Views/ActivityFullcalendarViewTest.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\Tests\civicrm_entity\FunctionalJavascript\Views;
 
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver;
 use Drupal\Tests\civicrm_entity\FunctionalJavascript\CivicrmEntityTestBase;
 
 /**
@@ -11,10 +13,27 @@ final class ActivityFullcalendarViewTest extends CivicrmEntityTestBase {
 
   /**
    * {@inheritdoc}
+   *
+   * @todo fix config schema from this module for Views.
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * The test activity.
+   *
+   * @var mixed
+   */
+  private $activityId;
+
+
+  /**
+   * {@inheritdoc}
    */
   protected static $modules = [
-    'fullcalendar_view',
+    'civicrm_entity_fullcalendar_test',
   ];
+
+
 
   /**
    * {@inheritdoc}
@@ -23,6 +42,14 @@ final class ActivityFullcalendarViewTest extends CivicrmEntityTestBase {
    */
   public function setUp(): void {
     parent::setUp();
+
+    $admin_user = $this->createUser([
+      'access content',
+      'administer civicrm entity',
+    ]);
+    $this->drupalLogin($admin_user);
+    $this->enableCivicrmEntityTypes(['civicrm_activity', 'civicrm_contact']);
+
     $civicrm_api = $this->container->get('civicrm_entity.api');
     $result = $civicrm_api->save('Contact', [
       'contact_type' => 'Individual',
@@ -31,16 +58,81 @@ final class ActivityFullcalendarViewTest extends CivicrmEntityTestBase {
       'email' => 'johnny@example.com',
     ]);
     $contact_id = $result['id'];
-    $civicrm_api->save('Activity', [
+    $user = $this->createUser([], 'johnny');
+
+    // Verify the user and contact linked.
+    $fetched_contact_id = \CRM_Core_BAO_UFMatch::getContactId($user->id());
+    self::assertEquals($contact_id, $fetched_contact_id);
+
+    $date = new DrupalDateTime('now');
+    $result = $civicrm_api->save('Activity', [
       'source_contact_id' => $contact_id,
       'activity_type_id' => 'Meeting',
       'subject' => 'Meeting about new seeds',
-      'activity_date_time' => '2011-06-02 14:36:13',
+      'activity_date_time' => $date->format('Y-m-d') . ' 12:00:00',
       'status_id' => 2,
       'priority_id' => 1,
       'duration' => 120,
       'location' => 'Pennsylvania',
       'details' => 'We need to find more seeds!',
+    ]);
+    $this->activityId = $result['id'];
+
+    \Drupal::configFactory()
+      ->getEditable('views.settings')
+      ->set('ui.always_live_preview', FALSE)
+      ->set('ui.show.advanced_column', TRUE)
+      ->save();
+  }
+
+  public function testFullcalendarDisplay() {
+    $this->drupalGet('/activity-fullcalendar');
+    $this->createScreenshot('../calendar.png');
+    $fullcalendar = $this->assertSession()->elementExists('css', '.js-drupal-fullcalendar');
+    $this->assertSession()->elementExists('css', '.fc-event-container', $fullcalendar);
+    $this->assertSession()->elementTextContains('css', '.fc-event-container .fc-time', '12:00 pm');
+    $this->assertSession()->elementTextContains('css', '.fc-event-container .fc-title', 'Meeting about new seeds');
+  }
+
+  /**
+   * @group debug
+   */
+  public function testActivityDragAndUpdate() {
+    $previous_day = new DrupalDateTime('-1 day');
+    $previous_day_formatted = $previous_day->format('Y-m-d');
+
+    $this->drupalGet('/activity-fullcalendar');
+    $fullcalendar = $this->assertSession()->elementExists('css', '.js-drupal-fullcalendar');
+    $event = $this->assertSession()->elementExists('css', '.fc-event-container .fc-event', $fullcalendar);
+    $destination = $this->assertSession()->elementExists('css', ".fc-bg [data-date='$previous_day_formatted']", $fullcalendar);
+
+    // @todo WebDriver\Exception\UnexpectedAlertOpen exception fix
+    // Why doesn't \Drupal\FunctionalJavascriptTests\Ajax\CommandsTest::testAjaxCommands fail?
+    // Or \Drupal\FunctionalJavascriptTests\BrowserWithJavascriptTest::drupalGetWithAlert
+    $event->dragTo($destination);
+    // Wait for the alert to appear.
+    $this->getSession()->getPage()->waitFor(10, function () {
+      try {
+        $driver = $this->getSession()->getDriver();
+        assert($driver instanceof DrupalSelenium2Driver);
+        $driver->getWebDriverSession()->getAlert_text();
+        return TRUE;
+      }
+      catch (\Exception $e) {
+        return FALSE;
+      }
+    });
+    $driver = $this->getSession()->getDriver();
+    assert($driver instanceof DrupalSelenium2Driver);
+    $alert_text = $driver->getWebDriverSession()->getAlert_text();
+    $this->assertEquals('Alert', $alert_text);
+    $driver->getWebDriverSession()->accept_alert();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->createScreenshot('../calendar.png');
+
+    $civicrm_api = $this->container->get('civicrm_entity.api');
+    $activity = $civicrm_api->get('activity', [
+      'id' => $this->activityId,
     ]);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
The example Fullcalendar View setup from @KarinG has complex usages of CiviCRM Entity + Views.

It'll cover CiviCRM Activity -> CiviCRM Contact -> Drupal User relationships. It'll also cover using Drupal User fields as a contextual filter. It also provides in-direct date testing with Activities since they need to render properly in the calendar.

Currently draft.

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_

Release notes snippet
----------------------------------------
_The notes to be added on the release_
