### PR TITLE
Test Drupal 9.3 instead of 9.2, bumping one Civi version to 5.44

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,9 @@ jobs:
             civicrm: '5.35.*'
           - drupal: '8.9.*'
             civicrm: '5.39.*'
-          - drupal: '9.2.*'
-            civicrm: '5.43.x-dev'
-          - drupal: '9.2.*'
+          - drupal: '9.3.*'
+            civicrm: '5.44.x-dev'
+          - drupal: '9.3.*'
             civicrm: 'dev-master'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:


### PR DESCRIPTION
Drupal 9.2 is deprecated
Test against Drupal 9.3 and Civi 5.44