### PR TITLE
Set the view mode for layout builder.

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -215,6 +215,11 @@ function civicrm_entity_entity_view_display_alter(EntityViewDisplayInterface $di
     $entity_display_repository = \Drupal::service('entity_display.repository');
     assert($entity_display_repository instanceof EntityDisplayRepositoryInterface);
     $view_mode = !empty($context['view_mode']) ? $context['view_mode'] : $entity_display_repository::DEFAULT_DISPLAY_MODE;
+
+    if (($display instanceof LayoutBuilderEntityViewDisplay) && $view_mode == 'full') {
+      $view_mode = $entity_display_repository::DEFAULT_DISPLAY_MODE;
+    }
+
     $root_display = $entity_display_repository->getViewDisplay(
       $entity_type->id(),
       $entity_type->id(),


### PR DESCRIPTION
Overview
----------------------------------------
Implementation of bundles is a bit incomplete than the "normal" entity type since I think it's only setting the bundle property. Layout builder is broken since #381. View mode seem to be "Full" when it's supposedly "Default". I've added a workaround instead.

Before
----------------------------------------
Layout builder broken when enabled for entities.

After
----------------------------------------
Layout builder working.

Technical Details
----------------------------------------
Added a workaround to use the "default" view mode when the view mode set is "Full". Using this script, you'll notice that the configuration for entity_view_display is different from node. The format is supposedly "<entity_type_id>.<bundle>.<view_mode>"

```php
<?php

$results = \Drupal::entityQuery('entity_view_display')
  ->condition('targetEntityType', ['node', 'civicrm_event'])
  ->condition('status', TRUE)
  ->execute();

foreach ($results as $row) {
  var_dump($row);
}
```

The result is:

```
string(35) "civicrm_event.civicrm_event.default"
string(20) "node.article.default"
string(16) "node.article.rss"
string(19) "node.article.teaser"
string(17) "node.page.default"
string(16) "node.page.teaser"
```

CE has the format "<entity_type_id>.<entity_type_id>.<view_mode>" which I think is the format for bundle-less entities. It seems to be happening here - https://git.drupalcode.org/project/drupal/-/blob/9.4.1/core/lib/Drupal/Core/Entity/Entity/EntityViewDisplay.php#L91-112.

