### PR TITLE
Handle contact subtype special.

### DIFF
--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -471,6 +471,15 @@ class CivicrmEntityViewsData extends EntityViewsData {
           ],
         ];
 
+        $field_definitions = $this->entityFieldManager->getBaseFieldDefinitions('civicrm_contact');
+        if (!empty($field_definitions) && isset($field_definitions['contact_sub_type'])) {
+          $field_definition = $field_definitions['contact_sub_type'];
+          $views_field['civicrm_contact']['contact_sub_type']['filter']['id'] = 'civicrm_entity_in_operator';
+          $views_field['civicrm_contact']['contact_sub_type']['filter']['options callback'] = 'civicrm_entity_pseudoconstant_options';
+          $views_field['civicrm_contact']['contact_sub_type']['filter']['options arguments'] = $field_definition->getFieldStorageDefinition();
+          $views_field['civicrm_contact']['contact_sub_type']['filter']['multi'] = TRUE;
+        }
+
         break;
 
       case 'civicrm_phone':

--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -471,12 +471,10 @@ class CivicrmEntityViewsData extends EntityViewsData {
           ],
         ];
 
-        $field_definitions = $this->entityFieldManager->getBaseFieldDefinitions('civicrm_contact');
-        if (!empty($field_definitions) && isset($field_definitions['contact_sub_type'])) {
-          $field_definition = $field_definitions['contact_sub_type'];
+        if (isset($views_field['civicrm_contact']['contact_sub_type'])) {
           $views_field['civicrm_contact']['contact_sub_type']['filter']['id'] = 'civicrm_entity_in_operator';
-          $views_field['civicrm_contact']['contact_sub_type']['filter']['options callback'] = 'civicrm_entity_pseudoconstant_options';
-          $views_field['civicrm_contact']['contact_sub_type']['filter']['options arguments'] = $field_definition->getFieldStorageDefinition();
+          $views_field['civicrm_contact']['contact_sub_type']['filter']['options callback'] = '\CRM_Contact_DAO_Contact::buildOptions';
+          $views_field['civicrm_contact']['contact_sub_type']['filter']['options arguments'] = 'contact_sub_type';
           $views_field['civicrm_contact']['contact_sub_type']['filter']['multi'] = TRUE;
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
Use the `civicrm_entity_in_operator` so that it's similar to Drupal 7.

In Drupal 7, the query looks like this:

```
 WHERE (( (civicrm_contact.contact_sub_type LIKE '%Alpha%' ) 
```

In Drupal 9, the query looks like this:

```
WHERE ((civicrm_contact.contact_sub_type = 'Alpha')
```

This doesn't work since contact_sub_type is stored with the `\CRM_Core_DAO::VALUE_SEPARATOR`.

Before
----------------------------------------
Query is like this `WHERE ((civicrm_contact.contact_sub_type = 'Alpha')`.

After
----------------------------------------
Query is like this `AND ((CAST(civicrm_contact.contact_sub_type AS BINARY) RLIKE BINARY 'Alpha|Beta'))`