### PR TITLE
Add extra filters(type, is_active)  to relationship join

### DIFF
--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -513,6 +513,15 @@ class CivicrmEntityViewsData extends EntityViewsData {
 
         break;
 
+      case 'civicrm_relationship':
+        if (isset($views_field['civicrm_contact']['reverse__civicrm_relationship__contact_id_a']['relationship'])) {
+          $views_field['civicrm_contact']['reverse__civicrm_relationship__contact_id_a']['relationship']['id'] = 'civicrm_entity_civicrm_relationship';
+        }
+        elseif (isset($views_field['civicrm_contact']['reverse__civicrm_relationship__contact_id_b']['relationship'])) {
+          $views_field['civicrm_contact']['reverse__civicrm_relationship__contact_id_b']['relationship']['id'] = 'civicrm_entity_civicrm_relationship';
+        }
+        break;
+
       case 'civicrm_case':
         $views_field['civicrm_case']['civicrm_activity'] = [
           'title' => $this->t('CiviCRM activity related to the CiviCRM case'),

--- a/src/Plugin/views/relationship/CiviCrmRelationship.php
+++ b/src/Plugin/views/relationship/CiviCrmRelationship.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\civicrm_entity\Plugin\views\relationship;
+
+use Drupal\civicrm_entity\Plugin\views\relationship\EntityReverse as CivicrmEntityReverse;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Relationship for referencing civicrm_contact and civicrm_relationship.
+ *
+ * @ingroup views_relationship_handlers
+ *
+ * @ViewsRelationship("civicrm_entity_civicrm_relationship")
+ */
+class CiviCrmRelationship extends CivicrmEntityReverse {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+    $options['relationship_type'] = ['default' => []];
+    $options['relationship_state'] = ['default' => FALSE];
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+    $form['relationship_type'] = [
+      '#type' => 'select',
+      '#multiple' => TRUE,
+      '#title' => $this->t('Choose a specific relationship type(s)'),
+      '#default_value' => $this->options['relationship_type'] ?? [],
+      '#options' => $this->getRelationshipTypes(),
+      '#description' => $this->t('Choose to limit this relationship to one or more specific types of CiviCRM relationship.'),
+    ];
+    $form['relationship_state'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Limit results only to active relationships?'),
+      '#description' => $this->t('Exclude relationships that are inactive.'),
+      '#default_value' => !empty($this->options['relationship_state']),
+    ];
+  }
+
+  /**
+   * Get the list of relationship types.
+   */
+  private function getRelationshipTypes() {
+    $relTypes = \Drupal::service('civicrm_entity.api')->get('RelationshipType', [
+      'return' => ["id", "label_a_b", "label_b_a"],
+      'options' => ['limit' => 0],
+    ]);
+    $options = [];
+    foreach ($relTypes as $info) {
+      $options[$info['id']] = "{$info['label_a_b']} | {$info['label_b_a']}";
+    }
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    if (!empty($this->options['relationship_type'])) {
+      $this->definition['extra'][] = [
+        'field' => 'relationship_type_id',
+        'value' => $this->options['relationship_type'],
+      ];
+    }
+
+    if (!empty($this->options['relationship_state'])) {
+      $this->definition['extra'][] = [
+        'field' => 'is_active',
+        'value' => 1,
+      ];
+    }
+    parent::query();
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Add extra filters (type, is_active) to relationship join.

Before
----------------------------------------
In D7, the relationship join has few extra filters added to the on clause.

![image](https://user-images.githubusercontent.com/5929648/141447228-9a61c2d2-1c41-4a3d-85b2-57524aac3cd2.png)

In D9 - these extra conditions for selecting type and state is missing.

![image](https://user-images.githubusercontent.com/5929648/141447426-b8523796-0a6e-42a3-970d-37b53b761087.png)


After
----------------------------------------
Filters are added.

![image](https://user-images.githubusercontent.com/5929648/141447490-ebdee802-e568-481a-94db-9523be3f37ff.png)

Technical Details
----------------------------------------
Added a new handler `civicrm_entity_civicrm_relationship` for relationship join. 

