### PR TITLE
make sure CiviCRM custom tables get fully qualified database name eve…

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -586,10 +586,10 @@ function civicrm_entity_views_query_alter(ViewExecutable $view, QueryPluginBase 
     $civicrm_connection = Database::getConnection('default', $civicrm_connection_name);
     $table_queue =& $query->getTableQueue();
     foreach ($table_queue as $alias => &$table_info) {
-      if (!empty($table_info['table']) && (strpos($table_info['table'], 'civicrm_') === 0 && strpos($table_info['table'], '.') === FALSE && strpos($table_info['table'], '__') === FALSE) || strpos($table_info['table'], 'civicrm_value_') === 0) {
+      if (!empty($table_info['table']) && ((strpos($table_info['table'], 'civicrm_') === 0 && strpos($table_info['table'], '.') === FALSE && strpos($table_info['table'], '__') === FALSE) || strpos($table_info['table'], 'civicrm_value_') === 0)) {
         $table_info['table'] = $civicrm_connection->getFullQualifiedTableName($table_info['table']);
       }
-      if (!empty($table_info['join']->table) && (strpos($table_info['join']->table, 'civicrm_') === 0 && strpos($table_info['join']->table, '.') === FALSE && strpos($table_info['join']->table, '__') === FALSE) || strpos($table_info['join']->table, 'civicrm_value_') === 0) {
+      if (!empty($table_info['join']->table) && ((strpos($table_info['join']->table, 'civicrm_') === 0 && strpos($table_info['join']->table, '.') === FALSE && strpos($table_info['join']->table, '__') === FALSE) || strpos($table_info['join']->table, 'civicrm_value_') === 0)) {
         $table_info['join']->table = $civicrm_connection->getFullQualifiedTableName($table_info['join']->table);
       }
     }

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -586,7 +586,7 @@ function civicrm_entity_views_query_alter(ViewExecutable $view, QueryPluginBase 
     $civicrm_connection = Database::getConnection('default', $civicrm_connection_name);
     $table_queue =& $query->getTableQueue();
     foreach ($table_queue as $alias => &$table_info) {
-      if (strpos($table_info['table'], 'civicrm_') === 0 && strpos($table_info['table'], '.') === FALSE && strpos($table_info['table'], '__') === FALSE) {
+      if (!empty($table_info['table']) && (strpos($table_info['table'], 'civicrm_') === 0 && strpos($table_info['table'], '.') === FALSE && strpos($table_info['table'], '__') === FALSE) || strpos($table_info['table'], 'civicrm_value_') === 0) {
         $table_info['table'] = $civicrm_connection->getFullQualifiedTableName($table_info['table']);
       }
       if (!empty($table_info['join']->table) && (strpos($table_info['join']->table, 'civicrm_') === 0 && strpos($table_info['join']->table, '.') === FALSE && strpos($table_info['join']->table, '__') === FALSE) || strpos($table_info['join']->table, 'civicrm_value_') === 0) {

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -589,7 +589,7 @@ function civicrm_entity_views_query_alter(ViewExecutable $view, QueryPluginBase 
       if (strpos($table_info['table'], 'civicrm_') === 0 && strpos($table_info['table'], '.') === FALSE && strpos($table_info['table'], '__') === FALSE) {
         $table_info['table'] = $civicrm_connection->getFullQualifiedTableName($table_info['table']);
       }
-      if (!empty($table_info['join']->table) && strpos($table_info['join']->table, 'civicrm_') === 0 && strpos($table_info['join']->table, '.') === FALSE && strpos($table_info['join']->table, '__') === FALSE) {
+      if (!empty($table_info['join']->table) && (strpos($table_info['join']->table, 'civicrm_') === 0 && strpos($table_info['join']->table, '.') === FALSE && strpos($table_info['join']->table, '__') === FALSE) || strpos($table_info['join']->table, 'civicrm_value_') === 0) {
         $table_info['join']->table = $civicrm_connection->getFullQualifiedTableName($table_info['join']->table);
       }
     }

--- a/src/Plugin/views/query/CivicrmSql.php
+++ b/src/Plugin/views/query/CivicrmSql.php
@@ -82,7 +82,7 @@ class CivicrmSql extends Sql {
       // and convert it to a fully qualified table name. But, make sure it has
       // not already been converted.
       // Also do not convert any drupal custom fields.
-      if ((strpos($table['table'], 'civicrm_') !== 0 && strpos($table['table'], '.') === FALSE) || ((strpos($table['table'], 'civicrm_') === 0 && strpos($table['table'], '__') !== FALSE)) || strpos($table_info['join']->table, 'civicrm_value_') === 0) {
+      if ((strpos($table['table'], 'civicrm_') !== 0 && strpos($table['table'], '.') === FALSE) || ((strpos($table['table'], 'civicrm_') === 0 && strpos($table['table'], '__') !== FALSE)) || strpos($table['table'], 'civicrm_value_') === 0) {
         $table['table'] = $connection->getFullQualifiedTableName($table['table']);
       }
     }

--- a/src/Plugin/views/query/CivicrmSql.php
+++ b/src/Plugin/views/query/CivicrmSql.php
@@ -82,7 +82,7 @@ class CivicrmSql extends Sql {
       // and convert it to a fully qualified table name. But, make sure it has
       // not already been converted.
       // Also do not convert any drupal custom fields.
-      if ((strpos($table['table'], 'civicrm_') !== 0 && strpos($table['table'], '.') === FALSE) || (strpos($table['table'], 'civicrm_') === 0 && strpos($table['table'], '__') !== FALSE)) {
+      if ((strpos($table['table'], 'civicrm_') !== 0 && strpos($table['table'], '.') === FALSE) || ((strpos($table['table'], 'civicrm_') === 0 && strpos($table['table'], '__') !== FALSE)) || strpos($table_info['join']->table, 'civicrm_value_') === 0) {
         $table['table'] = $connection->getFullQualifiedTableName($table['table']);
       }
     }


### PR DESCRIPTION
…n if contains double underscore

Overview
----------------------------------------
Coming from bug report: https://www.drupal.org/project/civicrm_entity/issues/3198146#comment-15086900

If a custom field table contains two underscores, the fully qualified database name is not added in Views queries, resulting in SQL error.

Before
----------------------------------------
When Civi tables in separate database from Drupal, and custom field tables contain two underscores, there's an SQL error

After
----------------------------------------
No SQL error for the conditions
