### PR TITLE
Require specific version of drupal core.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "homepage": "http://drupal.org/project/civicrm_entity",
     "license": "GPL-2.0+",
     "require": {
+        "drupal/core": "^10",
         "civicrm/civicrm-drupal-8": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Version 4.0.x is being pulled into Drupal 9 sites which is not intended. Added the requirement for Drupal.