### PR TITLE
Add compatibility fix for VBO 4.

### DIFF
--- a/src/Plugin/Action/CivicrmContactAddToGroup.php
+++ b/src/Plugin/Action/CivicrmContactAddToGroup.php
@@ -84,7 +84,7 @@ class CivicrmContactAddToGroup extends ViewsBulkOperationsActionBase implements 
   /**
    * {@inheritdoc}
    */
-  public function buildPreConfigurationForm(array $form, array $values, FormStateInterface $form_state) {
+  public function buildPreConfigurationForm(array $form, array $values, FormStateInterface $form_state): array {
     $groups = $this->fetchGroups();
 
     $form['allowed_groups'] = [


### PR DESCRIPTION
Overview
----------------------------------------
This is from https://www.drupal.org/project/civicrm_entity/issues/3314654. VBO 4 seem to started using type declarations in returns. This particular issue seem to happen for VBO 4.1.5.

Before
----------------------------------------
Getting the error:

> Fatal error: Declaration of Drupal\civicrm_entity\Plugin\Action\CivicrmContactAddToGroup::buildPreConfigurationForm(array $form, array $values, Drupal\Core\Form\FormStateInterface $form_state) must be compatible with Drupal\views_bulk_operations\Action\ViewsBulkOperationsPreconfigurationInterface::buildPreConfigurationForm(array $element, array $values, Drupal\Core\Form\FormStateInterface $form_state): array in /home/xx/public_html/modules/contrib/civicrm_entity/src/Plugin/Action/CivicrmContactAddToGroup.php on line 87

After
----------------------------------------
No more error.

Comments
----------------------------------------
Works fine for VBO 3 as well.