### PR TITLE
Test additions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
           cd ~/drupal/web
           ../vendor/bin/phpunit -c core modules/contrib/civicrm_entity
         env:
-          SYMFONY_DEPRECATIONS_HELPER: weak
+          SYMFONY_DEPRECATIONS_HELPER: disabled
           SIMPLETEST_DB: mysql://root:@127.0.0.1:${{ job.services.mysql.ports[3306] }}/db
           SIMPLETEST_CIVICRM_DB: mysql://root:@127.0.0.1:${{ job.services.mysql.ports[3306] }}/db_civicrm
           SIMPLETEST_BASE_URL: http://127.0.0.1:8080

--- a/tests/src/FunctionalJavascript/CivicrmEntityViewsTestBase.php
+++ b/tests/src/FunctionalJavascript/CivicrmEntityViewsTestBase.php
@@ -144,15 +144,38 @@ abstract class CivicrmEntityViewsTestBase extends CivicrmEntityTestBase {
     $this->assertViewWithRelationshipsResults();
   }
 
-  // @todo testCreateViewWithFilters()
-  // @todo testCreateViewWithSorts()
-  // @todo testCreateViewWithRelationships()
+  /**
+   * Tests creating a view with filters for the entity type.
+   */
+  public function testViewWithFilters() {
+    $this->createNewView();
+    $this->doSetupViewWithFilters();
+    $this->getSession()->getPage()->pressButton('Save');
+    $this->drupalGet('/' . static::$civicrmEntityTypeId);
+    $this->htmlOutput();
+    $this->assertViewWithFiltersResults();
+  }
 
+  /**
+   * Tests creating a view with sorts for the entity type.
+   */
+  public function testViewWithSorts() {
+    $this->createNewView();
+    $this->doSetupViewWithSorts();
+    $this->getSession()->getPage()->pressButton('Save');
+    $this->drupalGet('/' . static::$civicrmEntityTypeId);
+    $this->htmlOutput();
+    $this->assertViewWithSortsResults();
+  }
+
+  // @todo testCreateViewWithRelationships()
 
   /**
    * Creates sample data for each test.
    *
    * @return void
+   *
+   * @todo Should this use data providers?
    */
   abstract protected function createSampleData();
 
@@ -183,6 +206,34 @@ abstract class CivicrmEntityViewsTestBase extends CivicrmEntityTestBase {
    * @return void
    */
   abstract protected function assertViewWithRelationshipsResults();
+
+  /**
+   * Runs setup for the ::testViewWithFilters test.
+   *
+   * @return void
+   */
+  abstract protected function doSetupViewWithFilters();
+
+  /**
+   * Runs assertions for the ::testViewWithFilters test.
+   *
+   * @return void
+   */
+  abstract protected function assertViewWithFiltersResults();
+
+  /**
+   * Runs setup for the ::testViewWithSorts test.
+   *
+   * @return void
+   */
+  abstract protected function doSetupViewWithSorts();
+
+  /**
+   * Runs assertions for the ::testViewWithFilters test.
+   *
+   * @return void
+   */
+  abstract protected function assertViewWithSortsResults();
 
   /**
    * Creates a new View for the tested entity type.
@@ -224,6 +275,16 @@ abstract class CivicrmEntityViewsTestBase extends CivicrmEntityTestBase {
     $this->submitViewsDialog();
   }
 
+  /**
+   * Adds a relationship to a Views display.
+   *
+   * @param string $name_locator
+   *   The relationship's checkbox locator.
+   * @param array $configuration
+   *   The relationship's display configuration.
+   *
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   */
   protected function addRelationshipToDisplay(string $name_locator, array $configuration = []) {
     $this->clickAjaxLink('views-add-relationship');
     $this->getSession()->getPage()->checkField($name_locator);
@@ -235,6 +296,47 @@ abstract class CivicrmEntityViewsTestBase extends CivicrmEntityTestBase {
     $this->submitViewsDialog();
   }
 
+  /**
+   * Adds a sort to a Views display.
+   *
+   * @param string $name_locator
+   *   The filter's checkbox locator.
+   * @param array $configuration
+   *   The filter's display configuration.
+   *
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   */
+  protected function addSortToDisplay(string $name_locator, array $configuration = []) {
+    $this->clickAjaxLink('views-sort-filter');
+    $this->getSession()->getPage()->checkField($name_locator);
+    $this->submitViewsDialog();
+    foreach ($configuration as $field_name => $value) {
+      $field = $this->assertSession()->fieldExists($field_name);
+      $field->setValue($value);
+    }
+    $this->submitViewsDialog();
+  }
+
+  /**
+   * Adds a filter to a Views display.
+   *
+   * @param string $name_locator
+   *   The filter's checkbox locator.
+   * @param array $configuration
+   *   The filter's display configuration.
+   *
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   */
+  protected function addFilterToDisplay(string $name_locator, array $configuration = []) {
+    $this->clickAjaxLink('views-add-filter');
+    $this->getSession()->getPage()->checkField($name_locator);
+    $this->submitViewsDialog();
+    foreach ($configuration as $field_name => $value) {
+      $field = $this->assertSession()->fieldExists($field_name);
+      $field->setValue($value);
+    }
+    $this->submitViewsDialog();
+  }
   /**
    * Submits a dialog when editing a View.
    */
@@ -257,6 +359,5 @@ abstract class CivicrmEntityViewsTestBase extends CivicrmEntityTestBase {
     $this->getSession()->getPage()->clickLink($locator);
     $this->assertSession()->assertWaitOnAjaxRequest();
   }
-
 
 }

--- a/tests/src/FunctionalJavascript/CivicrmEntityViewsTestBase.php
+++ b/tests/src/FunctionalJavascript/CivicrmEntityViewsTestBase.php
@@ -168,7 +168,22 @@ abstract class CivicrmEntityViewsTestBase extends CivicrmEntityTestBase {
     $this->assertViewWithSortsResults();
   }
 
-  // @todo testCreateViewWithRelationships()
+  /**
+   * Tests creating a view with arguments for the entity type.
+   *
+   * @param array $arguments
+   *   The views arguments.
+   *
+   * @dataProvider dataArgumentValues
+   */
+  public function testViewWithArguments(array $arguments) {
+    $this->createNewView();
+    $this->doSetupViewWithArguments();
+    $this->getSession()->getPage()->pressButton('Save');
+    $this->drupalGet('/' . static::$civicrmEntityTypeId . '/' . implode('/', $arguments));
+    $this->htmlOutput();
+    $this->assertViewWithArgumentsResults($arguments);
+  }
 
   /**
    * Creates sample data for each test.
@@ -229,11 +244,36 @@ abstract class CivicrmEntityViewsTestBase extends CivicrmEntityTestBase {
   abstract protected function doSetupViewWithSorts();
 
   /**
-   * Runs assertions for the ::testViewWithFilters test.
+   * Runs assertions for the ::testViewWithSorts test.
    *
    * @return void
    */
   abstract protected function assertViewWithSortsResults();
+
+  /**
+   * Runs setup for the ::testViewWithArguments test.
+   *
+   * @return void
+   */
+  abstract protected function doSetupViewWithArguments();
+
+  /**
+   * Runs assertions for the ::testViewWithArguments test.
+   *
+   * @param array $arguments
+   *   The views arguments.
+   *
+   * @return void
+   */
+  abstract protected function assertViewWithArgumentsResults(array $arguments);
+
+  /**
+   * The arguments test data provider.
+   *
+   * @return \Generator
+   *   The arguments test data.
+   */
+  abstract public function dataArgumentValues();
 
   /**
    * Creates a new View for the tested entity type.
@@ -307,7 +347,7 @@ abstract class CivicrmEntityViewsTestBase extends CivicrmEntityTestBase {
    * @throws \Behat\Mink\Exception\ElementNotFoundException
    */
   protected function addSortToDisplay(string $name_locator, array $configuration = []) {
-    $this->clickAjaxLink('views-sort-filter');
+    $this->clickAjaxLink('views-add-sort');
     $this->getSession()->getPage()->checkField($name_locator);
     $this->submitViewsDialog();
     foreach ($configuration as $field_name => $value) {
@@ -337,6 +377,28 @@ abstract class CivicrmEntityViewsTestBase extends CivicrmEntityTestBase {
     }
     $this->submitViewsDialog();
   }
+
+  /**
+   * Adds a argument to a Views display.
+   *
+   * @param string $name_locator
+   *   The filter's checkbox locator.
+   * @param array $configuration
+   *   The filter's display configuration.
+   *
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   */
+  protected function addArgumentToDisplay(string $name_locator, array $configuration = []) {
+    $this->clickAjaxLink('views-add-argument');
+    $this->getSession()->getPage()->checkField($name_locator);
+    $this->submitViewsDialog();
+    foreach ($configuration as $field_name => $value) {
+      $field = $this->assertSession()->fieldExists($field_name);
+      $field->setValue($value);
+    }
+    $this->submitViewsDialog();
+  }
+
   /**
    * Submits a dialog when editing a View.
    */

--- a/tests/src/FunctionalJavascript/Views/CivicrmActivityViewsTest.php
+++ b/tests/src/FunctionalJavascript/Views/CivicrmActivityViewsTest.php
@@ -44,6 +44,17 @@ final class CivicrmActivityViewsTest extends CivicrmEntityViewsTestBase {
       'location' => 'Pennsylvania',
       'details' => 'We need to find more seeds!',
     ]);
+    $civicrm_api->save('Activity', [
+      'source_contact_id' => $contact_id,
+      'activity_type_id' => 'Email',
+      'subject' => 'Email about new seeds',
+      'activity_date_time' => '2011-06-03 14:36:13',
+      'status_id' => 2,
+      'priority_id' => 1,
+      'duration' => 120,
+      'location' => 'Texas',
+      'details' => 'We just got new seeds.',
+    ]);
   }
 
   /**
@@ -83,6 +94,89 @@ final class CivicrmActivityViewsTest extends CivicrmEntityViewsTestBase {
     $assert_session = $this->assertSession();
     $assert_session->pageTextContains('Meeting about new seeds');
     $assert_session->pageTextContains('Johnny Appleseed');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doSetupViewWithFilters() {
+    $this->addFilterToDisplay('name[civicrm_activity.activity_type_id]', [
+      'options[operator]' => 'or',
+      'options[value][]' => [1],
+    ]);
+
+    $this->addFieldToDisplay('name[civicrm_activity.details__value]');
+    $this->addFieldToDisplay('name[civicrm_activity.location]');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertViewWithFiltersResults() {
+    $assert_session = $this->assertSession();
+    $assert_session->pageTextContains('Meeting about new seeds');
+    $assert_session->pageTextContains('We need to find more seeds!');
+    $assert_session->pageTextContains('Pennsylvania');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doSetupViewWithSorts() {
+    $this->addSortToDisplay('name[civicrm_activity.id]', [
+      'options[order]' => 'DESC',
+    ]);
+
+    $this->addFieldToDisplay('name[civicrm_activity.details__value]');
+    $this->addFieldToDisplay('name[civicrm_activity.location]');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertViewWithSortsResults() {
+    $assert_session = $this->assertSession();
+    $assert_session->elementTextContains('css', '.views-row:first-child', 'Email about new seeds');
+    $assert_session->elementTextContains('css', '.views-row:first-child', 'We just got new seeds.');
+    $assert_session->elementTextContains('css', '.views-row:first-child', 'Texas');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doSetupViewWithArguments() {
+    $this->addArgumentToDisplay('name[civicrm_activity.id]');
+    $this->addFieldToDisplay('name[civicrm_activity.details__value]');
+    $this->addFieldToDisplay('name[civicrm_activity.location]');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertViewWithArgumentsResults(array $arguments) {
+    $assert_session = $this->assertSession();
+
+    switch ($arguments[0]) {
+      case 1:
+        $assert_session->pageTextContainsOnce('Meeting about new seeds');
+        $assert_session->pageTextContainsOnce('We need to find more seeds!');
+        $assert_session->pageTextContainsOnce('Pennsylvania');
+        break;
+
+      case 2:
+        $assert_session->pageTextContainsOnce('Email about new seeds');
+        $assert_session->pageTextContainsOnce('We just got new seeds.');
+        $assert_session->pageTextContainsOnce('Texas');
+        break;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function dataArgumentValues() {
+    yield [[1]];
+    yield [[2]];
   }
 
 }

--- a/tests/src/FunctionalJavascript/Views/CivicrmAddressViewsTest.php
+++ b/tests/src/FunctionalJavascript/Views/CivicrmAddressViewsTest.php
@@ -60,9 +60,14 @@ final class CivicrmAddressViewsTest extends CivicrmEntityViewsTestBase {
    * {@inheritdoc}
    */
   protected function doSetupViewWithRelationships() {
-    $this->addRelationshipToDisplay('name[civicrm_event.created_id]');
+    $this->addRelationshipToDisplay('name[civicrm_address.contact_id]');
     $this->addRelationshipToDisplay('name[civicrm_contact.user]');
     $this->addFieldToDisplay('name[civicrm_contact.display_name]');
+    $this->addFieldToDisplay('name[civicrm_address.location_type_id]');
+    $this->addFieldToDisplay('name[civicrm_address.country_id]');
+    $this->addFieldToDisplay('name[civicrm_address.postal_code]');
+    $this->addFieldToDisplay('name[civicrm_address.state_province_id]');
+    $this->addFieldToDisplay('name[civicrm_address.street_address]');
   }
 
   /**
@@ -70,8 +75,12 @@ final class CivicrmAddressViewsTest extends CivicrmEntityViewsTestBase {
    */
   protected function assertViewWithRelationshipsResults() {
     $assert_session = $this->assertSession();
-    $assert_session->pageTextContains('Annual CiviCRM meet');
-    $assert_session->pageTextContains('Johnny Appleseed');
+    $assert_session->pageTextContainsOnce('Home');
+    $assert_session->pageTextContainsOnce('United States');
+    $assert_session->pageTextContainsOnce('35005');
+    $assert_session->pageTextContainsOnce('Alabama');
+    $assert_session->pageTextContainsOnce('Test');
+    $assert_session->pageTextContainsOnce('Johnny Appleseed');
   }
 
 }

--- a/tests/src/FunctionalJavascript/Views/CivicrmAddressViewsTest.php
+++ b/tests/src/FunctionalJavascript/Views/CivicrmAddressViewsTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\Tests\civicrm_entity\FunctionalJavascript\Views;
+
+use Drupal\Tests\civicrm_entity\FunctionalJavascript\CivicrmEntityViewsTestBase;
+
+final class CivicrmAddressViewsTest extends CivicrmEntityViewsTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $civicrmEntityTypeId = 'civicrm_address';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function createSampleData() {
+    $civicrm_api = $this->container->get('civicrm_entity.api');
+    $result = $civicrm_api->save('Contact', [
+      'contact_type' => 'Individual',
+      'first_name' => 'Johnny',
+      'last_name' => 'Appleseed',
+      'email' => 'johnny@example.com',
+    ]);
+    $contact_id = $result['id'];
+    $civicrm_api->save('Address', [
+      'contact_id' => $contact_id,
+      'location_type_id' => 'Home',
+      'street_address' => 'Test',
+      'country_id' => 'US',
+      'state_province_id' => 'Alabama',
+      'postal_code' => 35005,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doSetupCreateView() {
+    $this->addFieldToDisplay('name[civicrm_address.location_type_id]');
+    $this->addFieldToDisplay('name[civicrm_address.country_id]');
+    $this->addFieldToDisplay('name[civicrm_address.postal_code]');
+    $this->addFieldToDisplay('name[civicrm_address.state_province_id]');
+    $this->addFieldToDisplay('name[civicrm_address.street_address]');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertCreateViewResults() {
+    $assert_session = $this->assertSession();
+    $assert_session->pageTextContainsOnce('Home');
+    $assert_session->pageTextContainsOnce('United States');
+    $assert_session->pageTextContainsOnce('35005');
+    $assert_session->pageTextContainsOnce('Alabama');
+    $assert_session->pageTextContainsOnce('Test');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doSetupViewWithRelationships() {
+    $this->addRelationshipToDisplay('name[civicrm_event.created_id]');
+    $this->addRelationshipToDisplay('name[civicrm_contact.user]');
+    $this->addFieldToDisplay('name[civicrm_contact.display_name]');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertViewWithRelationshipsResults() {
+    $assert_session = $this->assertSession();
+    $assert_session->pageTextContains('Annual CiviCRM meet');
+    $assert_session->pageTextContains('Johnny Appleseed');
+  }
+
+}

--- a/tests/src/FunctionalJavascript/Views/CivicrmAddressViewsTest.php
+++ b/tests/src/FunctionalJavascript/Views/CivicrmAddressViewsTest.php
@@ -31,6 +31,22 @@ final class CivicrmAddressViewsTest extends CivicrmEntityViewsTestBase {
       'state_province_id' => 'Alabama',
       'postal_code' => 35005,
     ]);
+
+    $result = $civicrm_api->save('Contact', [
+      'contact_type' => 'Individual',
+      'first_name' => 'John',
+      'last_name' => 'Doe',
+      'email' => 'john@example.com',
+    ]);
+    $contact_id = $result['id'];
+    $civicrm_api->save('Address', [
+      'contact_id' => $contact_id,
+      'location_type_id' => 'Billing',
+      'street_address' => '3820 Vitruvian Way',
+      'country_id' => 'US',
+      'state_province_id' => 'Texas',
+      'postal_code' => 75001,
+    ]);
   }
 
   /**
@@ -50,7 +66,7 @@ final class CivicrmAddressViewsTest extends CivicrmEntityViewsTestBase {
   protected function assertCreateViewResults() {
     $assert_session = $this->assertSession();
     $assert_session->pageTextContainsOnce('Home');
-    $assert_session->pageTextContainsOnce('United States');
+    $assert_session->pageTextContains('United States');
     $assert_session->pageTextContainsOnce('35005');
     $assert_session->pageTextContainsOnce('Alabama');
     $assert_session->pageTextContainsOnce('Test');
@@ -76,11 +92,115 @@ final class CivicrmAddressViewsTest extends CivicrmEntityViewsTestBase {
   protected function assertViewWithRelationshipsResults() {
     $assert_session = $this->assertSession();
     $assert_session->pageTextContainsOnce('Home');
-    $assert_session->pageTextContainsOnce('United States');
+    $assert_session->pageTextContains('United States');
     $assert_session->pageTextContainsOnce('35005');
     $assert_session->pageTextContainsOnce('Alabama');
     $assert_session->pageTextContainsOnce('Test');
     $assert_session->pageTextContainsOnce('Johnny Appleseed');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doSetupViewWithFilters() {
+    $this->addFilterToDisplay('name[civicrm_address.location_type_id]', [
+      'options[operator]' => 'or',
+      'options[value][]' => [1],
+    ]);
+
+    $this->addFilterToDisplay('name[civicrm_address.state_province_id]', [
+      'options[operator]' => 'or',
+      'options[value][]' => [1000],
+    ]);
+
+    $this->addFieldToDisplay('name[civicrm_address.location_type_id]');
+    $this->addFieldToDisplay('name[civicrm_address.country_id]');
+    $this->addFieldToDisplay('name[civicrm_address.postal_code]');
+    $this->addFieldToDisplay('name[civicrm_address.state_province_id]');
+    $this->addFieldToDisplay('name[civicrm_address.street_address]');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertViewWithFiltersResults() {
+    $assert_session = $this->assertSession();
+    $assert_session->pageTextContainsOnce('Home');
+    $assert_session->pageTextContains('United States');
+    $assert_session->pageTextContainsOnce('35005');
+    $assert_session->pageTextContainsOnce('Alabama');
+    $assert_session->pageTextContainsOnce('Test');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doSetupViewWithSorts() {
+    $this->addSortToDisplay('name[civicrm_address.contact_id]', [
+      'options[order]' => 'DESC',
+    ]);
+
+    $this->addFieldToDisplay('name[civicrm_address.location_type_id]');
+    $this->addFieldToDisplay('name[civicrm_address.country_id]');
+    $this->addFieldToDisplay('name[civicrm_address.postal_code]');
+    $this->addFieldToDisplay('name[civicrm_address.state_province_id]');
+    $this->addFieldToDisplay('name[civicrm_address.street_address]');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertViewWithSortsResults() {
+    $assert_session = $this->assertSession();
+    $assert_session->elementTextContains('css', '.views-row:first-child', 'Texas');
+    $assert_session->elementTextContains('css', '.views-row:first-child', 'United States');
+    $assert_session->elementTextContains('css', '.views-row:first-child', 75001);
+    $assert_session->elementTextContains('css', '.views-row:first-child', '3820 Vitruvian Way');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doSetupViewWithArguments() {
+    $this->addArgumentToDisplay('name[civicrm_address.id]');
+    $this->addFieldToDisplay('name[civicrm_address.location_type_id]');
+    $this->addFieldToDisplay('name[civicrm_address.country_id]');
+    $this->addFieldToDisplay('name[civicrm_address.postal_code]');
+    $this->addFieldToDisplay('name[civicrm_address.state_province_id]');
+    $this->addFieldToDisplay('name[civicrm_address.street_address]');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertViewWithArgumentsResults(array $arguments) {
+    $assert_session = $this->assertSession();
+
+    switch ($arguments[0]) {
+      case 1:
+        $assert_session->pageTextContainsOnce('Home');
+        $assert_session->pageTextContains('United States');
+        $assert_session->pageTextContainsOnce('35005');
+        $assert_session->pageTextContainsOnce('Alabama');
+        $assert_session->pageTextContainsOnce('Test');
+        break;
+
+      case 2:
+        $assert_session->pageTextContainsOnce('Billing');
+        $assert_session->pageTextContains('United States');
+        $assert_session->pageTextContainsOnce(75001);
+        $assert_session->pageTextContainsOnce('Texas');
+        $assert_session->pageTextContainsOnce('3820 Vitruvian Way');
+        break;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function dataArgumentValues() {
+    yield [[1]];
+    yield [[2]];
   }
 
 }

--- a/tests/src/FunctionalJavascript/Views/CivicrmEventViewsTest.php
+++ b/tests/src/FunctionalJavascript/Views/CivicrmEventViewsTest.php
@@ -167,8 +167,8 @@ final class CivicrmEventViewsTest extends CivicrmEntityViewsTestBase {
     $assert_session->elementTextContains('css', '.views-row:first-child', 'Annual Drupal meet');
     $assert_session->elementTextContains('css', '.views-row:first-child', 'This event is intended to give brief idea about progress of Drupal and giving solutions to common user issues');
     $assert_session->elementTextContains('css', '.views-row:first-child', 'If you have any Drupal related issues or want to track where Drupal is heading, Sign up now');
-    $assert_session->elementTextContains('css', '.views-row:first-child', 'Thu, 10/23/2009 - 00:00');
-    $assert_session->elementTextContains('css', '.views-row:first-child', 'Tue, 10/21/2009 - 00:00');
+    $assert_session->elementTextContains('css', '.views-row:first-child', 'Fri, 10/23/2009 - 00:00');
+    $assert_session->elementTextContains('css', '.views-row:first-child', 'Wed, 10/21/2009 - 00:00');
   }
 
   /**
@@ -201,8 +201,8 @@ final class CivicrmEventViewsTest extends CivicrmEntityViewsTestBase {
         $assert_session->pageTextContainsOnce('Annual Drupal meet');
         $assert_session->pageTextContainsOnce('This event is intended to give brief idea about progress of Drupal and giving solutions to common user issues');
         $assert_session->pageTextContainsOnce('If you have any Drupal related issues or want to track where Drupal is heading, Sign up now');
-        $assert_session->pageTextContainsOnce('Thu, 10/23/2009 - 00:00');
-        $assert_session->pageTextContainsOnce('Tue, 10/21/2009 - 00:00');
+        $assert_session->pageTextContainsOnce('Fri, 10/23/2009 - 00:00');
+        $assert_session->pageTextContainsOnce('Wed, 10/21/2009 - 00:00');
         break;
     }
   }

--- a/tests/src/FunctionalJavascript/Views/CivicrmEventViewsTest.php
+++ b/tests/src/FunctionalJavascript/Views/CivicrmEventViewsTest.php
@@ -58,6 +58,24 @@ final class CivicrmEventViewsTest extends CivicrmEntityViewsTestBase {
       'is_show_location' => 0,
       'created_id' => $contact_id,
     ]);
+    $civicrm_api->save('Event', [
+      'title' => 'Annual Drupal meet',
+      'summary' => 'If you have any Drupal related issues or want to track where Drupal is heading, Sign up now',
+      'description' => 'This event is intended to give brief idea about progress of Drupal and giving solutions to common user issues',
+      'event_type_id' => 2,
+      'is_public' => 1,
+      'start_date' => 20091021,
+      'end_date' => 20091023,
+      'is_online_registration' => 1,
+      'registration_start_date' => 20090601,
+      'registration_end_date' => '2009-10-15',
+      'max_participants' => 100,
+      'event_full_text' => 'Sorry! We are already full',
+      'is_monetary' => 0,
+      'is_active' => 1,
+      'is_show_location' => 0,
+      'created_id' => $contact_id,
+    ]);
   }
 
   /**
@@ -98,6 +116,103 @@ final class CivicrmEventViewsTest extends CivicrmEntityViewsTestBase {
     $assert_session = $this->assertSession();
     $assert_session->pageTextContains('Annual CiviCRM meet');
     $assert_session->pageTextContains('Johnny Appleseed');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doSetupViewWithFilters() {
+    $this->addFilterToDisplay('name[civicrm_event.event_type_id]', [
+      'options[operator]' => 'or',
+      'options[value][]' => [1],
+    ]);
+
+    $this->addFieldToDisplay('name[civicrm_event.description__value]');
+    $this->addFieldToDisplay('name[civicrm_event.summary]');
+    $this->addFieldToDisplay('name[civicrm_event.end_date]');
+    $this->addFieldToDisplay('name[civicrm_event.start_date]');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertViewWithFiltersResults() {
+    $assert_session = $this->assertSession();
+    $assert_session->pageTextContainsOnce('Annual CiviCRM meet');
+    $assert_session->pageTextContainsOnce('This event is intended to give brief idea about progress of CiviCRM and giving solutions to common user issues');
+    $assert_session->pageTextContainsOnce('If you have any CiviCRM related issues or want to track where CiviCRM is heading, Sign up now');
+    $assert_session->pageTextContainsOnce('Thu, 10/23/2008 - 00:00');
+    $assert_session->pageTextContainsOnce('Tue, 10/21/2008 - 00:00');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doSetupViewWithSorts() {
+    $this->addSortToDisplay('name[civicrm_event.id]', [
+      'options[order]' => 'DESC',
+    ]);
+
+    $this->addFieldToDisplay('name[civicrm_event.description__value]');
+    $this->addFieldToDisplay('name[civicrm_event.summary]');
+    $this->addFieldToDisplay('name[civicrm_event.end_date]');
+    $this->addFieldToDisplay('name[civicrm_event.start_date]');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertViewWithSortsResults() {
+    $assert_session = $this->assertSession();
+    $assert_session->elementTextContains('css', '.views-row:first-child', 'Annual Drupal meet');
+    $assert_session->elementTextContains('css', '.views-row:first-child', 'This event is intended to give brief idea about progress of Drupal and giving solutions to common user issues');
+    $assert_session->elementTextContains('css', '.views-row:first-child', 'If you have any Drupal related issues or want to track where Drupal is heading, Sign up now');
+    $assert_session->elementTextContains('css', '.views-row:first-child', 'Thu, 10/23/2009 - 00:00');
+    $assert_session->elementTextContains('css', '.views-row:first-child', 'Tue, 10/21/2009 - 00:00');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doSetupViewWithArguments() {
+    $this->addArgumentToDisplay('name[civicrm_event.id]');
+    $this->addFieldToDisplay('name[civicrm_event.description__value]');
+    $this->addFieldToDisplay('name[civicrm_event.summary]');
+    $this->addFieldToDisplay('name[civicrm_event.end_date]');
+    $this->addFieldToDisplay('name[civicrm_event.start_date]');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertViewWithArgumentsResults(array $arguments) {
+    $assert_session = $this->assertSession();
+
+    switch ($arguments[0]) {
+      case 1:
+        $assert_session->pageTextContainsOnce('Annual CiviCRM meet');
+        $assert_session->pageTextContainsOnce('This event is intended to give brief idea about progress of CiviCRM and giving solutions to common user issues');
+        $assert_session->pageTextContainsOnce('If you have any CiviCRM related issues or want to track where CiviCRM is heading, Sign up now');
+        $assert_session->pageTextContainsOnce('Thu, 10/23/2008 - 00:00');
+        $assert_session->pageTextContainsOnce('Tue, 10/21/2008 - 00:00');
+        break;
+
+      case 2:
+        $assert_session->pageTextContainsOnce('Annual Drupal meet');
+        $assert_session->pageTextContainsOnce('This event is intended to give brief idea about progress of Drupal and giving solutions to common user issues');
+        $assert_session->pageTextContainsOnce('If you have any Drupal related issues or want to track where Drupal is heading, Sign up now');
+        $assert_session->pageTextContainsOnce('Thu, 10/23/2009 - 00:00');
+        $assert_session->pageTextContainsOnce('Tue, 10/21/2009 - 00:00');
+        break;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function dataArgumentValues() {
+    yield [[1]];
+    yield [[2]];
   }
 
 }

--- a/tests/src/FunctionalJavascript/Views/CivicrmEventViewsTest.php
+++ b/tests/src/FunctionalJavascript/Views/CivicrmEventViewsTest.php
@@ -33,6 +33,13 @@ final class CivicrmEventViewsTest extends CivicrmEntityViewsTestBase {
    */
   protected function createSampleData() {
     $civicrm_api = $this->container->get('civicrm_entity.api');
+    $result = $civicrm_api->save('Contact', [
+      'contact_type' => 'Individual',
+      'first_name' => 'Johnny',
+      'last_name' => 'Appleseed',
+      'email' => 'johnny@example.com',
+    ]);
+    $contact_id = $result['id'];
     $civicrm_api->save('Event', [
       'title' => 'Annual CiviCRM meet',
       'summary' => 'If you have any CiviCRM related issues or want to track where CiviCRM is heading, Sign up now',
@@ -49,6 +56,7 @@ final class CivicrmEventViewsTest extends CivicrmEntityViewsTestBase {
       'is_monetary' => 0,
       'is_active' => 1,
       'is_show_location' => 0,
+      'created_id' => $contact_id,
     ]);
   }
 
@@ -77,23 +85,19 @@ final class CivicrmEventViewsTest extends CivicrmEntityViewsTestBase {
   /**
    * {@inheritdoc}
    */
-  public function testViewWithRelationships() {
-    // @todo implement setup and assert, then remove this.
-    $this->markTestSkipped('Needs to be implemented');
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   protected function doSetupViewWithRelationships() {
-    // TODO: Implement doSetupViewWithRelationships() method.
+    $this->addRelationshipToDisplay('name[civicrm_event.created_id]');
+    $this->addRelationshipToDisplay('name[civicrm_contact.user]');
+    $this->addFieldToDisplay('name[civicrm_contact.display_name]');
   }
 
   /**
    * {@inheritdoc}
    */
   protected function assertViewWithRelationshipsResults() {
-    // TODO: Implement assertViewWithRelationshipsResults() method.
+    $assert_session = $this->assertSession();
+    $assert_session->pageTextContains('Annual CiviCRM meet');
+    $assert_session->pageTextContains('Johnny Appleseed');
   }
 
 }

--- a/tests/src/Kernel/CivicrmEntityTestBase.php
+++ b/tests/src/Kernel/CivicrmEntityTestBase.php
@@ -69,6 +69,7 @@ abstract class CivicrmEntityTestBase extends KernelTestBase implements ServiceMo
     $this->config('civicrm_entity.settings')
       ->set('enabled_entity_types', [
         'civicrm_event',
+        'civicrm_address',
       ])->save();
     $this->container->get('entity_type.manager')->clearCachedDefinitions();
   }


### PR DESCRIPTION
Overview
----------------------------------------
There are a few `@todo`s in the FunctionalJavascript for views. I've implemented them.

Before
----------------------------------------
Missing tests.

After
----------------------------------------
Added tests.

Technical Details
----------------------------------------
The tests that were added were for the following:

* testViewWithFilters
* testViewWithSorts
* testViewWithArguments

These tests were implemented for the following entity types:

* CiviCRM Activity
* CiviCRM Event
* CiviCRM Address (added this) 

Yeah, I've changed `SYMFONY_DEPRECATORS_HELPER` as well since it was erroring out for D9 jobs due to deprecations.
