### PR TITLE
Include dblocale table names in list of civicrm entity info

### DIFF
--- a/src/SupportedEntities.php
+++ b/src/SupportedEntities.php
@@ -714,6 +714,23 @@ $civicrm_entity_info['civicrm_group_contact'] = [
       if (!in_array($entity_info['civicrm entity name'], $api_entity_types)) {
         unset($civicrm_entity_info[$entity_type]);
       }
+
+      // Insert dblocale table names
+      $multilingual = \CRM_Core_I18n::isMultilingual();
+      if ($multilingual) {
+        // @codingStandardsIgnoreStart
+        global $dbLocale;
+        // @codingStandardsIgnoreEnd
+        if ($dbLocale) {
+          $tables = \CRM_Core_I18n_Schema::schemaStructureTables();
+          if (in_array($entity_type, $tables)) {
+            $locale_table_name = $entity_type . $dbLocale;
+            if (strlen($locale_table_name) <= 32) {
+              $civicrm_entity_info[$locale_table_name] = $entity_info;
+            }
+          }
+        }
+      }
     }
     return $civicrm_entity_info;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Drupal view not able to access events from participants using civicrm entity

Before
----------------------------------------
For multilingual drupal installation, the view is unable to retrieve the relationship of event table. To replicate:

- Enable multilingual support in civicrm - add FR language.
-  Create a drupal view of CiviCRM Participants.
- Try to add a relationship to CiviCRM Event table. The field is not shown since the drupal view is searching for `civicrm_event_fr_FR` or `civicrm_event_en_US` table.

After
----------------------------------------
Event field is displayed

<img width="1120" alt="image" src="https://github.com/eileenmcnaughton/civicrm_entity/assets/5929648/93405b43-493f-4882-bee0-375ab1958733">


