### PR TITLE
Fix for issue 3310451

### DIFF
--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -306,7 +306,12 @@ class CiviEntityStorage extends SqlContentEntityStorage {
       return !in_array($component, $components) ? FALSE :
         $this->getCiviCrmApi()->getCount($this->entityType->get('civicrm_entity')) > 0;
     }
-    return $this->getCiviCrmApi()->getCount($this->entityType->get('civicrm_entity')) > 0;
+    else {
+      $enabled_components_as_entity = $this->getConfigFactory()->get('civicrm_entity.settings')->get('enabled_entity_types');
+      $component = $this->entityType->get('civicrm_entity');
+      return !in_array($component, $enabled_components_as_entity) ? FALSE :
+        $this->getCiviCrmApi()->getCount($this->entityType->get('civicrm_entity')) > 0;
+    }
   }
   /**
    * {@inheritdoc}


### PR DESCRIPTION
Fix for timeout issue reported at https://www.drupal.org/project/civicrm_entity/issues/3310451

Apache logs showed 

````
PHP Fatal error:  Allowed memory size of 536870912 bytes exhausted (tried to allocate 400560128 bytes) in ..../web/vendor/civicrm/civicrm-packages/DB/DataObject.php on line 571
````

On checking I found that hasData tries to get count and other details for all component which exhaust the memory limit and the uninstall page doesn't load.

Now we check only enabled components so that it doesn't try to count every entity.

Thanks,
Sadashiv