### PR TITLE
Use an "OR" operator for having multiple contact record type.

### DIFF
--- a/src/Plugin/views/relationship/CiviCrmActivityContact.php
+++ b/src/Plugin/views/relationship/CiviCrmActivityContact.php
@@ -51,8 +51,9 @@ class CiviCrmActivityContact extends RelationshipPluginBase {
    */
   public function buildOptionsForm(&$form, FormStateInterface $form_state) {
     $form['record_type_id'] = [
-      '#type' => 'radios',
-      '#options' => ['' => $this->t('- Any -')] + $this->recordTypeMapping,
+      '#type' => 'select',
+      '#multiple' => TRUE,
+      '#options' => $this->recordTypeMapping,
       '#title' => $this->t('Activity contact type'),
       '#default_value' => $this->options['record_type_id'],
     ];
@@ -68,11 +69,14 @@ class CiviCrmActivityContact extends RelationshipPluginBase {
 
     $this->definition['extra'] = [];
     if (!empty($this->options['record_type_id'])) {
-      $this->definition['extra'][] = [
-        'field' => 'record_type_id',
-        'value' => $this->options['record_type_id'],
-        'numeric' => TRUE,
-      ];
+      $record_type = !is_array($this->options['record_type_id']) ? [$this->options['record_type_id']] : $this->options['record_type_id'];
+      foreach ($record_type as $type) {
+        $this->definition['extra'][] = [
+          'field' => 'record_type_id',
+          'value' => $type,
+          'numeric' => TRUE,
+        ];
+      }
     }
   }
 
@@ -100,6 +104,7 @@ class CiviCrmActivityContact extends RelationshipPluginBase {
 
     if (!empty($this->definition['extra'])) {
       $first['extra'] = $this->definition['extra'];
+      $first['extra_operator'] = 'OR';
     }
 
     $first_join = Views::pluginManager('join')->createInstance('standard', $first);

--- a/tests/src/FunctionalJavascript/Views/CivicrmActivityViewsTest.php
+++ b/tests/src/FunctionalJavascript/Views/CivicrmActivityViewsTest.php
@@ -81,7 +81,7 @@ final class CivicrmActivityViewsTest extends CivicrmEntityViewsTestBase {
   protected function doSetupViewWithRelationships() {
     $this->addRelationshipToDisplay('name[civicrm_activity.contact]', [
       // Set relationship to source
-      'options[record_type_id]' => '2',
+      'options[record_type_id][]' => ['2'],
     ]);
     $this->addRelationshipToDisplay('name[civicrm_contact.user]');
     $this->addFieldToDisplay('name[civicrm_contact.display_name]');


### PR DESCRIPTION
Overview
----------------------------------------
Changes the configuration for the "Activity contact type" to allow multiple values and join them using an "OR" statement. This way it can be joined to different types of contacts whether it's the "Assignee", "Source", or "Target".

Before
----------------------------------------
Configuration for Activity Contact relationship only allows a single value with a query similar to `ON civicrm_activity.id = civicrm_activity_contact.activity_id AND civicrm_activity_contact.record_type_id = '2'`.

After
----------------------------------------
Allows this configuration:

![image](https://user-images.githubusercontent.com/34715246/170447642-273ccdfa-5a26-48b4-9d56-93a905fddcd1.png)

It produces a query similar to `ON civicrm_activity.id = civicrm_activity_contact.activity_id AND (civicrm_activity_contact.record_type_id = '2' OR civicrm_activity_contact.record_type_id = '3')`.