### PR TITLE
alter views query to set civi tables fully qualified name

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -29,6 +29,7 @@ use Drupal\field\FieldConfigInterface;
 use Drupal\layout_builder\Entity\LayoutBuilderEntityViewDisplay;
 use Drupal\views\ViewExecutable;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\Core\Database\Database;
 
 /**
  * Implements hook_theme().
@@ -490,6 +491,19 @@ function _civicrm_entity_post_invoke($op, $storage, $entity) {
 }
 
 function civicrm_entity_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
+  // Provide fully qualified table name in all Views queries
+  $civicrm_connection_name = drupal_valid_test_ua() ? 'civicrm_test' : 'civicrm';
+  $civicrm_connection = Database::getConnection('default', $civicrm_connection_name);
+  $table_queue =& $query->getTableQueue();
+  foreach ($table_queue as $alias => &$table_info) {
+    if (strpos($table_info['table'], 'civicrm_') === 0 && strpos($table_info['table'], '.') === FALSE) {
+      $table_info['table'] = $civicrm_connection->getFullQualifiedTableName($table_info['table']);
+    }
+    if (!empty($table_info['join']->table) && strpos($table_info['join']->table, 'civicrm_') === 0 && strpos($table_info['join']->table, '.') === FALSE) {
+      $table_info['join']->table = $civicrm_connection->getFullQualifiedTableName($table_info['join']->table);
+    }
+  }
+
   \Drupal::service('civicrm')->initialize();
   $multilingual = \CRM_Core_I18n::isMultilingual();
 

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -491,16 +491,20 @@ function _civicrm_entity_post_invoke($op, $storage, $entity) {
 }
 
 function civicrm_entity_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
-  // Provide fully qualified table name in all Views queries
+  // Provide fully qualified table name in all Views queries.
+  // If CiviCRM tables in a separate database.
   $civicrm_connection_name = drupal_valid_test_ua() ? 'civicrm_test' : 'civicrm';
-  $civicrm_connection = Database::getConnection('default', $civicrm_connection_name);
-  $table_queue =& $query->getTableQueue();
-  foreach ($table_queue as $alias => &$table_info) {
-    if (strpos($table_info['table'], 'civicrm_') === 0 && strpos($table_info['table'], '.') === FALSE) {
-      $table_info['table'] = $civicrm_connection->getFullQualifiedTableName($table_info['table']);
-    }
-    if (!empty($table_info['join']->table) && strpos($table_info['join']->table, 'civicrm_') === 0 && strpos($table_info['join']->table, '.') === FALSE) {
-      $table_info['join']->table = $civicrm_connection->getFullQualifiedTableName($table_info['join']->table);
+  $civicrm_database_info = Database::getConnectionInfo($civicrm_connection_name);
+  if (isset($civicrm_database_info['default'])) {
+    $civicrm_connection = Database::getConnection('default', $civicrm_connection_name);
+    $table_queue =& $query->getTableQueue();
+    foreach ($table_queue as $alias => &$table_info) {
+      if (strpos($table_info['table'], 'civicrm_') === 0 && strpos($table_info['table'], '.') === FALSE) {
+        $table_info['table'] = $civicrm_connection->getFullQualifiedTableName($table_info['table']);
+      }
+      if (!empty($table_info['join']->table) && strpos($table_info['join']->table, 'civicrm_') === 0 && strpos($table_info['join']->table, '.') === FALSE) {
+        $table_info['join']->table = $civicrm_connection->getFullQualifiedTableName($table_info['join']->table);
+      }
     }
   }
 

--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -66,7 +66,7 @@ class CivicrmEntityViewsData extends EntityViewsData {
       // Specify our own views query plugin, to support ensuring the CiviCRM
       // database connection exists in Drupal.
       // @see \Drupal\views\Plugin\views\display\DisplayPluginBase::getPlugin
-      // 'query_id' => 'civicrm_views_query',
+      'query_id' => 'civicrm_views_query',
     ];
     $data[$base_table]['table']['entity revision'] = FALSE;
     if ($label_key = $this->entityType->getKey('label')) {

--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -66,7 +66,7 @@ class CivicrmEntityViewsData extends EntityViewsData {
       // Specify our own views query plugin, to support ensuring the CiviCRM
       // database connection exists in Drupal.
       // @see \Drupal\views\Plugin\views\display\DisplayPluginBase::getPlugin
-      'query_id' => 'civicrm_views_query',
+      // 'query_id' => 'civicrm_views_query',
     ];
     $data[$base_table]['table']['entity revision'] = FALSE;
     if ($label_key = $this->entityType->getKey('label')) {


### PR DESCRIPTION
Overview
----------------------------------------
See issue: https://www.drupal.org/project/civicrm_entity/issues/3198146

In Drupal 9.3, and Civi tables in a separate database, using prefixing is deprecated, and log messages appear informing of this. 
In Drupal 10, database prefixing is likely to be removed. 

Prefixing is what has been done for many years, using in a settings.local.php
$databases['default']['default']['prefix'] array to map CiviCRM tables. 
This will need to be removed, and a database connection similar to:
```
$databases['civicrm']['default'] = array (
  'database' => 'CIVI_DB',
  'username' => 'DB_USERNAME',
  'password' => 'DB_PASSWORD',
  'prefix' => '',
  'host' => 'localhost',
  'port' => '3306',
  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
  'driver' => 'mysql',
);
```

Before
----------------------------------------
CiviCRM Entity 3.0 release had this capability. Unforntunately any View that started with a non-Civi base table, and then related to Civi table, would have a query error. 
It is common to have a View listing users, that then has a Views relationship to the CiviCRM Contact table
Also, adding an Entity Reference field (ERF) from any Drupal entity type, such as Content, then having a View listing content, and adding the ERF relationship, would also break.

After
----------------------------------------
Views starting from Drupal entity type base tables, that relate to Civi tables, when Civi tables in a separate DB, don't have a query error

Technical Details
----------------------------------------
This PR will add code to the civicrm_entity_views_query_alter() hook implementation, to update table names, and join table names, to the fully qualified name, including database, e.g database_name.table_name

Comments
----------------------------------------
This is just a beginning prototype to start testing. 

CE needs to continue to support when the Civi tables are in same DB as Drupal.
Does this work with Multilingual?
Test fields, sorts, filters, contextual filters, and a variety of relationships
Does anything else break that is non-Views, e.g ERF?
Do we still need the Views query plugin in ./src/Plugin/views/query/CivicrmSql.php ?
Search API integration still work?


