### PR TITLE
Add option to disable links.

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -134,7 +134,7 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
     if (!empty($civicrm_entity_info['bundle property'])) {
       $entity_type_info['entity_keys']['bundle'] = 'bundle';
       $entity_type_info['civicrm_bundle_property'] = $civicrm_entity_info['bundle property'];
-      if (isset($entity_type_info['links'])) {
+      if (isset($entity_type_info['links']['add-form'])) {
         // For entities with bundles that are exposed, add the `bundle` key to
         // the add-form route. In CiviCrmEntityRouteProvider::getAddFormRoute
         // we default the value, so that it isn't actually required in the URL.

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -108,14 +108,21 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
         ],
         // Generate route paths.
         'links' => [
-          'canonical' => sprintf('/%s/{%s}', $clean_entity_type_id, $entity_type_id),
-          'delete-form' => sprintf('/%s/{%s}/delete', $clean_entity_type_id, $entity_type_id),
-          'edit-form' => sprintf('/%s/{%s}/edit', $clean_entity_type_id, $entity_type_id),
-          'add-form' => sprintf('/%s/add', $clean_entity_type_id, $entity_type_id),
           'collection' => sprintf('/admin/structure/civicrm-entity/%s', $clean_entity_type_id),
         ],
         'field_ui_base_route' => "entity.$entity_type_id.collection",
       ]);
+
+      if (!$config->get('disable_links')) {
+        $entity_type_info = array_merge_recursive($entity_type_info, [
+          'links' => [
+            'canonical' => sprintf('/%s/{%s}', $clean_entity_type_id, $entity_type_id),
+            'delete-form' => sprintf('/%s/{%s}/delete', $clean_entity_type_id, $entity_type_id),
+            'edit-form' => sprintf('/%s/{%s}/edit', $clean_entity_type_id, $entity_type_id),
+            'add-form' => sprintf('/%s/add', $clean_entity_type_id, $entity_type_id),
+          ],
+        ]);
+      }
     }
 
     // If this entity has bundle support, we define the bundle field as "bundle"

--- a/config/install/civicrm_entity.settings.yml
+++ b/config/install/civicrm_entity.settings.yml
@@ -1,3 +1,4 @@
 filter_format: ''
 enabled_entity_types: {  }
 disable_hooks: FALSE
+disable_links: FALSE

--- a/config/schema/civicrm_entity.schema.yml
+++ b/config/schema/civicrm_entity.schema.yml
@@ -14,3 +14,6 @@ civicrm_entity.settings:
     disable_hooks:
       type: boolean
       label: 'Disable pre/post hooks'
+    disable_links:
+      type: boolean
+      label: 'Disable links'

--- a/src/CivicrmEntityListBuilder.php
+++ b/src/CivicrmEntityListBuilder.php
@@ -35,7 +35,7 @@ class CivicrmEntityListBuilder extends EntityListBuilder {
       return [
           'id' => $entity->id(),
           'bundle' => $entity->bundle(),
-          'label' => $entity->toLink(),
+          'label' => $entity->hasLinkTemplate('canonical') ? $entity->toLink() : $entity->label(),
         ] + parent::buildRow($entity);
     }
     return [

--- a/src/CivicrmEntityListBuilder.php
+++ b/src/CivicrmEntityListBuilder.php
@@ -40,7 +40,7 @@ class CivicrmEntityListBuilder extends EntityListBuilder {
     }
     return [
       'id' => $entity->id(),
-      'label' => $entity->toLink(),
+      'label' => $entity->hasLinkTemplate('canonical') ? $entity->toLink() : $entity->label(),
     ] + parent::buildRow($entity);
   }
 
@@ -50,11 +50,13 @@ class CivicrmEntityListBuilder extends EntityListBuilder {
   protected function getDefaultOperations(EntityInterface $entity) {
     $operations = parent::getDefaultOperations($entity);
 
-    $operations['view'] = [
-      'title' => $this->t('View'),
-      'weight' => 50,
-      'url' => $entity->toUrl(),
-    ];
+    if ($entity->hasLinkTemplate('canonical')) {
+      $operations['view'] = [
+        'title' => $this->t('View'),
+        'weight' => 0,
+        'url' => $entity->toUrl(),
+      ];
+    }
 
     return $operations;
   }

--- a/src/Form/CivicrmEntitySettings.php
+++ b/src/Form/CivicrmEntitySettings.php
@@ -155,9 +155,9 @@ class CivicrmEntitySettings extends ConfigFormBase {
 
     $form['advanced_settings']['disable_links'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Disable links'),
+      '#title' => $this->t('Disable Drupal pages'),
       '#default_value' => $config->get('disable_links'),
-      '#description' => $this->t('Disables links for canonical and add, edit, and delete forms.'),
+      '#description' => $this->t('Disables Drupal versions of view page and, add, edit, and delete forms for all enabled entity types.'),
     ];
 
     return $form;

--- a/src/Form/CivicrmEntitySettings.php
+++ b/src/Form/CivicrmEntitySettings.php
@@ -153,6 +153,13 @@ class CivicrmEntitySettings extends ConfigFormBase {
       '#description' => $this->t('Not intended for normal use. Provided to temporarily disable Drupal entity hooks for CiviCRM Entity types for special cases, such as migrations. Only disable if you know you need to.'),
     ];
 
+    $form['advanced_settings']['disable_links'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Disable links'),
+      '#default_value' => $config->get('disable_links'),
+      '#description' => $this->t('Disables links for canonical and add, edit, and delete forms.'),
+    ];
+
     return $form;
   }
 
@@ -166,6 +173,7 @@ class CivicrmEntitySettings extends ConfigFormBase {
       ->set('filter_format', $form_state->getValue('filter_format'))
       ->set('enabled_entity_types', $enabled_entity_type)
       ->set('disable_hooks', $form_state->getValue('disable_hooks'))
+      ->set('disable_links', $form_state->getValue('disable_links'))
       ->save();
 
     // Need to rebuild derivative routes.

--- a/src/Form/CivicrmEntitySettings.php
+++ b/src/Form/CivicrmEntitySettings.php
@@ -3,6 +3,7 @@
 namespace Drupal\civicrm_entity\Form;
 
 use Drupal\civicrm_entity\SupportedEntities;
+use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
@@ -55,6 +56,13 @@ class CivicrmEntitySettings extends ConfigFormBase {
   protected $menuLinkManager;
 
   /**
+   * The render cache manager.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cacheRender;
+
+  /**
    * Constructs a \Drupal\system\ConfigFormBase object.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
@@ -69,14 +77,17 @@ class CivicrmEntitySettings extends ConfigFormBase {
    *   The local task manager.
    * @param \Drupal\Core\Menu\MenuLinkManagerInterface $menu_link_manager
    *   The menu link manager.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_render
+   *   The render cache manager.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, RouteBuilderInterface $route_builder, LocalActionManagerInterface $local_action_manager, LocalTaskManagerInterface $local_task_manager, MenuLinkManagerInterface $menu_link_manager) {
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, RouteBuilderInterface $route_builder, LocalActionManagerInterface $local_action_manager, LocalTaskManagerInterface $local_task_manager, MenuLinkManagerInterface $menu_link_manager, CacheBackendInterface $cache_render) {
     parent::__construct($config_factory);
     $this->entityTypeManager = $entity_type_manager;
     $this->routeBuilder = $route_builder;
     $this->localActionManager = $local_action_manager;
     $this->localTaskManager = $local_task_manager;
     $this->menuLinkManager = $menu_link_manager;
+    $this->cacheRender = $cache_render;
   }
 
   /**
@@ -89,7 +100,8 @@ class CivicrmEntitySettings extends ConfigFormBase {
       $container->get('router.builder'),
       $container->get('plugin.manager.menu.local_action'),
       $container->get('plugin.manager.menu.local_task'),
-      $container->get('plugin.manager.menu.link')
+      $container->get('plugin.manager.menu.link'),
+      $container->get('cache.render')
     );
   }
 
@@ -181,6 +193,7 @@ class CivicrmEntitySettings extends ConfigFormBase {
     $this->routeBuilder->rebuild();
     $this->localActionManager->clearCachedDefinitions();
     $this->localTaskManager->clearCachedDefinitions();
+    $this->cacheRender->invalidateAll();
   }
 
 }

--- a/src/Plugin/Derivative/CivicrmEntityLocalAction.php
+++ b/src/Plugin/Derivative/CivicrmEntityLocalAction.php
@@ -54,15 +54,18 @@ class CivicrmEntityLocalAction extends DeriverBase implements ContainerDeriverIn
 
     /** @var \Drupal\Core\Entity\EntityTypeInterface $entity_type */
     foreach ($civicrm_entities as $entity_type_id => $entity_type) {
-      $this->derivatives["civicrm_entity_add_$entity_type_id"] = [
-        'route_name' => "entity.$entity_type_id.add_form",
-        'title' => $this->t('Add :label', [':label' => $entity_type->getLabel()]),
-        'appears_on' => ["entity.$entity_type_id.collection"],
-      ] + $base_plugin_definition;
-      if ($entity_type->hasKey('bundle')) {
-        $this->derivatives["civicrm_entity_add_$entity_type_id"]['route_parameters'] = [
-          $entity_type->getKey('bundle') => $entity_type_id,
-        ];
+      if ($entity_type->hasLinkTemplate('add-form')) {
+        $this->derivatives["civicrm_entity_add_$entity_type_id"] = [
+          'route_name' => "entity.$entity_type_id.add_form",
+          'title' => $this->t('Add :label', [':label' => $entity_type->getLabel()]),
+          'appears_on' => ["entity.$entity_type_id.collection"],
+        ] + $base_plugin_definition;
+
+        if ($entity_type->hasKey('bundle')) {
+          $this->derivatives["civicrm_entity_add_$entity_type_id"]['route_parameters'] = [
+            $entity_type->getKey('bundle') => $entity_type_id,
+          ];
+        }
       }
     }
 

--- a/src/Plugin/Derivative/DynamicLocalTasks.php
+++ b/src/Plugin/Derivative/DynamicLocalTasks.php
@@ -6,6 +6,7 @@ use Drupal\Component\Plugin\Derivative\DeriverBase;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
+use Drupal\Core\Routing\RouteProvider;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -32,6 +33,13 @@ class DynamicLocalTasks extends DeriverBase implements ContainerDeriverInterface
   protected $entityTypeManager;
 
   /**
+   * The route provider.
+   *
+   * @var \Drupal\Core\Routing\RouteProvider
+   */
+  protected $routeProvider;
+
+  /**
    * Creates an FieldUiLocalTask object.
    *
    * @param string $base_plugin_id
@@ -40,11 +48,14 @@ class DynamicLocalTasks extends DeriverBase implements ContainerDeriverInterface
    *   The entity type manager.
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    *   The translation manager.
+   * @param \Drupal\Core\Routing\RouteProvider $route_provider
+   *   The route provider.
    */
-  public function __construct($base_plugin_id, EntityTypeManagerInterface $entity_type_manager, TranslationInterface $string_translation) {
+  public function __construct($base_plugin_id, EntityTypeManagerInterface $entity_type_manager, TranslationInterface $string_translation, RouteProvider $route_provider) {
     $this->entityTypeManager = $entity_type_manager;
     $this->stringTranslation = $string_translation;
     $this->basePluginId = $base_plugin_id;
+    $this->routeProvider = $route_provider;
   }
 
   /**
@@ -54,7 +65,8 @@ class DynamicLocalTasks extends DeriverBase implements ContainerDeriverInterface
     return new static(
       $base_plugin_id,
       $container->get('entity_type.manager'),
-      $container->get('string_translation')
+      $container->get('string_translation'),
+      $container->get('router.route_provider')
     );
   }
 
@@ -69,22 +81,30 @@ class DynamicLocalTasks extends DeriverBase implements ContainerDeriverInterface
     });
 
     foreach ($civicrm_entities as $entity_type_id => $entity_type) {
-      $this->derivatives["$entity_type_id.canonical"] = [
-        'route_name' => "entity.$entity_type_id.canonical",
-        'title' => $this->t('View'),
-        'base_route' => "entity.$entity_type_id.canonical",
-      ] + $base_plugin_definition;
-      $this->derivatives["$entity_type_id.edit_form"] = [
+      if ($this->routeProvider->getRouteByName("$entity_type_id.canonical")) {
+        $this->derivatives["$entity_type_id.canonical"] = [
+          'route_name' => "entity.$entity_type_id.canonical",
+          'title' => $this->t('View'),
+          'base_route' => "entity.$entity_type_id.canonical",
+        ] + $base_plugin_definition;
+      }
+
+      if ($this->routeProvider->getRouteByName("$entity_type_id.canonical")) {
+        $this->derivatives["entity.$entity_type_id.edit_form"] = [
         'route_name' => "entity.$entity_type_id.edit_form",
         'title' => $this->t('Edit'),
         'base_route' => "entity.$entity_type_id.canonical",
-      ] + $base_plugin_definition;
-      $this->derivatives["entity.$entity_type_id.collection"] = [
-        'route_name' => "entity.$entity_type_id.collection",
-        'title' => $this->t('List'),
-        'base_route' => "entity.$entity_type_id.collection",
-        'weight' => -10,
-      ] + $base_plugin_definition;
+        ] + $base_plugin_definition;
+      }
+
+      if ($this->routeProvider->getRouteByName("entity.$entity_type_id.collection")) {
+        $this->derivatives["entity.$entity_type_id.collection"] = [
+          'route_name' => "entity.$entity_type_id.collection",
+          'title' => $this->t('List'),
+          'base_route' => "entity.$entity_type_id.collection",
+          'weight' => -10,
+        ] + $base_plugin_definition;
+      }
     }
 
     return $this->derivatives;

--- a/src/Plugin/Derivative/DynamicLocalTasks.php
+++ b/src/Plugin/Derivative/DynamicLocalTasks.php
@@ -10,6 +10,7 @@ use Drupal\Core\Routing\RouteProvider;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
  * Generates moderation-related local tasks.
@@ -81,29 +82,30 @@ class DynamicLocalTasks extends DeriverBase implements ContainerDeriverInterface
     });
 
     foreach ($civicrm_entities as $entity_type_id => $entity_type) {
-      if ($this->routeProvider->getRouteByName("$entity_type_id.canonical")) {
-        $this->derivatives["$entity_type_id.canonical"] = [
-          'route_name' => "entity.$entity_type_id.canonical",
-          'title' => $this->t('View'),
-          'base_route' => "entity.$entity_type_id.canonical",
-        ] + $base_plugin_definition;
-      }
-
-      if ($this->routeProvider->getRouteByName("$entity_type_id.canonical")) {
-        $this->derivatives["entity.$entity_type_id.edit_form"] = [
+      $this->derivatives["entity.$entity_type_id.edit_form"] = [
         'route_name' => "entity.$entity_type_id.edit_form",
         'title' => $this->t('Edit'),
         'base_route' => "entity.$entity_type_id.canonical",
-        ] + $base_plugin_definition;
-      }
+      ] + $base_plugin_definition;
 
-      if ($this->routeProvider->getRouteByName("entity.$entity_type_id.collection")) {
-        $this->derivatives["entity.$entity_type_id.collection"] = [
-          'route_name' => "entity.$entity_type_id.collection",
-          'title' => $this->t('List'),
-          'base_route' => "entity.$entity_type_id.collection",
-          'weight' => -10,
-        ] + $base_plugin_definition;
+      $this->derivatives["entity.$entity_type_id.collection"] = [
+        'route_name' => "entity.$entity_type_id.collection",
+        'title' => $this->t('List'),
+        'base_route' => "entity.$entity_type_id.collection",
+        'weight' => -10,
+      ] + $base_plugin_definition;
+
+      try {
+        if ($this->routeProvider->getRouteByName("entity.$entity_type_id.canonical")) {
+          $this->derivatives["$entity_type_id.canonical"] = [
+            'route_name' => "entity.$entity_type_id.canonical",
+            'title' => $this->t('View'),
+            'base_route' => "entity.$entity_type_id.canonical",
+          ] + $base_plugin_definition;
+        }
+      }
+      catch (RouteNotFoundException $e) {
+        $this->derivatives["entity.$entity_type_id.edit_form"]['base_route'] = "entity.$entity_type_id.edit_form";
       }
     }
 

--- a/src/Plugin/Derivative/DynamicLocalTasks.php
+++ b/src/Plugin/Derivative/DynamicLocalTasks.php
@@ -81,7 +81,7 @@ class DynamicLocalTasks extends DeriverBase implements ContainerDeriverInterface
       return $type->getProvider() == 'civicrm_entity' && $type->get('civicrm_entity_ui_exposed');
     });
 
-    foreach ($civicrm_entities as $entity_type_id => $entity_type) {
+    foreach (array_keys($civicrm_entities) as $entity_type_id) {
       $this->derivatives["entity.$entity_type_id.edit_form"] = [
         'route_name' => "entity.$entity_type_id.edit_form",
         'title' => $this->t('Edit'),
@@ -103,9 +103,14 @@ class DynamicLocalTasks extends DeriverBase implements ContainerDeriverInterface
             'base_route' => "entity.$entity_type_id.canonical",
           ] + $base_plugin_definition;
         }
+        else {
+          if ($this->routeProvider->getRouteByName("entity.$entity_type_id.edit_form")) {
+            $this->derivatives["entity.$entity_type_id.edit_form"]['base_route'] = "entity.$entity_type_id.edit_form";
+          }
+        }
       }
       catch (RouteNotFoundException $e) {
-        $this->derivatives["entity.$entity_type_id.edit_form"]['base_route'] = "entity.$entity_type_id.edit_form";
+        // No-op.
       }
     }
 

--- a/src/Routing/CiviCrmEntityRouteProvider.php
+++ b/src/Routing/CiviCrmEntityRouteProvider.php
@@ -28,7 +28,7 @@ class CiviCrmEntityRouteProvider extends AdminHtmlRouteProvider {
   protected function getAddFormRoute(EntityTypeInterface $entity_type) {
     $has_bundles = $entity_type->hasKey('bundle');
     $entity_add_form_route = parent::getAddFormRoute($entity_type);
-    if ($has_bundles) {
+    if ($has_bundles && $entity_add_form_route) {
       // This ensures the form receives a default bundle from the
       // CivicrmEntity::preCreate method, avoiding the need for the `add_page`
       // route for selecting a bundle.

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -111,9 +111,11 @@ final class RouteSubscriber extends RouteSubscriberBase {
 
       foreach ($field_ui_routes as $route_name => $defaults) {
         $route = $collection->get($route_name);
-        assert($route !== NULL);
-        foreach ($defaults as $name => $default) {
-          $route->setDefault($name, $default);
+
+        if ($route) {
+          foreach ($defaults as $name => $default) {
+            $route->setDefault($name, $default);
+          }
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Add an option to disable links. Usually admins miss that entities have links to view, edit, or delete. This option allows admins to disable these links.

Ideally, these links can be handled using existing permissions for CiviCRM although there are certain scenarios where you'd want to enable permissions for CiviCRM. Enabling those permissions have possibilities of exposing all data to users e.g. "view all CiviCRM contacts" that can be used in webform_civicrm. Enabling that permission also enables canonical display of CiviCRM contacts.

Before
----------------------------------------
No way to hide "built-in" links.

After
----------------------------------------
Option to show or hide "built-in" links.
