### PR TITLE
unset SupportedEntities entity types if API Entity.get does not include it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: Integration Tests
 on:
   workflow_dispatch:
   push:
+    branches: [ 8.x-3.x ]
   pull_request:
     types: [assigned, opened, synchronize, reopened]
     branches:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,8 +66,8 @@ jobs:
           composer config minimum-stability dev
           composer config prefer-stable true
           composer config preferred-install dist
-          composer config repositories.0 path $GITHUB_WORKSPACE
-          composer config repositories.1 composer https://packages.drupal.org/8
+          composer config repositories.0 composer https://packages.drupal.org/8
+          composer config repositories.1 path $GITHUB_WORKSPACE
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev-pinned:${{ matrix.drupal }} --no-suggest
       - name: Deal with https://lab.civicrm.org/dev/drupal/-/issues/164
         # This is temporary until no longer testing anything less than 5.41. A more sophisticated way would be to make this conditional on civi version so that for 5.41+ it doesn't do this, giving a closer approximation to real installs for 5.41+, but as far as I know this is only used by compile-lib to make some bootstrap css files.

--- a/src/SupportedEntities.php
+++ b/src/SupportedEntities.php
@@ -705,7 +705,18 @@ $civicrm_entity_info['civicrm_group_contact'] = [
     ];
 
     static::alterEntityInfo($civicrm_entity_info);
-
+    // Check if API finds each entity type.
+    // Necessary for tests/civi upgrade after CiviGrant moved to extension in 5.47.
+    $civicrm_api = \Drupal::service('civicrm_entity.api');
+    $api_entity_types = $civicrm_api->get('entity', ['sequential' => FALSE]);
+    array_walk($api_entity_types, function(&$value) {
+      $value = static::getEntityNameFromCamel($value);
+    });
+    foreach ($civicrm_entity_info as $entity_type => $entity_info) {
+      if (!in_array($entity_info['civicrm entity name'], $api_entity_types)) {
+        unset($civicrm_entity_info[$entity_type]);
+      }
+    }
     return $civicrm_entity_info;
   }
 

--- a/tests/src/Kernel/CivicrmEntityTestBase.php
+++ b/tests/src/Kernel/CivicrmEntityTestBase.php
@@ -162,6 +162,13 @@ abstract class CivicrmEntityTestBase extends KernelTestBase implements ServiceMo
       'Conference' => 'Conference',
     ]);
 
+    $civicrm_api_mock->get('entity', Argument::type('array'))->willReturn([
+      'Event',
+      'Activity',
+      'Contact',
+      'Address',
+    ]);
+
     $container->set('civicrm_entity.api', $civicrm_api_mock->reveal());
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM Core in 5.47 will move CiviGrant to an extension. 

This causes test fails because CiviGrant is not installed by the test suite. 

Also manifested an error on upgrade. 
Before
----------------------------------------
Tests fail

After
----------------------------------------
Tests pass

Technical Details
----------------------------------------
What entity types have always been hardcoded. With entity types being moved to extensions, we have to check if Civi provides that entity type via API.
