### PR TITLE
Add phone type.

### DIFF
--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -490,7 +490,7 @@ class CivicrmEntityViewsData extends EntityViewsData {
 
       case 'civicrm_phone':
         if (isset($views_field['civicrm_contact']['reverse__civicrm_phone__contact_id']['relationship'])) {
-          $views_field['civicrm_contact']['reverse__civicrm_phone__contact_id']['relationship']['id'] = 'civicrm_entity_reverse_location';
+          $views_field['civicrm_contact']['reverse__civicrm_phone__contact_id']['relationship']['id'] = 'civicrm_entity_reverse_location_phone';
           $views_field['civicrm_contact']['reverse__civicrm_phone__contact_id']['relationship']['label'] = $this->t('Phone');
         }
 

--- a/src/Plugin/views/relationship/EntityReverseLocationPhone.php
+++ b/src/Plugin/views/relationship/EntityReverseLocationPhone.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\civicrm_entity\Plugin\views\relationship;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\display\DisplayPluginBase;
+use Drupal\views\ViewExecutable;
+
+/**
+ * Reverse CiviCRM entity reference locations for phone.
+ *
+ * @ingroup views_relationship_handlers
+ *
+ * @ViewsRelationship("civicrm_entity_reverse_location_phone")
+ */
+class EntityReverseLocationPhone extends EntityReverseLocation {
+
+  /**
+   * An array of CiviCRM phone types.
+   *
+   * @var array
+   */
+  protected $phoneTypes = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function init(ViewExecutable $view, DisplayPluginBase $display, array &$options = NULL) {
+    parent::init($view, $display, $options);
+
+    $this->phoneTypes = \CRM_Core_BAO_Phone::buildOptions('phone_type_id');
+
+    if (!empty($this->options['phone_type'])) {
+      $this->definition['extra'][] = [
+        'field' => 'phone_type_id',
+        'value' => $this->options['phone_type'],
+        'numeric' => TRUE,
+      ];
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+    $options['phone_type'] = ['default' => 0];
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    $form['phone_type'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Phone type'),
+      '#options' => [0 => $this->t('Any')] + $this->phoneTypes,
+      '#default_value' => isset($this->options['phone_type']) ? (int) $this->options['phone_type'] : 0,
+      '#weight' => -2,
+    ];
+
+    parent::buildOptionsForm($form, $form_state);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This resolves https://www.drupal.org/project/civicrm_entity/issues/3327285.

Before
----------------------------------------
In Drupal 7, there was a selection of phone type when using the phone field. In D9/D10, there wasn't. This adds a configuration for relationship for D10 for phone.

After
----------------------------------------
There is selection for phone type when adding phone field.

![image](https://github.com/eileenmcnaughton/civicrm_entity/assets/34715246/84637d00-e723-4d81-8625-0b4332018c31)
