### PR TITLE
port to 4.0.x from 436: Include dblocale table names in list of civicrm entity info

### DIFF
--- a/src/SupportedEntities.php
+++ b/src/SupportedEntities.php
@@ -715,6 +715,22 @@ final class SupportedEntities {
       if (!in_array($entity_info['civicrm entity name'], $api_entity_types)) {
         unset($civicrm_entity_info[$entity_type]);
       }
+      // Insert dblocale table names
+      $multilingual = \CRM_Core_I18n::isMultilingual();
+      if ($multilingual) {
+        // @codingStandardsIgnoreStart
+        global $dbLocale;
+        // @codingStandardsIgnoreEnd
+        if ($dbLocale) {
+          $tables = \CRM_Core_I18n_Schema::schemaStructureTables();
+          if (in_array($entity_type, $tables)) {
+            $locale_table_name = $entity_type . $dbLocale;
+            if (strlen($locale_table_name) <= 32) {
+              $civicrm_entity_info[$locale_table_name] = $entity_info;
+            }
+          }
+        }
+      }
     }
     return $civicrm_entity_info;
   }


### PR DESCRIPTION
Port of contribution to 3.x branch
See https://github.com/eileenmcnaughton/civicrm_entity/pull/436/files for details

Per new norms, new features and fixes should first go into the 4.0.x branch

