### PR TITLE
Adds break that was missed in PR377

### DIFF
--- a/src/Plugin/views/field/CustomEntityField.php
+++ b/src/Plugin/views/field/CustomEntityField.php
@@ -303,7 +303,8 @@ class CustomEntityField extends EntityField {
         // For booleans we want to convert the empty string to NULL to avoid it being displayed as false
         if ($value == '') {
           return NULL;
-        }
+	}
+	break;
     }
 
     return $value;


### PR DESCRIPTION
Overview
----------------------------------------
Adds a break that was missing from the end of the switch context.

As per comment -> https://github.com/eileenmcnaughton/civicrm_entity/pull/377#discussion_r865907641

Before
----------------------------------------
Code execution flowed out of the switch - but if someone added another case they would need to add a break beforehand.

After
----------------------------------------
Tidy up with a break at end of switch statement.