### PR TITLE
bumping up drupal and civi test versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,11 @@ jobs:
           - drupal: '^8.9'
             civicrm: '~5.33'
           - drupal: '^8.9'
-            civicrm: '~5.35'
-          - drupal: '^9.1'
-            civicrm: '~5.36'
-          - drupal: '^9.1'
-            civicrm: '5.38.x-dev'
+            civicrm: '~5.39'
+          - drupal: '^9.2'
+            civicrm: '~5.39'
+          - drupal: '^9.2'
+            civicrm: '~5.41'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
       mysql:


### PR DESCRIPTION
Update tests to run with D8.9 5.33 and 5.39 (ESR versions)
D9.2 with 5.39 (ESR) and 5.41 (latest stable)