### PR TITLE
EntityTag now sends a object.

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -512,7 +512,7 @@ function civicrm_entity_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   }
   else {
     // Special handling for EntityTag objects.
-    if ($entityType == 'civicrm_entity_tag') {
+    if ($entityType == 'civicrm_entity_tag' && is_array($objectRef)) {
       foreach ($objectRef[0] as $entityTag) {
         $object = new CRM_Core_BAO_EntityTag();
         $object->entity_id = $entityTag;


### PR DESCRIPTION
Overview
----------------------------------------
Error: Cannot use object of type CRM_Core_BAO_EntityTag as array in civicrm_entity_civicrm_post() (line 454 of /var/sites/drupal10/web/modules/contrib/civicrm_entity/civicrm_entity.module).