### PR TITLE
Add handler for inline_entity_form.

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -31,6 +31,7 @@ use Drupal\views\ViewExecutable;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\Core\Database\Database;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\inline_entity_form\Form\EntityInlineForm;
 
 /**
  * Implements hook_theme().
@@ -89,6 +90,7 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
         'access' => CivicrmEntityAccessHandler::class,
         'views_data' => CivicrmEntityViewsData::class,
         'storage_schema' => CivicrmEntityStorageSchema::class,
+        'inline_form' => EntityInlineForm::class,
       ],
     ];
 


### PR DESCRIPTION
Overview
----------------------------------------
Getting an error for IEF 2.0.x.

Before
----------------------------------------
The error is:

> Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException: The "civicrm_activity" entity type did not specify a inline_form handler. in Drupal\Core\Entity\EntityTypeManager->getHandler() (line 256 of /var/www/web/distro10.skvare.com/web/core/lib/Drupal/Core/Entity/EntityTypeManager.php).

After
----------------------------------------
No more error.