### PR TITLE
Add workaround for contribution source not displaying.

### DIFF
--- a/civicrm_entity.views.inc
+++ b/civicrm_entity.views.inc
@@ -138,6 +138,7 @@ function civicrm_entity_views_data_alter(&$data) {
 
   $data['civicrm_contact']['current_employer']['real field'] = 'organization_name';
   $data['civicrm_contact']['employer_id']['field']['id'] = 'standard';
+  $data['civicrm_contribution']['contribution_source']['real field'] = 'source';
 }
 
 /**

--- a/src/CiviCrmApi.php
+++ b/src/CiviCrmApi.php
@@ -31,6 +31,12 @@ class CiviCrmApi implements CiviCrmApiInterface {
    */
   public function get($entity, array $params = []) {
     $this->initialize();
+
+    if ($entity == 'contribution') {
+      $params['return'][] = 'contribution_source';
+      $params['return'] = array_diff($params['return'], ['source']);
+    }
+
     $result = civicrm_api3($entity, 'get', $params);
     return $result['values'];
   }
@@ -70,6 +76,12 @@ class CiviCrmApi implements CiviCrmApiInterface {
       // 'sequential' => 1,
       'action' => $action,
     ]);
+
+    if ($entity == 'contribution' && isset($result['values']['source'])) {
+      $result['values']['contribution_source'] = $result['values']['source'];
+      unset($result['values']['source']);
+    }
+
     return $result['values'];
   }
 

--- a/src/SupportedEntities.php
+++ b/src/SupportedEntities.php
@@ -145,7 +145,7 @@ final class SupportedEntities {
     $civicrm_entity_info['civicrm_contribution'] = [
       'civicrm entity label' => t('Contribution'),
       'civicrm entity name' => 'contribution',
-      'label property' => 'source',
+      'label property' => 'contribution_source',
       'permissions' => [
         'view' => ['access CiviContribute', 'administer CiviCRM'],
         'edit' => ['edit contributions', 'administer CiviCRM'],


### PR DESCRIPTION
Overview
----------------------------------------
Contribution source is not displaying correctly because of CiviCRM API inconsistency. If you do this in the CiviCRM API3 UI - https://take.ms/JwFOF, you'll see that no contribution source is being displayed.

This is what works instead:

```php
$result = civicrm_api3('Contribution', 'get', [
  'sequential' => 1,
  'return' => ["contribution_source", "id"],
  'options' => ['limit' => 2],
]);
```
I've added a workaround instead.

Before
----------------------------------------
No contribution is being displayed.

After
----------------------------------------
Contribution being displayed.