### PR TITLE
infinite loop when checking username existance

### DIFF
--- a/src/Plugin/RulesAction/UserCreate.php
+++ b/src/Plugin/RulesAction/UserCreate.php
@@ -21,32 +21,32 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *      "contact_id" = @ContextDefinition("integer",
  *        label = @Translation("CiviCRM contact ID"),
  *        description = @Translation("The CiviCRM contact ID."),
- *        required = TRUE,
+ *        required = TRUE
  *      ),
  *      "is_active" = @ContextDefinition("boolean",
  *        label = @Translation("Activate account"),
  *        description = @Translation("Set to TRUE to activate account. Leave empty to not activate the account. Defaults to TRUE."),
  *        assignment_restriction = "input",
  *        default_value = TRUE,
- *        required = FALSE,
+ *        required = FALSE
  *      ),
  *      "notify" = @ContextDefinition("boolean",
  *        label = @Translation("Send account notification email"),
  *        description = @Translation("Set to TRUE to send a notification email. Leave empty to not send an account notification email."),
  *        assignment_restriction = "input",
  *        default_value = TRUE,
- *        required = FALSE,
+ *        required = FALSE
  *      ),
  *      "signin" = @ContextDefinition("boolean",
  *        label = @Translation("Instant signin"),
  *        description = @Translation("Set to TRUE to automatically log in the user. Leave empty to not automatically log in the user."),
  *        assignment_restriction = "input",
  *        default_value = TRUE,
- *        required = FALSE,
+ *        required = FALSE
  *      ),
  *      "format" = @ContextDefinition("string",
  *        label = @Translation("Format"),
- *        description = @Translation("Format of the username."),
+ *        description = @Translation("Format of the username.")
  *      )
  *   },
  *   provides = {

--- a/src/Plugin/RulesAction/UserCreate.php
+++ b/src/Plugin/RulesAction/UserCreate.php
@@ -21,28 +21,28 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *      "contact_id" = @ContextDefinition("integer",
  *        label = @Translation("CiviCRM contact ID"),
  *        description = @Translation("The CiviCRM contact ID."),
- *        required = TRUE
+ *        required = TRUE,
  *      ),
  *      "is_active" = @ContextDefinition("boolean",
  *        label = @Translation("Activate account"),
  *        description = @Translation("Set to TRUE to activate account. Leave empty to not activate the account. Defaults to TRUE."),
  *        assignment_restriction = "input",
  *        default_value = TRUE,
- *        required = FALSE
+ *        required = FALSE,
  *      ),
  *      "notify" = @ContextDefinition("boolean",
  *        label = @Translation("Send account notification email"),
  *        description = @Translation("Set to TRUE to send a notification email. Leave empty to not send an account notification email."),
  *        assignment_restriction = "input",
  *        default_value = TRUE,
- *        required = FALSE
+ *        required = FALSE,
  *      ),
  *      "signin" = @ContextDefinition("boolean",
  *        label = @Translation("Instant signin"),
  *        description = @Translation("Set to TRUE to automatically log in the user. Leave empty to not automatically log in the user."),
  *        assignment_restriction = "input",
  *        default_value = TRUE,
- *        required = FALSE
+ *        required = FALSE,
  *      ),
  *      "format" = @ContextDefinition("string",
  *        label = @Translation("Format"),
@@ -138,8 +138,12 @@ class UserCreate extends RulesActionBase implements ContainerFactoryPluginInterf
     if ($this->checkUserNameExists($params, $config->userSystem)) {
       $counter = 0;
       do {
-        $params['name'] = $params['name'] . '_' . $counter++;
-      } while ($this->checkUserNameExists($params, $config->userSystem));
+        # try to add an extension to username
+        $params['name'] = $format . '_' . $counter++;
+      } while ($this->checkUserNameExists($params, $config->userSystem)
+              # exit loop if to many errors
+              # Invalid charater in username for example
+              && $counter < 10);
     }
 
     /** @var \Drupal\user\UserInterface $user */

--- a/src/Plugin/RulesAction/UserCreate.php
+++ b/src/Plugin/RulesAction/UserCreate.php
@@ -141,8 +141,8 @@ class UserCreate extends RulesActionBase implements ContainerFactoryPluginInterf
         # try to add an extension to username
         $params['name'] = $format . '_' . $counter++;
       } while ($this->checkUserNameExists($params, $config->userSystem)
-              # exit loop if to many errors
-              # Invalid charater in username for example
+              // exit loop if to many errors
+              // Invalid charater in username for example
               && $counter < 10);
     }
 


### PR DESCRIPTION
checkUserNameExists function does not distinguish between an existing username and an invalid username.
This can generate an infinite loop. Stops after 10 attempts
Also corrects the addition of the extension to the username, to increment the number added at the end and not concatenate the increments.
