### PR TITLE
fix for multi-value filter on views

### DIFF
--- a/src/Plugin/views/filter/InOperator.php
+++ b/src/Plugin/views/filter/InOperator.php
@@ -109,26 +109,29 @@ class InOperator extends BaseInOperator {
     // If this is a multi-value field in CiviCRM, we use 'LIKE' and 'NOT LIKE'
     // instead.
     else {
+
+      $values = array_map(function($value) {
+        return \CRM_Core_DAO::VALUE_SEPARATOR . $value . \CRM_Core_DAO::VALUE_SEPARATOR;
+      }, $values);
+
       switch ($this->operator) {
         case 'in':
-          $values = array_map(function($value) {
-            return \CRM_Core_DAO::VALUE_SEPARATOR . $value . \CRM_Core_DAO::VALUE_SEPARATOR;
-          }, $values);
-
-          $this
-            ->query
-            ->addWhereExpression($this->options['group'], "CAST({$field} AS BINARY) RLIKE BINARY :arg1", [':arg1' => implode('|', $values)]);
+          $this->query
+            ->addWhereExpression(
+              $this->options['group'],
+              "CAST({$field} AS BINARY) RLIKE BINARY :" . $this->realField,
+              [':' . $this->realField => implode('|', $values)]
+            );
 
           break;
 
         case 'not in':
-          $values = array_map(function($value) {
-            return \CRM_Core_DAO::VALUE_SEPARATOR . $value . \CRM_Core_DAO::VALUE_SEPARATOR;
-          }, $values);
-
-          $this
-            ->query
-            ->addWhereExpression($this->options['group'], "CAST({$field} AS BINARY) NOT RLIKE BINARY :arg1", [':arg1' => implode('|', $values)]);
+          $this->query
+            ->addWhereExpression(
+              $this->options['group'],
+              "CAST({$field} AS BINARY) NOT RLIKE BINARY :" . $this->realField,
+              [':' . $this->realField => implode('|', $values)]
+            );
 
           break;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Views results are not filtered when more than one multi-value(checkbox or multiselect) custom field is exposed. When trying to filter two fields.

Steps to replicate:
1. Create two expose filter for multi-select or checkbox custom field.
2. Try to filter the results using both the filters.

Before
----------------------------------------
Filtered incorrectly

After
----------------------------------------
Filtered correctly

Technical Details
----------------------------------------
when filtering the views result with custom fields (more than one), the second filter values are over-ridden from the first filter. Looks like :arg1 is cached and the first value is over-ridden in all where clause. hence we tried to set arg differently for each filter.
