### PR TITLE
unset API options, sort for getCount query

### DIFF
--- a/src/Entity/Query/CiviCRM/Query.php
+++ b/src/Entity/Query/CiviCRM/Query.php
@@ -62,6 +62,7 @@ class Query extends QueryBase implements QueryInterface {
     }
 
     if ($this->count) {
+      unset($params['options']['sort']);
       return $this->civicrmApi->getCount($this->entityType->get('civicrm_entity'), $params);
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to: https://github.com/eileenmcnaughton/civicrm_entity/pull/373/files

Before
----------------------------------------
Error on pages like admin/structure/civicrm-entity/civicrm-contact

Due to 'options' => ['sort' => 'id ASC'] being added to query, for the getCount() .. which CiviCRM API throws an error

After
----------------------------------------
No error 
