### PR TITLE
set the view mode to default

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -214,7 +214,8 @@ function civicrm_entity_entity_view_display_alter(EntityViewDisplayInterface $di
   if ($entity_type->get('civicrm_entity') && $entity_type->hasKey('bundle')) {
     $entity_display_repository = \Drupal::service('entity_display.repository');
     assert($entity_display_repository instanceof EntityDisplayRepositoryInterface);
-    $view_mode = !empty($context['view_mode']) ? $context['view_mode'] : $entity_display_repository::DEFAULT_DISPLAY_MODE;
+    $entity_view_mode_ids = array_keys($entity_display_repository->getViewModeOptions($entity_type->id()));
+    $view_mode = !empty($context['view_mode']) && in_array($context['view_mode'], $entity_view_mode_ids) ? $context['view_mode'] : $entity_display_repository::DEFAULT_DISPLAY_MODE;
     $root_display = $entity_display_repository->getViewDisplay(
       $entity_type->id(),
       $entity_type->id(),


### PR DESCRIPTION
Overview
----------------------------------------
Layout builder does not work for any civi entity, because the entity is rendered through `full` view_mode, even though it is not defined.

Described here:
https://www.drupal.org/project/civicrm_entity/issues/3247663#comment-14812845

Before
----------------------------------------
Entities always render through the `full` view mode.

After
----------------------------------------
If the view mode in the context is not in the list of available view_mode for civicrm_entity, it will be changed to `default`. 
E.g. if view_mode is `full` when not defined, it will be changed to `default`. **(see Technical Details)**
In summary, entities are rendered in the appropriate view mode.

Technical Details
----------------------------------------
![image](https://user-images.githubusercontent.com/121243945/209412259-d6e0ce71-008d-47a3-97a2-1de278c6a3d3.png)
On the entity page in each function across the call stack, view_mode is set to `full` and then attached to the context. 
Since 66524f6a313cf6d0e354f535e9348aa800d15a41 the view mode is set from context. While this works correctly for views(since we define a view mode in the format tab on the view configuration page), for entity pages the view_mode `full` is always set which is incorrect behavior.
