### PR TITLE
Improve civi case permissions.

### DIFF
--- a/src/SupportedEntities.php
+++ b/src/SupportedEntities.php
@@ -99,13 +99,10 @@ final class SupportedEntities {
       'label property' => 'subject',
       'permissions' => [
         'view' => ['access all cases and activities'],
-        'edit' => ['access all cases and activities'],
-        'update' => ['access all cases and activities'],
-        'create' => ['add cases', 'access all cases and activities'],
-        'delete' => [
-          'delete in CiviCase',
-          'access all cases and activities',
-        ],
+        'edit' => ['add cases'],
+        'update' => ['add cases'],
+        'create' => ['add cases'],
+        'delete' => ['delete in CiviCase'],
       ],
       'required' => [
         'contact_id' => TRUE,
@@ -116,10 +113,11 @@ final class SupportedEntities {
       'civicrm entity name' => 'case_type',
       'label property' => 'title',
       'permissions' => [
-        'view' => [],
-        'update' => [],
-        'create' => [],
-        'delete' => [],
+        'view' => ['access all cases and activities'],
+        'edit' => ['add cases'],
+        'update' => ['add cases'],
+        'create' => ['add cases'],
+        'delete' => ['delete in CiviCase'],
       ],
     ];
     $civicrm_entity_info['civicrm_contact'] = [


### PR DESCRIPTION
Overview
----------------------------------------
Non admins are not able to view civi case types.

Before
----------------------------------------
Case Types are not visible to non admin roles.

After
----------------------------------------
Case type are viewable to other roles.

Technical Details
----------------------------------------
I've updated permission requirements for both Civi case and case types. For civi case, it was mostly dependent on "access all cases and activities" wherein it's required to view a case but the permissions for CE uses an "OR" condition in which case the delete operation relies on either "delete in CiviCase" or "access all cases and activities".