### PR TITLE
Fix incorrect columns on custom fields

### DIFF
--- a/src/Entity/CivicrmBaseFieldDefinition.php
+++ b/src/Entity/CivicrmBaseFieldDefinition.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\civicrm_entity\Entity;
+
+use Drupal\Core\Field\BaseFieldDefinition;
+
+/**
+ * Custom base field definition to fix custom field column names.
+ */
+class CivicrmBaseFieldDefinition extends BaseFieldDefinition {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getColumns() {
+    $columns = parent::getColumns();
+    $metadata = $this->getSetting('civicrm_entity_field_metadata');
+    if (is_array($metadata)) {
+      return [
+        $metadata['column_name'] => $columns['value']
+      ];
+    }
+    return $columns;
+  }
+
+}

--- a/src/Entity/FieldDefinitionProvider.php
+++ b/src/Entity/FieldDefinitionProvider.php
@@ -3,7 +3,6 @@
 namespace Drupal\civicrm_entity\Entity;
 
 use Drupal\civicrm_entity\SupportedEntities;
-use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItem;
 
@@ -33,7 +32,7 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
             $table_name = $foreign_key_dao::getTableName();
             // Verify the foreign key table is a valid entity type.
             if (array_key_exists($table_name, SupportedEntities::getInfo())) {
-              $field = BaseFieldDefinition::create('entity_reference')
+              $field = CivicrmBaseFieldDefinition::create('entity_reference')
                 ->setSetting('target_type', $foreign_key_dao::getTableName())
                 ->setSetting('handler', 'default');
               if (!empty($civicrm_field['pseudoconstant'])) {
@@ -45,7 +44,7 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
             }
           }
           elseif (isset($civicrm_field['data_type']) && $civicrm_field['data_type'] === 'ContactReference') {
-            $field = BaseFieldDefinition::create('entity_reference')
+            $field = CivicrmBaseFieldDefinition::create('entity_reference')
               ->setSetting('target_type', 'civicrm_contact')
               ->setSetting('handler', 'default');
 
@@ -67,7 +66,7 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
         case \CRM_Utils_Type::T_MONEY:
         case \CRM_Utils_Type::T_FLOAT:
           // @todo this needs to be handled.
-          $field = BaseFieldDefinition::create('float');
+          $field = CivicrmBaseFieldDefinition::create('float');
           break;
 
         case \CRM_Utils_Type::T_STRING:
@@ -102,14 +101,14 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
           break;
 
         case \CRM_Utils_Type::T_ENUM:
-          $field = BaseFieldDefinition::create('map');
+          $field = CivicrmBaseFieldDefinition::create('map');
           break;
 
         case \CRM_Utils_Type::T_TIME:
           // @see https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/DAO.php#L279
           // When T_TIME DAO throws error?
         default:
-          $field = BaseFieldDefinition::create('any');
+          $field = CivicrmBaseFieldDefinition::create('any');
           break;
       }
     }
@@ -136,11 +135,11 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
   /**
    * Gets the identifier field definition.
    *
-   * @return \Drupal\Core\Field\BaseFieldDefinition
+   * @return \Drupal\civicrm_entity\Entity\CivicrmBaseFieldDefinition
    *   The base field definition.
    */
   protected function getIdentifierDefinition() {
-    return BaseFieldDefinition::create('integer')
+    return CivicrmBaseFieldDefinition::create('integer')
       ->setReadOnly(TRUE)
       ->setSetting('unsigned', TRUE);
   }
@@ -155,12 +154,12 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
    * @param array $civicrm_field
    *   The CiviCRM field definition.
    *
-   * @return \Drupal\Core\Field\BaseFieldDefinition
+   * @return \Drupal\civicrm_entity\Entity\CivicrmBaseFieldDefinition
    *   The base field definition.
    */
   protected function getIntegerDefinition(array $civicrm_field) {
     if (!empty($civicrm_field['pseudoconstant']) && $civicrm_field['name'] != 'card_type_id') {
-      $field = BaseFieldDefinition::create('list_integer')
+      $field = CivicrmCivicrmBaseFieldDefinition::create('list_integer')
         ->setSetting('allowed_values_function', 'civicrm_entity_pseudoconstant_options')
         ->setDisplayOptions('view', [
           'label' => 'hidden',
@@ -174,7 +173,7 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
     }
     // Otherwise it is just a regular integer field.
     else {
-      $field = BaseFieldDefinition::create('integer')
+      $field = CivicrmCivicrmBaseFieldDefinition::create('integer')
         ->setDisplayOptions('view', [
           'label' => 'hidden',
           'type' => 'number_integer',
@@ -191,11 +190,11 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
   /**
    * Gets a boolean field definition.
    *
-   * @return \Drupal\Core\Field\BaseFieldDefinition
+   * @return \Drupal\civicrm_entity\Entity\CivicrmBaseFieldDefinition
    *   The base field definition.
    */
   protected function getBooleanDefinition() {
-    return BaseFieldDefinition::create('boolean')
+    return CivicrmBaseFieldDefinition::create('boolean')
       ->setDisplayOptions('form', [
         'type' => 'boolean_checkbox',
         'settings' => [
@@ -215,12 +214,12 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
    * @param array $civicrm_field
    *   The CiviCRM field definition.
    *
-   * @return \Drupal\Core\Field\BaseFieldDefinition
+   * @return \Drupal\civicrm_entity\Entity\CivicrmBaseFieldDefinition
    *   The base field definition.
    */
   protected function getStringDefinition(array $civicrm_field) {
     if (!empty($civicrm_field['pseudoconstant'])) {
-      $field = BaseFieldDefinition::create('list_string')
+      $field = CivicrmBaseFieldDefinition::create('list_string')
         ->setSetting('allowed_values_function', 'civicrm_entity_pseudoconstant_options')
         ->setDisplayOptions('view', [
           'type' => 'list_default',
@@ -233,7 +232,7 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
     }
     // Otherwise it is just a regular integer field.
     else {
-      $field = BaseFieldDefinition::create('string')
+      $field = CivicrmBaseFieldDefinition::create('string')
         ->setDisplayOptions('view', [
           'label' => 'hidden',
           'type' => 'text_default',
@@ -266,7 +265,7 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
    * @param array $civicrm_field
    *   The CiviCRM field definition.
    *
-   * @return \Drupal\Core\Field\BaseFieldDefinition
+   * @return \Drupal\civicrm_entity\Entity\CivicrmBaseFieldDefinition
    *   The base field definition.
    */
   protected function getTextDefinition(array $civicrm_field) {
@@ -285,7 +284,7 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
       $field_type = 'text_long';
     }
 
-    $field = BaseFieldDefinition::create($field_type)
+    $field = CivicrmBaseFieldDefinition::create($field_type)
       ->setDisplayOptions('view', [
         'type' => $field_type == 'string_long' ? 'basic_string' : 'text_default',
         'weight' => 0,
@@ -302,11 +301,11 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
   /**
    * Gets an email field definition.
    *
-   * @return \Drupal\Core\Field\BaseFieldDefinition
+   * @return \Drupal\civicrm_entity\Entity\CivicrmBaseFieldDefinition
    *   The base field definition.
    */
   protected function getEmailDefinition() {
-    return BaseFieldDefinition::create('email')
+    return CivicrmBaseFieldDefinition::create('email')
       ->setDisplayOptions('view', [
         'label' => 'above',
         'type' => 'string',
@@ -321,11 +320,11 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
   /**
    * Gets a URL field definition.
    *
-   * @return \Drupal\Core\Field\BaseFieldDefinition
+   * @return \Drupal\civicrm_entity\Entity\CivicrmBaseFieldDefinition
    *   The base field definition.
    */
   protected function getUrlDefinition() {
-    return BaseFieldDefinition::create('uri')
+    return CivicrmBaseFieldDefinition::create('uri')
       ->setDisplayOptions('form', [
         'type' => 'uri',
         'weight' => 0,
@@ -339,11 +338,11 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
   /**
    * Gets a date field definition.
    *
-   * @return \Drupal\Core\Field\BaseFieldDefinition
+   * @return \Drupal\civicrm_entity\Entity\CivicrmBaseFieldDefinition
    *   The base field definition.
    */
   protected function getDateDefinition() {
-    return BaseFieldDefinition::create('datetime')
+    return CivicrmBaseFieldDefinition::create('datetime')
       ->setSetting('datetime_type', DateTimeItem::DATETIME_TYPE_DATE)
       ->setDisplayOptions('form', [
         'type' => 'datetime_default',
@@ -358,11 +357,11 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
   /**
    * Gets a datetime field definition.
    *
-   * @return \Drupal\Core\Field\BaseFieldDefinition
+   * @return \Drupal\civicrm_entity\Entity\CivicrmBaseFieldDefinition
    *   The base field definition.
    */
   protected function getDatetimeDefinition() {
-    $field = BaseFieldDefinition::create('datetime')
+    $field = CivicrmBaseFieldDefinition::create('datetime')
       ->setSetting('datetime_type', DateTimeItem::DATETIME_TYPE_DATETIME)
       ->setDisplayOptions('form', [
         'type' => 'datetime_default',
@@ -380,11 +379,11 @@ class FieldDefinitionProvider implements FieldDefinitionProviderInterface {
    *
    * This is used for CiviCRM field types which are not mappable.
    *
-   * @return \Drupal\Core\Field\BaseFieldDefinition
+   * @return \Drupal\civicrm_entity\Entity\CivicrmBaseFieldDefinition
    *   The base field definition.
    */
   protected function getDefaultDefinition() {
-    return BaseFieldDefinition::create('string')
+    return CivicrmBaseFieldDefinition::create('string')
       ->setDisplayOptions('view', [
         'label' => 'hidden',
         'type' => 'text_default',

--- a/src/Plugin/views/field/CustomEntityField.php
+++ b/src/Plugin/views/field/CustomEntityField.php
@@ -99,6 +99,22 @@ class CustomEntityField extends EntityField {
   /**
    * {@inheritdoc}
    */
+  protected function getFieldDefinition() {
+    if (!$this->fieldDefinition) {
+      // The parent method always replaces the storage definition class with
+      // an instance of `BaseFieldDefinition`, causing us to lose the custom
+      // column names.
+      $field_storage = $this->getFieldStorageDefinition();
+      if ($field_storage instanceof FieldDefinitionInterface) {
+        $this->fieldDefinition = $field_storage;
+      }
+    }
+    return parent::getFieldDefinition();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   protected function defineOptions() {
     $options = parent::defineOptions();
 


### PR DESCRIPTION
Overview
----------------------------------------
Views is pulling wrong columns name for Group By in Views

Before
----------------------------------------
Issue in https://civicrm.stackexchange.com/questions/45192/getting-aggregation-to-work-in-d9-d10-views-with-civicrm-relationships

After
----------------------------------------
GROUP BY added for custom field

Technical Details
----------------------------------------
Drupal defaults the column to `value` which isn't true for custom field tables.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_

Release notes snippet
----------------------------------------
_The notes to be added on the release_
