### PR TITLE
Check if VBO exists.

### DIFF
--- a/src/Plugin/Action/CivicrmContactAddToGroup.php
+++ b/src/Plugin/Action/CivicrmContactAddToGroup.php
@@ -11,6 +11,10 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\civicrm_entity\CiviCrmApi;
 
+if (!class_exists('Drupal\views_bulk_operations\Action\ViewsBulkOperationsActionBase')) {
+  return;
+}
+
 /**
  * Action to add CiviCRM Contact to a CiviCRM group
  *


### PR DESCRIPTION
Overview
----------------------------------------
Getting this error when enabling the `action` module and visiting /admin/config/system/actions:

> Error: Class 'Drupal\views_bulk_operations\Action\ViewsBulkOperationsActionBase' not found in include()

Before
----------------------------------------
Error when visiting actions configuration page.

After
----------------------------------------
No error. Action is still displayed as a valid choice when enabling VBO. **The "Actions" configuration page doesn't show this action plugin though.** Although it seems to be already like that with VBO enabled and without the patch.

Comments
----------------------------------------
Not entirely sure if this is the right fix although it seems to allow visiting the actions configuration page and at the same time, shows as an option when VBO is installed.