### PR TITLE
Fix multi-valued custom field display

### DIFF
--- a/src/Plugin/views/field/CustomEntityField.php
+++ b/src/Plugin/views/field/CustomEntityField.php
@@ -203,7 +203,7 @@ class CustomEntityField extends EntityField {
       ];
     }
 
-    return $items;
+    return $this->prepareItemsByDelta($items);
   }
 
   /**
@@ -248,7 +248,7 @@ class CustomEntityField extends EntityField {
         }, ARRAY_FILTER_USE_KEY);
 
         if (!empty($result)) {
-          if (is_array($result[0])) {
+          if (isset($result[0]) && is_array($result[0])) {
             $result = reset($result);
           }
 


### PR DESCRIPTION
Overview
----------------------------------------
Custom Fields from Multiple Record Fieldsets not Displaying Correctly in Views

Before
----------------------------------------
When displaying a list of records in a view from a multiple records custom fieldset, the values for all the records for a custom field are repeated in each row, instead of giving the individual value for that field in each row. This is when the Multiple Fields Settings option "Display all values in the same row" is left unticked. If ticked, it works as expected. Please see the attached image as an example.

Strangely, this does not apply to a file type field (a custom field that allows you to upload a file) which is part of a multiple record fieldset. Nor does this field have a Multiple Field Settings option.


![image](https://user-images.githubusercontent.com/5929648/202834562-958b3052-ea5c-4cb4-9ecf-1e382ed72582.png)

After
----------------------------------------
Fixed. Each row is displayed separately with required values.

Comments
----------------------------------------
Drupal Issue - https://www.drupal.org/project/civicrm_entity/issues/3312320

Release notes snippet
----------------------------------------
Fixes multi-valued custom field display in views.