### PR TITLE
4.0.x field mappings

### DIFF
--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -158,17 +158,13 @@ class CiviEntityStorage extends SqlContentEntityStorage {
 
     // Get all the fields.
     $fields = $this->getCiviCrmApi()->getFields($this->entityType->get('civicrm_entity'));
-    $field_names = [];
-    foreach ($fields as $field) {
-      $field_names[] = $field['name'];
-    }
 
     $ids = $this->cleanIds($ids);
 
     if (!empty($ids)) {
       $options = [
         'id' => ['IN' => $ids],
-        'return' => $field_names,
+        'return' => array_keys($fields),
         'options' => ['limit' => 0],
       ];
 
@@ -195,7 +191,14 @@ class CiviEntityStorage extends SqlContentEntityStorage {
             $civicrm_entity = $temporary;
           }
 
-          $entity = $this->prepareLoadedEntity($civicrm_entity);
+          $massaged_civicrm_entity = [];
+          foreach ($fields as $name => $field) {
+            if (isset($civicrm_entity[$name])) {
+              $massaged_civicrm_entity[$field['name']] = $civicrm_entity[$name];
+            }
+          }
+
+          $entity = $this->prepareLoadedEntity($massaged_civicrm_entity);
           $entities[$entity->id()] = $entity;
         }
       }

--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -198,7 +198,7 @@ class CiviEntityStorage extends SqlContentEntityStorage {
             }
           }
 
-          $entity = $this->prepareLoadedEntity($massaged_civicrm_entity);
+          $entity = $this->prepareLoadedEntity($civicrm_entity + $massaged_civicrm_entity);
           $entities[$entity->id()] = $entity;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Patch for https://www.drupal.org/project/civicrm_entity/issues/3203231#comment-14028098. Originally, this is specific to just the "Contact is in Trash".

There was a similar case for contribution source before although it was handled differently - #418 (more like a "field to field basis"). This is an attempt to handle all inconsistencies at once.

Before
----------------------------------------
"Contact is in Trash" not displayed properly on views. Field name is "is_deleted" although CiviCRM API uses "contact_is_deleted" to retrieve the value.

After
----------------------------------------
"Contact is in Trash" working.
