### PR TITLE
update .info file of civicrm_entity_leaflet to require leaflet 2.2.6 …

### DIFF
--- a/modules/civicrm_entity_leaflet/civicrm_entity_leaflet.info.yml
+++ b/modules/civicrm_entity_leaflet/civicrm_entity_leaflet.info.yml
@@ -6,4 +6,4 @@ package: 'CiviCRM'
 
 dependencies:
   - civicrm_entity:civicrm_entity
-  - leaflet:leaflet_views (>=2.0.0)
+  - leaflet:leaflet_views (>=2.2.6)


### PR DESCRIPTION
Follow up to https://github.com/eileenmcnaughton/civicrm_entity/pull/396
update civicrm_entity_leaflet.info.yml to require 2.2.6 or greater
