### PR TITLE
Use PHP 7.4 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-            php-version: 7.3
+            php-version: 7.4
             extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, soap, intl, gd, exif, iconv
             coverage: none
             tools: composer:v1


### PR DESCRIPTION
Overview
----------------------------------------
7.3 isn't supported anymore. Bumps to 7.4, which also has some performance improvements.
