### PR TITLE
Call to undefined method - Issue 3284337

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -504,7 +504,7 @@ function civicrm_entity_views_query_alter(ViewExecutable $view, QueryPluginBase 
   // If CiviCRM tables in a separate database.
   $civicrm_connection_name = drupal_valid_test_ua() ? 'civicrm_test' : 'civicrm';
   $civicrm_database_info = Database::getConnectionInfo($civicrm_connection_name);
-  if (isset($civicrm_database_info['default'])) {
+  if (isset($civicrm_database_info['default']) && method_exists($query, "getTableQueue")) {
     $civicrm_connection = Database::getConnection('default', $civicrm_connection_name);
     $table_queue =& $query->getTableQueue();
     foreach ($table_queue as $alias => &$table_info) {


### PR DESCRIPTION
Fixes a fatal error, when this module is used with other contributed modules that can add their own methods. 

This fix checks for the expected core method.

Overview
----------------------------------------
Without this check, a fatal error is caused. This is caused by contributed modules, such as Search API or View implementing methods.

Before
----------------------------------------
Fatal errors such as:
`Error: Call to undefined method Drupal\views_contextual_filters_or\Plugin\views\query\ExtendedSearchApiQuery::getTableQueue() in civicrm_entity_views_query_alter() (line 509 of /code/web/modules/contrib/civicrm_entity/civicrm_entity.module)`

`Error: Call to undefined method Drupal\search_api\Plugin\views\query\SearchApiQuery::getTableQueue() in civicrm_entity_views_query_alter() (line 509 of /code/web/modules/contrib/civicrm_entity/civicrm_entity.module)`

After
----------------------------------------
No fatal error, and works for the method it needs to.

Technical Details
----------------------------------------
Originally raised on Drupal.org here: [Issue 3284337](https://www.drupal.org/project/civicrm_entity/issues/3284337)

Comments
----------------------------------------
Original patch: [sstapleton](https://www.drupal.org/u/sstapleton)
Patch reroll: [jefflogan] (https://ww.drupal.org/u/jefflogan)

