### PR TITLE
Views Relationship, for Relationship contact_id_b relationship type and other options

### DIFF
--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -544,7 +544,7 @@ class CivicrmEntityViewsData extends EntityViewsData {
         if (isset($views_field['civicrm_contact']['reverse__civicrm_relationship__contact_id_a']['relationship'])) {
           $views_field['civicrm_contact']['reverse__civicrm_relationship__contact_id_a']['relationship']['id'] = 'civicrm_entity_civicrm_relationship';
         }
-        elseif (isset($views_field['civicrm_contact']['reverse__civicrm_relationship__contact_id_b']['relationship'])) {
+        if (isset($views_field['civicrm_contact']['reverse__civicrm_relationship__contact_id_b']['relationship'])) {
           $views_field['civicrm_contact']['reverse__civicrm_relationship__contact_id_b']['relationship']['id'] = 'civicrm_entity_civicrm_relationship';
         }
         break;


### PR DESCRIPTION
Follow up for https://github.com/eileenmcnaughton/civicrm_entity/pull/336

the "Contact ID B" relationship was not getting set to use the new Views relationship handler, with the options. 

After PR, both relationships have the options. 