### PR TITLE
fix route error on entity types with dynamic bundle type

### DIFF
--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -75,6 +75,9 @@ final class RouteSubscriber extends RouteSubscriberBase {
         "field_ui.field_storage_config_add_$entity_type_id" => [
           'bundle' => $entity_type_id,
         ],
+        "field_ui.field_storage_config_reuse_{$entity_type_id}" => [
+          'bundle' => $entity_type_id,
+        ],
         "entity.entity_form_display.{$entity_type_id}.default" => [
           'bundle' => $entity_type_id,
         ],


### PR DESCRIPTION
Overview
----------------------------------------
On "Manage Fields" page for those entity types with dynamic bundle property, WSOD:
`TypeError: Symfony\Component\HttpFoundation\InputBag::get(): Argument #1 ($key) must be of type string, null given, called in ./web/core/lib/Drupal/Core/Routing/RouteMatch.php on line 127 in Symfony\Component\HttpFoundation\InputBag->get() (line 28 of ./vendor/symfony/http-foundation/InputBag.php).`

Before
----------------------------------------
WSOD

After
----------------------------------------
No error
