### PR TITLE
Activity Targets not showing up.

### DIFF
--- a/src/CiviCrmApi.php
+++ b/src/CiviCrmApi.php
@@ -67,7 +67,7 @@ class CiviCrmApi implements CiviCrmApiInterface {
   public function getFields($entity, $action = '') {
     $this->initialize();
     $result = civicrm_api3($entity, 'getfields', [
-      'sequential' => 1,
+      // 'sequential' => 1,
       'action' => $action,
     ]);
     return $result['values'];

--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\TypedData\Plugin\DataType\DateTimeIso8601;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItem;
 use Symfony\Component\Validator\ConstraintViolation;
@@ -104,18 +105,18 @@ class CivicrmEntity extends ContentEntityBase {
     $field_definition_provider = \Drupal::service('civicrm_entity.field_definition_provider');
     $civicrm_fields = \Drupal::service('civicrm_entity.api')->getFields($entity_type->get('civicrm_entity'), 'create');
 
-    foreach ($civicrm_fields as $civicrm_field) {
+    foreach ($civicrm_fields as $name => $civicrm_field) {
       // Apply any additional field data provided by the module.
-      if (!empty($civicrm_entity_info['fields'][$civicrm_field['name']])) {
-        $civicrm_field = $civicrm_entity_info['fields'][$civicrm_field['name']] + $civicrm_field;
+      if (!empty($civicrm_entity_info['fields'][$name])) {
+        $civicrm_field = $civicrm_entity_info['fields'][$name] + $civicrm_field;
       }
 
-      $fields[$civicrm_field['name']] = $field_definition_provider->getBaseFieldDefinition($civicrm_field);
-      $fields[$civicrm_field['name']]->setRequired(isset($civicrm_required_fields[$civicrm_field['name']]));
+      $fields[$name] = $field_definition_provider->getBaseFieldDefinition($civicrm_field);
+      $fields[$name]->setRequired(isset($civicrm_required_fields[$name]));
 
-      if ($values = \Drupal::service('civicrm_entity.api')->getCustomFieldMetadata($civicrm_field['name'])) {
-        $fields[$civicrm_field['name']]->setSetting('civicrm_entity_field_metadata', $values);
-        $fields[$civicrm_field['name']]->setRequired((bool) $civicrm_field['is_required']);
+      if ($values = \Drupal::service('civicrm_entity.api')->getCustomFieldMetadata($name)) {
+        $fields[$name]->setSetting('civicrm_entity_field_metadata', $values);
+        $fields[$name]->setRequired((bool) $civicrm_field['is_required']);
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Activity Target is showing empty in the "full" display and in views. For some reason, the name of the field is different from the actual property name. The machine name of the field is `target_contact_id` while the property name is `target_id`.

Before
----------------------------------------
Activity Target not showing up on "full" display of CiviCRM activity and in views.

After
----------------------------------------
Activity Target showing up.

Full display:

![image](https://user-images.githubusercontent.com/34715246/167804926-5a931f51-004d-4da4-a66f-880f500a140e.png)

Views:

![image](https://user-images.githubusercontent.com/34715246/167805130-b1f9df19-e957-47d8-a901-852f1cac4eca.png)

Technical Details
----------------------------------------
In CiviCRM API3, if you do this:

```php
$result = civicrm_api3('Activity', 'getfields', [
  'api_action' => "create",
]);
```

You get the following result:

```json
"target_contact_id": {
    "name": "target_id",
    "title": "Activity Target",
    "description": "Contact(s) participating in this activity.",
    "type": 1,
    "FKClassName": "CRM_Contact_DAO_Contact",
    "FKApiName": "Contact"
},
```

The difference is in the key and the property "name". Loading a CiviCRM entity uses the following:

```php
$result = civicrm_api3('Activity', 'getfields');
```

This results to:

```json
"target_contact_id": {
    "title": "Target Contact ID",
    "description": "Find activities with specified target contact.",
    "type": 1,
    "FKClassName": "CRM_Contact_DAO_Contact",
    "FKApiName": "Contact",
    "name": "target_contact_id"
},
```

The key and property "name" are the same.

The changes make the name and the key consistent instead.

Comments
----------------------------------------
Views still considers "Activity Target" as a single value field wherein the configurations for multivalue fields are not available. I haven't tested the effects of creation of CiviCRM activities although I think most use CE for displaying values instead of creating entities.