### PR TITLE
leaflet 2.2.9 compatibility

### DIFF
--- a/modules/civicrm_entity_leaflet/src/Plugin/views/style/CivicrmEntityAddressLeafletMap.php
+++ b/modules/civicrm_entity_leaflet/src/Plugin/views/style/CivicrmEntityAddressLeafletMap.php
@@ -447,13 +447,13 @@ class CivicrmEntityAddressLeafletMap extends LeafletMap {
                       // Generate correct Absolute iconUrl & shadowUrl,
                       // if not external.
                       if (!empty($feature['icon']['iconUrl'])) {
-                        $feature['icon']['iconUrl'] = $this->leafletService->pathToAbsolute($feature['icon']['iconUrl']);
+                        $feature['icon']['iconUrl'] = $this->leafletService->generateAbsoluteString($feature['icon']['iconUrl']);
                       }
                     }
                     if (!empty($this->options['icon']['shadowUrl'])) {
                       $feature['icon']['shadowUrl'] = str_replace(["\n", "\r"], "", $this->viewsTokenReplace($this->options['icon']['shadowUrl'], $tokens));
                       if (!empty($feature['icon']['shadowUrl'])) {
-                        $feature['icon']['shadowUrl'] = $this->leafletService->pathToAbsolute($feature['icon']['shadowUrl']);
+                        $feature['icon']['shadowUrl'] = $this->leafletService->generateAbsoluteString($feature['icon']['shadowUrl']);
                       }
                     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Drupal Leaflet 2.2.9 dropped this week.  It removed a function that broke my [leaflet_latlon](https://github.com/MegaphoneJon/leaflet_latlon) module.  This module uses the same function, so I'm guessing that anyone who updates the Leaflet module to the latest version will see all their Civi maps break.

Before
----------------------------------------
Broken maps.

After
----------------------------------------
Working maps.

Technical Details
----------------------------------------
Leaflet [removed the pathToAbsolute function](https://git.drupalcode.org/project/leaflet/-/commit/27c087b12d016799e27afa1146febd8fa0a94841).  It's replaced with [generateAbsoluteString](https://git.drupalcode.org/project/leaflet/-/commit/1554ab74f2c4fc9e2a932f2ef95067bc90d2f790).

Comments
----------------------------------------
I don't use this module, so I haven't tested this!  However, an identical fix worked for me, so I have full faith this will work (but reviewers should definitely test).

Release notes snippet
----------------------------------------
Updated `civicrm_entity_leaflet` to be compatible with Drupal Leaflet 2.2.9.
