### PR TITLE
Do not convert Drupal custom tables for CiviCRM entities in views

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -501,10 +501,10 @@ function civicrm_entity_views_query_alter(ViewExecutable $view, QueryPluginBase 
     $civicrm_connection = Database::getConnection('default', $civicrm_connection_name);
     $table_queue =& $query->getTableQueue();
     foreach ($table_queue as $alias => &$table_info) {
-      if (strpos($table_info['table'], 'civicrm_') === 0 && strpos($table_info['table'], '.') === FALSE) {
+      if (strpos($table_info['table'], 'civicrm_') === 0 && strpos($table_info['table'], '.') === FALSE && strpos($table_info['table'], '__') === FALSE) {
         $table_info['table'] = $civicrm_connection->getFullQualifiedTableName($table_info['table']);
       }
-      if (!empty($table_info['join']->table) && strpos($table_info['join']->table, 'civicrm_') === 0 && strpos($table_info['join']->table, '.') === FALSE) {
+      if (!empty($table_info['join']->table) && strpos($table_info['join']->table, 'civicrm_') === 0 && strpos($table_info['join']->table, '.') === FALSE && strpos($table_info['join']->table, '__') === FALSE) {
         $table_info['join']->table = $civicrm_connection->getFullQualifiedTableName($table_info['join']->table);
       }
     }

--- a/src/Plugin/views/query/CivicrmSql.php
+++ b/src/Plugin/views/query/CivicrmSql.php
@@ -79,7 +79,8 @@ class CivicrmSql extends Sql {
       // If the table is not prefixed with civicrm_, assume it is a Drupal table
       // and convert it to a fully qualified table name. But, make sure it has
       // not already been converted.
-      if (strpos($table['table'], 'civicrm_') !== 0 && strpos($table['table'], '.') === FALSE) {
+      // Also do not convert any drupal custom fields.
+      if ((strpos($table['table'], 'civicrm_') !== 0 && strpos($table['table'], '.') === FALSE) || (strpos($table['table'], 'civicrm_') === 0 && strpos($table['table'], '__') !== FALSE)) {
          $table['table'] = $connection->getFullQualifiedTableName($table['table']);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
We have a client that has some drupal custom tables specifically around geolocation data for CiviCRM Contacts and Events. We found that they were created within the Drupal database as expected with table names like `civicrm_contact__geolocation....` but they were when used in views having the wrong database name appended this fixes that.

Before
----------------------------------------
CiviCRM database name appended to any drupal custom field tables for civicrm entities

After
----------------------------------------
CiviCRM database name not appended

