### PR TITLE
Add sorting option for entityquery.

### DIFF
--- a/src/Entity/Query/CiviCRM/Query.php
+++ b/src/Entity/Query/CiviCRM/Query.php
@@ -57,10 +57,8 @@ class Query extends QueryBase implements QueryInterface {
 
     $this->initializePager();
     if ($this->range) {
-      $params['options'] = [
-        'limit' => $this->range['length'],
-        'offset' => $this->range['start'],
-      ];
+      $params['options']['limit'] = $this->range['length'];
+      $params['options']['offset'] = $this->range['start'];
     }
 
     if ($this->count) {

--- a/src/Entity/Query/CiviCRM/Query.php
+++ b/src/Entity/Query/CiviCRM/Query.php
@@ -48,6 +48,13 @@ class Query extends QueryBase implements QueryInterface {
       }
     }
 
+    $sort = [];
+    foreach ($this->sort as $s) {
+      $sort[] = $s['field'] . ' ' . $s['direction'];
+    }
+
+    $params['options']['sort'] = implode(',', $sort);
+
     $this->initializePager();
     if ($this->range) {
       $params['options'] = [


### PR DESCRIPTION
Overview
----------------------------------------
Doing a sort using `EntityQuery` doesn't work since it's not being passed as  an  option to the API. 

Before
----------------------------------------
Sorting doesn't work. An example is using the following script:

```php
$storage = \Drupal::entityTypeManager()->getStorage('civicrm_contact');
$query = $storage->getQuery()->accessCheck(FALSE)->sort('sort_name', 'ASC')->sort('id',  'DESC')->pager(200);
$result = $query->execute();
$result = $storage->loadMultiple($result);

/** @var  \Drupal\civicrm_entity\Entity\CivicrmEntity $entity */
foreach ($result as $entity) {
  var_dump($entity->get('sort_name')->value);
}
```

Default install outputs the following:

```
string(20) "Default Organization"
string(17) "admin@example.com"
```

After
----------------------------------------
Example script shows:

```
string(17) "admin@example.com"
string(20) "Default Organization"
```

Technical Details
----------------------------------------
EntityQuery sort option is passed to CiviCRM API.