### PR TITLE
Add tests for activity contact record filter.

### DIFF
--- a/civicrm_entity.views.inc
+++ b/civicrm_entity.views.inc
@@ -135,6 +135,8 @@ function civicrm_entity_views_data_alter(&$data) {
     'real field' => 'id',
     'field' => ['id' => 'civicrm_entity_mailing_event_opened_rate'],
   ];
+
+  // $data['civicrm_contact']['current_employer']['real field'] = 'organization_name';
 }
 
 /**

--- a/tests/modules/civicrm_entity_test_views/test_views/views.view.test_activity.yml
+++ b/tests/modules/civicrm_entity_test_views/test_views/views.view.test_activity.yml
@@ -1,0 +1,298 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - civicrm_entity
+    - options
+    - text
+id: test_activity
+label: 'Test activity'
+module: views
+description: ''
+tag: ''
+base_table: civicrm_activity
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      fields:
+        subject:
+          id: subject
+          table: civicrm_activity
+          field: subject
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: subject
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        details__value:
+          id: details__value
+          table: civicrm_activity
+          field: details__value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: civicrm_activity
+          entity_field: details
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        location:
+          id: location
+          table: civicrm_activity
+          field: location
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: civicrm_activity
+          entity_field: location
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        id:
+          id: id
+          table: civicrm_activity
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: civicrm_activity
+          entity_field: id
+          plugin_id: standard
+          order: ASC
+          exposed: false
+      arguments: {  }
+      filters: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+      tags: {  }

--- a/tests/src/Kernel/Handler/FilterActivityContactRecordTest.php
+++ b/tests/src/Kernel/Handler/FilterActivityContactRecordTest.php
@@ -11,23 +11,109 @@ use Drupal\views\Views;
  */
 final class FilterActivityContactRecordTest extends KernelHandlerTestBase {
 
-  public static $testViews = ['test_view'];
+  public static $testViews = ['test_activity'];
 
   protected $columnMap = [
-    'contact_type' => 'contact_type',
-    'display_name' => 'display_name',
+    'subject' => 'subject',
+    'location' => 'location',
+    'details__value' => 'details__value',
   ];
 
   /**
-   * Tests general offset.
+   * Tests simple operator.
    */
-  public function testOffset() {
-  }
+  public function testFilter() {
+    $view = Views::getView('test_activity');
 
-  /**
-   * Tests the filter operator between/not between.
-   */
-  protected function testBetween() {
+    $view->setDisplay();
+    $view->displayHandlers->get('default')->overrideOption('filters', [
+      'assignee_id' => [
+        'id' => 'assignee_id',
+        'table' => 'civicrm_activity',
+        'field' => 'assignee_id',
+        'value' => ['value' => 4],
+        'operator' => '=',
+        'entity_type' => 'civicrm_activity',
+        'entity_field' => 'assignee_id',
+        'plugin_id' => 'civicrm_entity_civicrm_activity_contact_record',
+      ],
+    ]);
+
+    $this->executeView($view);
+
+    $expected_result = [
+      [
+        'subject' => 'Email about new seeds',
+        'location' => 'Texas',
+        'details__value' => 'We just got new seeds.',
+      ],
+    ];
+
+    $this->assertCount(1, $view->result);
+    $this->assertIdenticalResultset($view, $expected_result, $this->columnMap);
+
+    $view->destroy();
+
+    $view->setDisplay();
+    $view->displayHandlers->get('default')->overrideOption('filters', [
+      'source_contact_id' => [
+        'id' => 'source_contact_id',
+        'table' => 'civicrm_activity',
+        'field' => 'source_contact_id',
+        'value' => ['value' => 3],
+        'operator' => '=',
+        'entity_type' => 'civicrm_activity',
+        'entity_field' => 'source_contact_id',
+        'plugin_id' => 'civicrm_entity_civicrm_activity_contact_record',
+      ],
+    ]);
+
+    $this->executeView($view);
+
+    $expected_result = [
+      [
+        'subject' => 'Meeting about new seeds',
+        'location' => 'Pennsylvania',
+        'details__value' => 'We need to find more seeds!',
+      ],
+      [
+        'subject' => 'Email about new seeds',
+        'location' => 'Texas',
+        'details__value' => 'We just got new seeds.',
+      ],
+    ];
+
+    $this->assertCount(2, $view->result);
+    $this->assertIdenticalResultset($view, $expected_result, $this->columnMap);
+
+    $view->destroy();
+
+    $view->setDisplay();
+    $view->displayHandlers->get('default')->overrideOption('filters', [
+      'target_id' => [
+        'id' => 'target_id',
+        'table' => 'civicrm_activity',
+        'field' => 'target_id',
+        'value' => ['value' => 4],
+        'operator' => '=',
+        'entity_type' => 'civicrm_activity',
+        'entity_field' => 'target_id',
+        'plugin_id' => 'civicrm_entity_civicrm_activity_contact_record',
+      ],
+    ]);
+
+    $this->executeView($view);
+
+    $expected_result = [
+      [
+        'subject' => 'Meeting about new seeds',
+        'location' => 'Pennsylvania',
+        'details__value' => 'We need to find more seeds!',
+      ],
+    ];
+
+    $this->assertCount(1, $view->result);
+    $this->assertIdenticalResultset($view, $expected_result, $this->columnMap);
   }
 
   /**
@@ -37,24 +123,39 @@ final class FilterActivityContactRecordTest extends KernelHandlerTestBase {
     /** @var \Drupal\civicrm_entity\CiviCrmApi $civicrm_api */
     $civicrm_api = $this->container->get('civicrm_entity.api');
 
-    $result = $civicrm_api->save('CustomGroup', [
-      'title' => 'Test',
-      'extends' => 'Individual',
-    ]);
-
-    $result = reset($result['values']);
-
-    $civicrm_api->save('CustomField', [
-      'custom_group_id' => $result['id'],
-      'label' => 'Test date',
-      "data_type" => 'Date',
-      "html_type" => 'Select Date',
-    ]);
-
-    $contacts = $this->createSampleData();
-
-    foreach ($contacts as $contact) {
+    foreach ($this->createSampleData() as $contact) {
       $civicrm_api->save('Contact', $contact);
+    }
+
+    $activities = [
+      [
+        'subject' => 'Meeting about new seeds',
+        'activity_type_id' => 'Meeting',
+        'location' => 'Pennsylvania',
+        'details' => 'We need to find more seeds!',
+        // Jane Smith.
+        'source_contact_id' => 3,
+        // Jane Smith.
+        'assignee_id' => 3,
+        // John Doe.
+        'target_id' => 4,
+      ],
+      [
+        'subject' => 'Email about new seeds',
+        'activity_type_id' => 'Email',
+        'location' => 'Texas',
+        'details' => 'We just got new seeds.',
+        // Jane Smith.
+        'source_contact_id' => 3,
+        // John Doe.
+        'assignee_id' => 4,
+        // John Smith.
+        'target_id' => 2,
+      ],
+    ];
+
+    foreach ($activities as $activity) {
+      $civicrm_api->save('Activity', $activity);
     }
 
     drupal_flush_all_caches();

--- a/tests/src/Kernel/Handler/FilterActivityContactRecordTest.php
+++ b/tests/src/Kernel/Handler/FilterActivityContactRecordTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\Tests\civicrm_entity\Kernel\Handler;
+
+use Drupal\views\Views;
+
+/**
+ * Test ActivityContactRecord.
+ *
+ * @group civicrim_entity
+ */
+final class FilterActivityContactRecordTest extends KernelHandlerTestBase {
+
+  public static $testViews = ['test_view'];
+
+  protected $columnMap = [
+    'contact_type' => 'contact_type',
+    'display_name' => 'display_name',
+  ];
+
+  /**
+   * Tests general offset.
+   */
+  public function testOffset() {
+  }
+
+  /**
+   * Tests the filter operator between/not between.
+   */
+  protected function testBetween() {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUpFixtures() {
+    /** @var \Drupal\civicrm_entity\CiviCrmApi $civicrm_api */
+    $civicrm_api = $this->container->get('civicrm_entity.api');
+
+    $result = $civicrm_api->save('CustomGroup', [
+      'title' => 'Test',
+      'extends' => 'Individual',
+    ]);
+
+    $result = reset($result['values']);
+
+    $civicrm_api->save('CustomField', [
+      'custom_group_id' => $result['id'],
+      'label' => 'Test date',
+      "data_type" => 'Date',
+      "html_type" => 'Select Date',
+    ]);
+
+    $contacts = $this->createSampleData();
+
+    foreach ($contacts as $contact) {
+      $civicrm_api->save('Contact', $contact);
+    }
+
+    drupal_flush_all_caches();
+  }
+
+  /**
+   * Create sample data.
+   */
+  protected function createSampleData() {
+    return [
+      [
+        'first_name' => 'John',
+        'last_name' => 'Smith',
+        'contact_type' => 'Individual',
+        'custom_1' => date('Y-m-d H:i:s', strtotime('-5 days')),
+      ],
+      [
+        'first_name' => 'Jane',
+        'last_name' => 'Smith',
+        'contact_type' => 'Individual',
+        'custom_1' => date('Y-m-d H:i:s', strtotime('+5 days')),
+      ],
+      [
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'contact_type' => 'Individual',
+        'custom_1' => date('Y-m-d H:i:s', strtotime('-1 month')),
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Add a simple test for "Activity Contact" filter plugin.

Before
----------------------------------------
No test.

After
----------------------------------------
Added a simple test for the custom plugin that tests assignee_id, target_id, and source_contact_id to see if the expected results are taken.