### PR TITLE
Add argument validator for contact type.

### DIFF
--- a/civicrm_entity.views.inc
+++ b/civicrm_entity.views.inc
@@ -647,3 +647,10 @@ function civicrm_entity_field_default_views_data(FieldStorageConfigInterface $fi
 
   return $data;
 }
+
+/**
+ * Implements hook_views_plugins_argument_validator_alter().
+ */
+function civicrm_entity_views_plugins_argument_validator_alter(array &$plugins) {
+  $plugins['entity:civicrm_contact']['class'] = 'Drupal\civicrm_entity\Plugin\views\argument_validator\CivicrmContact';
+}

--- a/config/schema/civicrm_entity.views.schema.yml
+++ b/config/schema/civicrm_entity.views.schema.yml
@@ -62,3 +62,14 @@ views.filter_value.civicrm_entity_civicrm_address_proximity:
     distance_unit:
       type: string
       label: 'Distance unit'
+
+views.argument_validator.entity:civicrm_contact:
+  type: views.argument_validator_entity
+  label: 'Civicrm contact'
+  mapping:
+    contact_type:
+      type: sequence
+      label: 'Restrict to selected contact types'
+      sequence:
+        type: string
+        label: 'Contact type'

--- a/src/Plugin/views/argument_validator/CivicrmContact.php
+++ b/src/Plugin/views/argument_validator/CivicrmContact.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\civicrm_entity\Plugin\views\argument_validator;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\argument_validator\Entity;
+
+/**
+ * Validates whether the argument matches a contact type.
+ */
+class CivicrmContact extends Entity {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+
+    $options['contact_type'] = ['default' => []];
+
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+
+    $contact_types = ['Individual', 'Organization', 'Household'];
+    $form['contact_type'] = [
+      '#title' => $this->t('Contact type'),
+      '#default_value' => $this->options['contact_type'],
+      '#type' => 'checkboxes',
+      '#options' => array_combine($contact_types, $contact_types),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitOptionsForm(&$form, FormStateInterface $form_state, &$options = []) {
+    $options['contact_type'] = array_filter($options['contact_type']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function validateEntity(EntityInterface $entity) {
+    /** @var \Drupal\civicrm_entity\Entity\CivicrmEntity $entity */
+    $valid = TRUE;
+
+    if (!empty($this->options['contact_type']) && !in_array($entity->get('contact_type')->value, $this->options['contact_type'])) {
+      $valid = FALSE;
+    }
+
+    return $valid && parent::validateEntity($entity);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds an argument validator for contact type.

Before
----------------------------------------
There is no way to validate argument by contact type.

After
----------------------------------------
Adds a configuration to validate by contact type:

![image](https://user-images.githubusercontent.com/34715246/203498014-59d7100f-9bce-4b30-924d-8a97d7b01d6a.png)
