### PR TITLE
Use getWhere when class is SearchApiQuery.

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -502,7 +502,13 @@ function civicrm_entity_views_query_alter(ViewExecutable $view, QueryPluginBase 
         $affectedColumns[] = "{$table}.{$column}";
       }
     }
-    foreach ($query->where as &$condition_group) {
+    $class = get_class($query);
+    if ($class == 'Drupal\search_api\Plugin\views\query\SearchApiQuery') {
+      $where = $query->getWhere();
+    } else {
+      $where = $query->where;
+    }
+    foreach ($where as &$condition_group) {
       foreach ($condition_group['conditions'] as &$condition) {
         if (!is_object($condition['field'])) {
           foreach ($affectedColumns as $aff_column) {

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -520,9 +520,11 @@ function civicrm_entity_views_query_alter(ViewExecutable $view, QueryPluginBase 
       }
     }
 
-    foreach ($query->fields as &$field) {
-      if (array_key_exists($field['table'], $columns) && array_key_exists($field['field'], $columns[$field['table']])) {
-        $field['field'] .= $dbLocale;
+    if ($query->fields) {
+      foreach ($query->fields as &$field) {
+        if (array_key_exists($field['table'], $columns) && array_key_exists($field['field'], $columns[$field['table']])) {
+          $field['field'] .= $dbLocale;
+        }
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
After installing this module, and having Search API in the site, when I go to a page that has a view that uses a search index I get the error:

The website encountered an unexpected error. Please try again later.
Error: Cannot access protected property Drupal\search_api\Plugin\views\query\SearchApiQuery::$where in civicrm_entity_views_query_alter() (line 505 of modules/contrib/civicrm_entity/civicrm_entity.module).
civicrm_entity_views_query_alter(Object, Object)
call_user_func_array('civicrm_entity_views_query_alter', Array) (Line: 403)
Drupal\Core\Extension\ModuleHandler->invokeAll('views_query_alter', Array) (Line: 537)

Before
----------------------------------------
- Create a view that uses a Search API index and place it somewhere in your site.
- Enable the civicrm_entity module.
- Go to see the view results.
- The site breaks with the error shown before.

After
----------------------------------------
The site is back up working.

Technical Details
----------------------------------------
Here I'm checking what class corresponds to the query and then we get the conditions depending on it, so that if it is Drupal\search_api\Plugin\views\query\SearchApiQuery then we use the method getWhere, and otherwise we access the property directly.

I'm also checking if $query->fields exists before doing the foreach to prevent a warning message that was being logged.

Release notes snippet
----------------------------------------
Use getWhere when class is SearchApiQuery.