### PR TITLE
Unsupported operand types: null + array error on custom field view

### DIFF
--- a/src/Plugin/views/field/CustomEntityField.php
+++ b/src/Plugin/views/field/CustomEntityField.php
@@ -219,7 +219,7 @@ class CustomEntityField extends EntityField {
     if ($this->limit_values) {
       $row = $this->view->result[$this->view->row_index];
 
-      if (!$this->options['group_rows'] && is_numeric($row->delta)) {
+      if (!$this->options['group_rows'] && isset($all_values[$row->delta]) && is_numeric($row->delta)) {
         return [$all_values[$row->delta]];
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix view display when custom field has NULL values in the database

Before
----------------------------------------
Still getting this error after https://github.com/eileenmcnaughton/civicrm_entity/pull/428

>TypeError: Unsupported operand types: null + array in Drupal\views\Plugin\views\field\FieldPluginBase->advancedRender() (line 1215 of /srv/www/iussp/iussp.org/web/core/modules/views/src/Plugin/views/field/FieldPluginBase.php).

Maybe, because custom field value is stored as NULL in the database for few contacts. To replicate:

- Create custom field of type date and add it on the view.
- Edit and save the custom field form inline. Do not add any value for the date field. Ensure a NULL row is created in the custom table.
- Load the view. Error `Unsupported operand types: null + array...`


After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Safety check to ensure `$all_values[$row->delta]` is available before returning the value.

