### PR TITLE
Replace isset with is_numeric in prepareItemsByDelta()

### DIFF
--- a/src/Plugin/views/field/CustomEntityField.php
+++ b/src/Plugin/views/field/CustomEntityField.php
@@ -213,7 +213,7 @@ class CustomEntityField extends EntityField {
     if ($this->limit_values) {
       $row = $this->view->result[$this->view->row_index];
 
-      if (!$this->options['group_rows'] && isset($row->delta)) {
+      if (!$this->options['group_rows'] && is_numeric($row->delta)) {
         return [$all_values[$row->delta]];
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
With some CiviCRM views,we are seeing this error: 
```
The website encountered an unexpected error. Please try again later.
TypeError: Unsupported operand types: null + array in Drupal\views\Plugin\views\field\FieldPluginBase->advancedRender() (line 1178 of core/modules/views/src/Plugin/views/field/FieldPluginBase.php).
```


Before
----------------------------------------
```
The website encountered an unexpected error. Please try again later.
TypeError: Unsupported operand types: null + array in Drupal\views\Plugin\views\field\FieldPluginBase->advancedRender() (line 1178 of core/modules/views/src/Plugin/views/field/FieldPluginBase.php).
```

After
----------------------------------------
No errors!

Technical Details
----------------------------------------
The problem stems from this method: 

https://github.com/eileenmcnaughton/civicrm_entity/blob/8.x-3.x/src/Plugin/views/field/CustomEntityField.php#L212-L222

It seems that when $row->delta is false, isset(false) returns true, so we are sometimes returning an array or items like [0 => null] which causes 'TypeError: Unsupported operand types: null + array'

This PR aims to fix that by changing isset() to is_numeric()

Release notes snippet
----------------------------------------
Fix TypeError: Unsupported operand types: null + array in Drupal\views\Plugin\views\field\FieldPluginBase->advancedRender() for some CiviCRM entity views. 

