### PR TITLE
Bump CiviCRM and Drupal version for testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,15 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - drupal: '9.3.*'
-            civicrm: '5.45.*'
           - drupal: '9.4.*'
-            civicrm: '5.51.*'
-          - drupal: '9.4.*'
-            civicrm: '5.52.*'
-          - drupal: '9.4.*'
-            civicrm: '5.53.x-dev'
-          - drupal: '9.4.*'
+            civicrm: '5.59.**'
+          - drupal: '9.5.*'
+            civicrm: '5.59.*'
+          - drupal: '9.5.*'
+            civicrm: '5.60.x-dev*'
+          - drupal: '9.5.*'
             civicrm: 'dev-master'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:


### PR DESCRIPTION
Overview
----------------------------------------
Updates to Drupal:
  versions 9.4 and 9.5
CiviCRM
 5.59.x
 5.60.x-dev
 dev-master

This gets us testing on latest Stable CiviCRM, as well as the RC and master.

Bumped drupal versions to 9.4 and 9.5 due to 9.3 end of life.