### PR TITLE
Add Rule Condition ContactInGroup and options provider CiviCRMGroupOptions

### DIFF
--- a/src/Plugin/Condition/ContactInGroup.php
+++ b/src/Plugin/Condition/ContactInGroup.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\civicrm_entity\Plugin\Condition;
+
+use Drupal\civicrm_entity\CiviCrmApi;
+use Drupal\civicrm_entity\Entity\CivicrmEntity;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\rules\Core\RulesConditionBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'CiviCRM Contact in Group' condition.
+ *
+ * @Condition(
+ *   id = "civicrm_entity_contact_in_group",
+ *   label = @Translation("CiviCRM Contact in Group"),
+ *   category = @Translation("CiviCRM"),
+ *   context_definitions = {
+ *     "civicrm_contact" = @ContextDefinition("entity:civicrm_contact",
+ *        label = @Translation("CiviCRM contact entity"),
+ *        description = @Translation("The CiviCRM contact entity."),
+ *        required = TRUE
+ *      ),
+ *     "group" = @ContextDefinition("string",
+ *       label = @Translation("Group"),
+ *       description = @Translation("The group the contact is in."),
+ *       options_provider = "\Drupal\civicrm_entity\TypedData\Options\CivicrmGroupOptions",
+ *       multiple = FALSE,
+ *       required = TRUE
+ *     ),
+ *   }
+ * )
+ */
+class ContactInGroup extends RulesConditionBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The CiviCRM API service.
+   *
+   * @var \Drupal\civicrm_entity\CiviCrmApi
+   */
+  protected $civicrmApi;
+
+  /**
+   * Constructs a ContactInGroup object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\civicrm_entity\CiviCrmApi $civicrm_api
+   *   The CiviCRM API service interface.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, CiviCrmApi $civicrm_api) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->civicrmApi = $civicrm_api;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('civicrm_entity.api')
+    );
+  }
+
+  /**
+   * Check if contact is in group.
+   *
+   * @param \Drupal\civicrm_entity\Entity\CivicrmEntity $civicrm_contact
+   *   The CiviCRM contact to check.
+   * @param string $group
+   *   The group id.
+   *
+   * @return bool
+   *   TRUE if the contact is in a CiviCRM group.
+   */
+  protected function doEvaluate(CivicrmEntity $civicrm_contact, string $group) {
+    try {
+      $id = $civicrm_contact->get('id')->getString();
+      if (!empty($id) && is_numeric($id)) {
+        $result = $this->civicrmApi->get('GroupContact', [
+          'sequential' => 1,
+          'contact_id' => (int) $id,
+          'group_id' => $group,
+          'status' => "Added",
+        ]);
+        if (!empty($result[0]['id'])) {
+          return TRUE;
+        }
+      }
+    }
+    catch (\CiviCRM_API3_Exception $e) {
+      return FALSE;
+    }
+    return FALSE;
+  }
+
+}

--- a/src/TypedData/Options/CivicrmGroupOptions.php
+++ b/src/TypedData/Options/CivicrmGroupOptions.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\civicrm_entity\TypedData\Options;
+
+use Drupal\civicrm_entity\CiviCrmApi;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Options provider to list CiviCRM Groups.
+ */
+class CivicrmGroupOptions extends OptionsProviderBase implements ContainerInjectionInterface {
+
+  /**
+   * The CiviCRM API service interface.
+   *
+   * @var \Drupal\civicrm_entity\CiviCrmApi
+   */
+  protected $civicrmApi;
+
+  /**
+   * Constructs a CivicrmGroupOptions object.
+   *
+   * @param \Drupal\civicrm_entity\CiviCrmApi $civicrm_api
+   *   The CiviCRM API service interface.
+   */
+  public function __construct(CiviCrmApi $civicrm_api) {
+    $this->civicrmApi = $civicrm_api;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('civicrm_entity.api')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPossibleOptions(AccountInterface $account = NULL) {
+    $options = [];
+
+    // Load all the node types.
+    $groups = $this->civicrmApi->get('group', []);
+
+    foreach ($groups as $group_id => $group) {
+      $options[$group_id] = $group['title'];
+    }
+
+    // Sort the result by value for ease of locating and selecting.
+    asort($options);
+
+    return $options;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds Rule condition "Contact in Group"
Allows configuration of contact entity and group id in the Rules condition. Returns TRUE if the contact has a GroupContact record with status = Added 

Technical Details
----------------------------------------
Includes options_provider for when Rules allows customizable select list on the condition form.

Comments
----------------------------------------
Enter the numeric group id for the group.
Example configuration for the Condition, example Rule triggered on "After updating a civicrm contact entity" event
![image](https://github.com/eileenmcnaughton/civicrm_entity/assets/1508311/5be49928-d965-46f5-9e74-8e9545a51447)
