### PR TITLE
Ensure that only if we have a custom field that we pass it to getCust…

### DIFF
--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -114,7 +114,7 @@ class CivicrmEntity extends ContentEntityBase {
       $fields[$name] = $field_definition_provider->getBaseFieldDefinition($civicrm_field);
       $fields[$name]->setRequired(isset($civicrm_required_fields[$name]));
 
-      if ($values = \Drupal::service('civicrm_entity.api')->getCustomFieldMetadata($name)) {
+      if (str_starts_with($name, 'custom_') && $values = \Drupal::service('civicrm_entity.api')->getCustomFieldMetadata($name)) {
         $fields[$name]->setSetting('civicrm_entity_field_metadata', $values);
         $fields[$name]->setRequired((bool) $civicrm_field['is_required']);
       }


### PR DESCRIPTION
…omFieldMetadata

Overview
----------------------------------------
On a client site I was noticing errors in the watchdog table and the backtrace was like this and the code was essentially passing through all field_names to do a customfield.get where id = something other than a number. This aims to limit to just custom fields that we pass through to getCustomFieldMetadata

```
$backtrace = #0 /var/www/xxx/htdocs/modules/civicrm_entity/src/CiviCrmApi.php(139): CRM_Core_Error::backtrace("backtrace", TRUE)
#1 /var/www/xxx/htdocs/modules/civicrm_entity/src/Entity/CivicrmEntity.php(116): Drupal\civicrm_entity\CiviCrmApi->getCustomFieldMetadata((Array:2))
#2 /var/www/xxx/htdocs/core/lib/Drupal/Core/Entity/EntityFieldManager.php(231): Drupal\civicrm_entity\Entity\CivicrmEntity::baseFieldDefinitions(Object(Drupal\Core\Entity\ContentEntityType))
#3 /var/www/xxx/htdocs/core/lib/Drupal/Core/Entity/EntityFieldManager.php(196): Drupal\Core\Entity\EntityFieldManager->buildBaseFieldDefinitions("civicrm_action_schedule")
#4 /var/www/xxx/htdocs/modules/civicrm_entity/src/CivicrmEntityViewsData.php(104): Drupal\Core\Entity\EntityFieldManager->getBaseFieldDefinitions("civicrm_action_schedule")
#5 /var/www/xxx/htdocs/core/modules/views/views.views.inc(180): Drupal\civicrm_entity\CivicrmEntityViewsData->getViewsData()
#6 /var/www/xxx/htdocs/core/modules/views/src/ViewsData.php(236): views_views_data()
#7 /var/www/xxx/htdocs/core/lib/Drupal/Core/Extension/ModuleHandler.php(405): Drupal\views\ViewsData->Drupal\views\{closure}(Object(Closure), "views")
#8 /var/www/xxx/htdocs/core/modules/views/src/ViewsData.php(244): Drupal\Core\Extension\ModuleHandler->invokeAllWith("views_data", Object(Closure))
#9 /var/www/xxx/htdocs/core/modules/views/src/ViewsData.php(154): Drupal\views\ViewsData->getData()
#10 /var/www/xxx/htdocs/core/modules/views/src/Plugin/ViewsHandlerManager.php(85): Drupal\views\ViewsData->get("search_api_datasource_default_entity_civicrm_event")
#11 /var/www/xxx/htdocs/core/modules/views/src/Plugin/views/display/DisplayPluginBase.php(888): Drupal\views\Plugin\ViewsHandlerManager->getHandler((Array:39), NULL)
#12 /var/www/xxx/htdocs/core/modules/views/src/ViewExecutable.php(1045): Drupal\views\Plugin\views\display\DisplayPluginBase->getHandlers("field")
#13 /var/www/xxx/htdocs/core/modules/views/src/ViewExecutable.php(903): Drupal\views\ViewExecutable->_initHandler("field", (Array:5))
#14 /var/www/xxx/htdocs/core/modules/views/src/Plugin/views/display/DisplayPluginBase.php(2318): Drupal\views\ViewExecutable->initHandlers()
#15 /var/www/xxx/htdocs/core/modules/views/src/ViewExecutable.php(1697): Drupal\views\Plugin\views\display\DisplayPluginBase->preExecute()
#16 /var/www/xxx/htdocs/core/modules/views/src/ViewExecutable.php(1632): Drupal\views\ViewExecutable->preExecute((Array:0))
#17 /var/www/xxx/htdocs/core/modules/views/src/Element/View.php(81): Drupal\views\ViewExecutable->executeDisplay("page_1", (Array:0))
#18 [internal function](): Drupal\views\Element\View::preRenderViewElement((Array:17))
#19 /var/www/xxx/htdocs/core/lib/Drupal/Core/Security/DoTrustedCallbackTrait.php(101): call_user_func_array((Array:2), (Array:1))
``` 


ping @jackrabbithanna 