### PR TITLE
Disable creation of entity tables.

### DIFF
--- a/src/Entity/Sql/CivicrmEntityStorageSchema.php
+++ b/src/Entity/Sql/CivicrmEntityStorageSchema.php
@@ -50,4 +50,11 @@ class CivicrmEntityStorageSchema extends SqlContentEntityStorageSchema {
     return FALSE;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function onFieldableEntityTypeCreate(EntityTypeInterface $entity_type, array $field_storage_definitions) {
+    return;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This solves https://www.drupal.org/project/civicrm_entity/issues/3299224.

Before
----------------------------------------
Tables for CiviCRM are duplicated in the Drupal database.

After
----------------------------------------
No tables created anymore.
