### PR TITLE
Add state/province entity type to list of supported types

### DIFF
--- a/src/SupportedEntities.php
+++ b/src/SupportedEntities.php
@@ -605,6 +605,18 @@ final class SupportedEntities {
         'delete' => ['administer CiviCampaign'],
       ],
     ];
+    $civicrm_entity_info['civicrm_state_province'] = [
+      'civicrm entity label' => t('State/Province'),
+      'civicrm entity name' => 'state_province',
+      'label property' => 'name',
+      'permissions' => [
+        'view' => ['view all contacts'],
+        'edit' => [],
+        'update' => [],
+        'create' => [],
+        'delete' => [],
+      ],
+    ];
     $civicrm_entity_info['civicrm_tag'] = [
       'civicrm entity label' => t('Tag'),
       'civicrm entity name' => 'tag',


### PR DESCRIPTION
Overview
----------------------------------------
Add the State/Province entity type to list of supported entity types integrated into Drupal

Will be testing, and on the look out for any effects on existing Views integration, does anything change? 

Consider if "view all contacts" is the appropriate permission for the "view" operation. This is what "Country" type has now.