### PR TITLE
Adds is Empty/NULL operators

### DIFF
--- a/src/Plugin/views/filter/InOperator.php
+++ b/src/Plugin/views/filter/InOperator.php
@@ -140,21 +140,22 @@ class InOperator extends BaseInOperator {
 
   public function operators() {
     $operators = parent::operators();
-    $operators += [
-      'empty string' => [
-        'title' => $this->t('Is EMPTY/NULL'),
-        'method' => 'opEmptyString',
-        'short' => $this->t('empty string'),
-        'values' => 0,
-      ],
-      'not empty string' => [
-        'title' => $this->t('Is not EMPTY/NULL'),
-        'method' => 'opEmptyString',
-        'short' => $this->t('not empty string'),
-        'values' => 0,
-      ],
-    ];
-
+    if (!empty($this->definition['allow empty'])) {
+      $operators += [
+        'empty string' => [
+          'title' => $this->t('Is EMPTY/NULL'),
+          'method' => 'opEmptyString',
+          'short' => $this->t('empty string'),
+          'values' => 0,
+        ],
+        'not empty string' => [
+          'title' => $this->t('Is not EMPTY/NULL'),
+          'method' => 'opEmptyString',
+          'short' => $this->t('not empty string'),
+          'values' => 0,
+        ],
+      ];
+    }
     return $operators;
   }
 

--- a/src/Plugin/views/filter/InOperator.php
+++ b/src/Plugin/views/filter/InOperator.php
@@ -137,4 +137,44 @@ class InOperator extends BaseInOperator {
     }
   }
 
+  public function operators() {
+    $operators = parent::operators();
+    $operators += [
+      'empty string' => [
+        'title' => $this->t('Is EMPTY/NULL'),
+        'method' => 'opEmptyString',
+        'short' => $this->t('empty string'),
+        'values' => 0,
+      ],
+      'not empty string' => [
+        'title' => $this->t('Is not EMPTY/NULL'),
+        'method' => 'opEmptyString',
+        'short' => $this->t('not empty string'),
+        'values' => 0,
+      ],
+    ];
+
+    return $operators;
+  }
+
+  protected function opEmptyString() {
+    $this->ensureMyTable();
+    $field = "$this->tableAlias.$this->realField";
+
+    if ($this->operator == 'empty string') {
+      $operator = "=";
+      $nullOP = 'IS NULL';
+    }
+    else {
+      $operator = "!=";
+      $nullOP = 'IS NOT NULL';
+    }
+
+    $condition = new Condition('OR');
+    $condition->condition($field, '', $operator);
+    $condition->condition($field, NULL, $nullOP);
+
+    $this->query->addWhere($this->options['group'], $condition);
+  }
+
 }

--- a/src/Plugin/views/filter/InOperator.php
+++ b/src/Plugin/views/filter/InOperator.php
@@ -3,6 +3,7 @@
 namespace Drupal\civicrm_entity\Plugin\views\filter;
 
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\Query\Condition;
 use Drupal\civicrm_entity\CiviCrmApiInterface;
 use Drupal\views\Plugin\views\display\DisplayPluginBase;
 use Drupal\views\Plugin\views\filter\InOperator as BaseInOperator;


### PR DESCRIPTION
Overview
----------------------------------------

Replicates behaviour from search builder.  Adds two filters 'Is EMPTY/NULL' and the negative.

By default drupals InOperator provides an is empty filter however this only checks for null values. 

These check to see if the field is empty or null. This is useful for cases where fields can be both NULL or empty.


Before
----------------------------------------

On a view we can filter by these options.

![image](https://user-images.githubusercontent.com/9410526/229676904-2d33d5fe-d366-4f77-90cb-c77000acfc8a.png)


After
----------------------------------------
On a view we can filter by these options.
![image](https://user-images.githubusercontent.com/9410526/229676943-7d48a1a3-dbc2-474c-a6fe-9448ec379347.png)


Release notes snippet
----------------------------------------
Adds new filter option Is Empty/NULL and Is Not Empty/NULL 
