### PR TITLE
Add check for objectref.

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -547,7 +547,7 @@ function civicrm_entity_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   }
   else {
     // Special handling for EntityTag objects.
-    if ($entityType == 'civicrm_entity_tag') {
+    if ($entityType == 'civicrm_entity_tag' && is_array($objectRef)) {
       foreach ($objectRef[0] as $entityTag) {
         $object = new CRM_Core_BAO_EntityTag();
         $object->entity_id = $entityTag;


### PR DESCRIPTION
Overview
----------------------------------------
Error occurs when doing bulk update of contacts to add tags:

> Error: Cannot use object of type CRM_Core_BAO_EntityTag as array in civicrm_entity_civicrm_post() (line 551 of /***/civicrm_entity/civicrm_entity.module).

This happens if you have a search kit that uses contacts and you use that search kit to bulk update contacts to add tags.

Before
----------------------------------------
Has error.

After
----------------------------------------
No more error.