### PR TITLE
Mailing reports

### DIFF
--- a/civicrm_entity.views.inc
+++ b/civicrm_entity.views.inc
@@ -60,6 +60,81 @@ function civicrm_entity_views_data_alter(&$data) {
   }
   // End: views_views_data_alter() snippet.
   // @codingStandardsIgnoreEnd
+
+  $civicrm_mailing_events = [
+    'civicrm_mailing_event_bounce' => [
+      'title' => t('Bounces'),
+      'description' => t('Total count of Bounces.'),
+      'bao' => 'CRM_Mailing_Event_BAO_Bounce',
+    ],
+    'civicrm_mailing_event_confirm' => [
+      'title' => t('Confirm'),
+      'description' => t('Total count of Confirmations.'),
+      'bao' => 'CRM_Mailing_Event_BAO_Confirm',
+    ],
+    'civicrm_mailing_event_delivered' => [
+      'title' => t('Delivered'),
+      'description' => t('Total count of Delivered.'),
+      'bao' => 'CRM_Mailing_Event_BAO_Delivered',
+    ],
+    'civicrm_mailing_event_forward' => [
+      'title' => t('Forward'),
+      'description' => t('Total count of Forwarded.'),
+      'bao' => 'CRM_Mailing_Event_BAO_Forward',
+    ],
+    'civicrm_mailing_event_opened' => [
+      'title' => t('Opened'),
+      'description' => t('Total count of Opened.'),
+      'bao' => 'CRM_Mailing_Event_BAO_Opened',
+    ],
+    'civicrm_mailing_event_unique_opened' => [
+      'title' => t('Unique Opened'),
+      'description' => t('Total count of Unique Opened.'),
+      'bao' => 'CRM_Mailing_Event_BAO_Opened',
+      'distinct' => TRUE,
+    ],
+    'civicrm_mailing_event_reply' => [
+      'title' => t('Reply'),
+      'description' => t('Total count of Replies.'),
+      'bao' => 'CRM_Mailing_Event_BAO_Reply',
+    ],
+    'civicrm_mailing_event_subscribe' => [
+      'title' => t('Subscribe'),
+      'description' => t('Total count of Subscriptions.'),
+      'bao' => 'CRM_Mailing_Event_BAO_Subscribe',
+    ],
+    'civicrm_mailing_event_trackable_url_open' => [
+      'title' => t('Trackable URL Open'),
+      'description' => t('Total count of Trackable URL Opened.'),
+      'bao' => 'CRM_Mailing_Event_BAO_TrackableURLOpen',
+    ],
+    'civicrm_mailing_event_unsubscribe' => [
+      'title' => t('Unsubscribe'),
+      'description' => t('Total count of Unsubscribes.'),
+      'bao' => 'CRM_Mailing_Event_BAO_Unsubscribe',
+    ],
+  ];
+
+  foreach ($civicrm_mailing_events as $table => $value) {
+    $key = str_replace('civicrm_mailing_event_', '', $table);
+    $data['civicrm_mailing'][$key] = [
+      'title' => $value['title'],
+      'help' => $value['description'],
+      'real field' => 'id',
+      'field' => [
+        'id' => 'civicrm_entity_mailing_event',
+        'bao' => $value['bao'],
+        'distinct' => !empty($value['distinct']) ? TRUE : FALSE,
+      ],
+    ];
+  }
+
+  $data['civicrm_mailing']['opened_rate'] = [
+    'title' => t('Opened Rate'),
+    'help' => t('Total count of Opened Rate.'),
+    'real field' => 'id',
+    'field' => ['id' => 'civicrm_entity_mailing_event_opened_rate'],
+  ];
 }
 
 /**

--- a/src/Plugin/views/field/MailingEvent.php
+++ b/src/Plugin/views/field/MailingEvent.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\civicrm_entity\Plugin\views\field;
+
+use Drupal\views\Plugin\views\field\NumericField;
+use Drupal\views\ResultRow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class for MailingJobOpened.
+ *
+ * @ViewsField("civicrm_entity_mailing_event")
+ */
+class MailingEvent extends NumericField {
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * The CiviCRM API.
+   *
+   * @var \Drupal\civicrm_entity\CiviCrmApi
+   */
+  protected $civicrmApi;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->civicrmApi = $container->get('civicrm_entity.api');
+    $instance->database = $container->get('database');
+
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(ResultRow $values, $field = NULL) {
+    $value = parent::getValue($values, $field);
+
+    if (!class_exists($this->definition['bao'])) {
+      $this->civicrmApi->civicrmInitialize();
+    }
+
+    $bao = $this->definition['bao'];
+    $count = $this->definition['distinct'] ? $bao::getTotalCount($value, NULL, TRUE) : $bao::getTotalCount($value);
+
+    return $count ? $count : 0;
+  }
+
+}

--- a/src/Plugin/views/field/MailingEventOpenedRate.php
+++ b/src/Plugin/views/field/MailingEventOpenedRate.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\civicrm_entity\Plugin\views\field;
+
+use Drupal\views\Plugin\views\field\NumericField;
+use Drupal\views\ResultRow;
+
+/**
+ * Class for MailingEventOpenedRate.
+ *
+ * @ViewsField("civicrm_entity_mailing_event_opened_rate")
+ */
+class MailingEventOpenedRate extends MailingEvent {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(ResultRow $values, $field = NULL) {
+    $value = NumericField::getValue($values);
+
+    if (!class_exists('CRM_Mailing_Event_BAO_Delivered') || !class_exists('CRM_Mailing_Event_BAO_Opened')) {
+      $this->civicrmApi->civicrmInitialize();
+    }
+
+    $delivered = \CRM_Mailing_Event_BAO_Delivered::getTotalCount($value);
+    $opened = \CRM_Mailing_Event_BAO_Opened::getTotalCount($value, NULL, TRUE);
+
+    return number_format($delivered ? (($opened / $delivered) * 100) : 0, 2);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Exposes mailing report fields from /civicrm/mailing/report?mid=<MAILING_ID>&reset=1 as views fields. Yeah, these are only views plugins since there doesn't seem to be API v3 support for "civicrm_mailing_events_*".

There are no sorting nor filter support though. Example [screenshot](https://i.imgur.com/ehJGrLY.png).

Before
----------------------------------------
No mailing reports.

After
----------------------------------------
Additional fields for CiviCRM Mailing:

* Bounce
* Confirm
* Delivered
* Forward
* Opened
* Unique Opened
* Reply
* Subscribe
* Trackable URL Open
* Unsubscribe
* Opened Rate

Technical Details
----------------------------------------
The field plugins make use of `\CRM_Mailing_Event_BAO_*::getTotalCount()`.