### PR TITLE
Use organization name instead.

### DIFF
--- a/civicrm_entity.views.inc
+++ b/civicrm_entity.views.inc
@@ -135,6 +135,8 @@ function civicrm_entity_views_data_alter(&$data) {
     'real field' => 'id',
     'field' => ['id' => 'civicrm_entity_mailing_event_opened_rate'],
   ];
+
+  $data['civicrm_contact']['current_employer']['real field'] = 'organization_name';
 }
 
 /**

--- a/civicrm_entity.views.inc
+++ b/civicrm_entity.views.inc
@@ -137,6 +137,7 @@ function civicrm_entity_views_data_alter(&$data) {
   ];
 
   $data['civicrm_contact']['current_employer']['real field'] = 'organization_name';
+  $data['civicrm_contact']['employer_id']['field']['id'] = 'standard';
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
The filter "Current employer" doesn't work since it's looking for the current_employer which doesn't exist. API3 uses current_employer while the actual column is organization_name. Changed "real field" to use organization_name instead.

Before
----------------------------------------
Adding the filter "Current employer" produces this error:

> SQLSTATE[42S22]: Column not found: 1054 Unknown column 'civicrm_contact.current_employer' in 'where clause': SELECT "civicrm_contact"."id" AS "id" FROM "civicrm_contact" "civicrm_contact" WHERE ((civicrm_contact.contact_type = :civicrm_contact_contact_type)) AND ("civicrm_contact"."current_employer" LIKE :db_condition_placeholder_0 ESCAPE '\\') LIMIT 11 OFFSET 0; Array ( [:civicrm_contact_contact_type] => Individual [:db_condition_placeholder_0] => Default organization )

After
----------------------------------------
Error is gone - https://take.ms/VlQwl.
