### PR TITLE
Add search api fix for separate civi database.

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -33,6 +33,7 @@ use Drupal\Core\Database\Database;
 use Drupal\Core\Entity\Display\EntityDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\civicrm_entity\Plugin\search_api\datasource\CivicrmEntity as DatasourceCivicrmEntity;
 
 /**
  * Implements hook_theme().
@@ -730,5 +731,17 @@ function civicrm_entity_rules_action_info_alter(&$rules_actions) {
         '@url' => 'https://www.drupal.org/docs/8/modules/typed-data-api-enhancements/typeddata-tokens',
         '@filters' => $filters,
       ]));
+  }
+}
+
+/**
+ * Implements hook_search_api_datasource_info_alter().
+ */
+function civicrm_entity_search_api_datasource_info_alter(array &$infos) {
+  foreach ($infos as $entity_type => &$info) {
+    if (strpos($entity_type, 'entity:civicrm_') !== FALSE) {
+      unset($info['deriver']);
+      $info['class'] = DatasourceCivicrmEntity::class;
+    }
   }
 }

--- a/src/Plugin/search_api/datasource/CivicrmEntity.php
+++ b/src/Plugin/search_api/datasource/CivicrmEntity.php
@@ -15,7 +15,8 @@ class CivicrmEntity extends ContentEntity {
     $datasource = parent::create($container, $configuration, $plugin_id, $plugin_definition);
 
     $civicrm_connection_name = drupal_valid_test_ua() ? 'civicrm_test' : 'civicrm';
-    if (Database::getConnectionInfo($civicrm_connection_name)) {
+    $civicrm_database_info = Database::getConnectionInfo($civicrm_connection_name);
+    if (isset($civicrm_database_info['default'])) {
       $datasource->setDatabaseConnection(Database::getConnection('default', $civicrm_connection_name));
     }
 

--- a/src/Plugin/search_api/datasource/CivicrmEntity.php
+++ b/src/Plugin/search_api/datasource/CivicrmEntity.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\civicrm_entity\Plugin\search_api\datasource;
+
+use Drupal\Core\Database\Database;
+use Drupal\search_api\Plugin\search_api\datasource\ContentEntity;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class CivicrmEntity extends ContentEntity {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $datasource = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $civicrm_connection_name = drupal_valid_test_ua() ? 'civicrm_test' : 'civicrm';
+    $datasource->setDatabaseConnection(Database::getConnection('default', $civicrm_connection_name));
+
+    return $datasource;
+  }
+
+}

--- a/src/Plugin/search_api/datasource/CivicrmEntity.php
+++ b/src/Plugin/search_api/datasource/CivicrmEntity.php
@@ -13,8 +13,11 @@ class CivicrmEntity extends ContentEntity {
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     $datasource = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+
     $civicrm_connection_name = drupal_valid_test_ua() ? 'civicrm_test' : 'civicrm';
-    $datasource->setDatabaseConnection(Database::getConnection('default', $civicrm_connection_name));
+    if (Database::getConnectionInfo($civicrm_connection_name)) {
+      $datasource->setDatabaseConnection(Database::getConnection('default', $civicrm_connection_name));
+    }
 
     return $datasource;
   }


### PR DESCRIPTION
Overview
----------------------------------------
When civi database is different from Drupal database, when you build index, you get the error:

> Drupal\Core\Database\DatabaseExceptionWrapper: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'drupal9.civicrm_contact' doesn't exist: SELECT "base_table"."id" AS "id" FROM "civicrm_contact" "base_table" ORDER BY "id" ASC LIMIT 100 OFFSET 0; Array ( ) in Drupal\search_api\Plugin\search_api\datasource\ContentEntity->getPartialItemIds() (line 874 of /app/web/modules/contrib/search_api/src/Plugin/search_api/datasource/ContentEntity.php).

Before
----------------------------------------
Getting errors saying table don't exist.

After
----------------------------------------
Works now even if civi database is separate from Drupal.