### PR TITLE
Make Display Suite work for entity types with bundles for rendered view modes

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -230,6 +230,12 @@ function civicrm_entity_entity_view_display_alter(EntityViewDisplayInterface $di
         $display->setThirdPartySetting('layout_builder', $setting_key, $setting);
       }
     }
+    $ds_settings = $root_display->getThirdPartySettings('ds');
+    if (!empty($ds_settings) && is_array($ds_settings)) {
+      foreach ($ds_settings as $setting_key => $setting) {
+        $display->setThirdPartySetting('ds', $setting_key, $setting);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM Entity types with bundles (Events and Activities)
If Display suite was enabled and used for a View mode, rendered entities were not getting markup for regions from the display suite settings.

This patch makes display suite work for Events and Activities, to work the same as all the other entity types.

Technical Details
----------------------------------------
This PR is a draft, it makes it work with DS, but I realize now it would be preferable to set ALL third party settings to the display, and not just doing them one at a time. We had fixed Layout Builder, and now Display Suite, but there is no guarantee other contrib modules that have third party settings, will have those settings set.

