### PR TITLE
use view_mode from context, entity types with bundles, displaying rendered entity

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -214,9 +214,11 @@ function civicrm_entity_entity_view_display_alter(EntityViewDisplayInterface $di
   if ($entity_type->get('civicrm_entity') && $entity_type->hasKey('bundle')) {
     $entity_display_repository = \Drupal::service('entity_display.repository');
     assert($entity_display_repository instanceof EntityDisplayRepositoryInterface);
+    $view_mode = !empty($context['view_mode']) ? $context['view_mode'] : $entity_display_repository::DEFAULT_DISPLAY_MODE;
     $root_display = $entity_display_repository->getViewDisplay(
       $entity_type->id(),
-      $entity_type->id()
+      $entity_type->id(),
+      $view_mode
     );
     $display->set('content', $root_display->get('content'));
     $display->set('hidden', $root_display->get('hidden'));


### PR DESCRIPTION

Overview
----------------------------------------
When a CiviCRM entity type that has bundles (Activity, Event), and you render an entity of that type, via any view mode that is not 'default', the 'default' view mode is always what renders. 

Reported here:
https://www.drupal.org/project/civicrm_entity/issues/3247663

And by Seamus: 
https://chat.civicrm.org/civicrm/pl/8jor7k7a3bnidf5kxjwdik4dmh

Before
----------------------------------------
When a CiviCRM entity type that has bundles (Activity, Event), and you render an entity of that type, via any view mode that is not 'default', the 'default' view mode is always what renders. 
This can be rendering an entity as a view mode, in Views, or other places.

After
----------------------------------------
Entities render through the correct view mode
