### PR TITLE
Views custom field plugin, date fields, check for non-empty value before constructing DateTime object

### DIFF
--- a/src/Plugin/views/field/CustomEntityField.php
+++ b/src/Plugin/views/field/CustomEntityField.php
@@ -284,8 +284,10 @@ class CustomEntityField extends EntityField {
 
     switch ($definition->getType()) {
       case 'datetime':
-        $datetime_format = $definition->getSetting('datetime_type') === DateTimeItem::DATETIME_TYPE_DATE ? DateTimeItemInterface::DATE_STORAGE_FORMAT : DateTimeItemInterface::DATETIME_STORAGE_FORMAT;
-        return (new \DateTime($value, new \DateTimeZone(date_default_timezone_get())))->setTimezone(new \DateTimeZone('UTC'))->format($datetime_format);
+        if (!empty($value)) {
+          $datetime_format = $definition->getSetting('datetime_type') === DateTimeItem::DATETIME_TYPE_DATE ? DateTimeItemInterface::DATE_STORAGE_FORMAT : DateTimeItemInterface::DATETIME_STORAGE_FORMAT;
+          return (new \DateTime($value, new \DateTimeZone(date_default_timezone_get())))->setTimezone(new \DateTimeZone('UTC'))->format($datetime_format);
+        }
     }
 
     return $value;


### PR DESCRIPTION
For issue: https://github.com/eileenmcnaughton/civicrm_entity/issues/318

Overview
----------------------------------------
Fixes Views field display of CiviCRM custom date field, displaying "now" date if no value present.

Before
----------------------------------------
Views displays the "now" date when no value for date CiviCRM custom field. 

After
----------------------------------------
No date is displayed when no value for date CiviCRM custom field.
