### PR TITLE
Add filter for state province.

### DIFF
--- a/civicrm_entity.libraries.yml
+++ b/civicrm_entity.libraries.yml
@@ -3,3 +3,12 @@ form:
   css:
     theme:
       css/civicrm_entity.form.css: {}
+
+states:
+  version: VERSION
+  js:
+    js/civicrm_entity.states.js: {}
+  dependencies:
+    - core/drupal
+    - core/jquery
+    - core/once

--- a/civicrm_entity.views.inc
+++ b/civicrm_entity.views.inc
@@ -144,6 +144,7 @@ function civicrm_entity_views_data_alter(&$data) {
   $data['civicrm_contact']['current_employer']['real field'] = 'organization_name';
   $data['civicrm_contact']['employer_id']['field']['id'] = 'standard';
   $data['civicrm_contribution']['contribution_source']['real field'] = 'source';
+  $data['civicrm_address']['state_province_id']['filter']['id'] = 'civicrm_entity_civicrm_address_state_province';
 }
 
 /**

--- a/config/schema/civicrm_entity.views.schema.yml
+++ b/config/schema/civicrm_entity.views.schema.yml
@@ -63,6 +63,9 @@ views.filter_value.civicrm_entity_civicrm_address_proximity:
       type: string
       label: 'Distance unit'
 
+views.filter.civicrm_entity_civicrm_address_state_province:
+  type: views.filter.many_to_one
+
 views.argument_validator.entity:civicrm_contact:
   type: views.argument_validator_entity
   label: 'Civicrm contact'

--- a/js/civicrm_entity.states.js
+++ b/js/civicrm_entity.states.js
@@ -17,9 +17,10 @@
       $(once('loadStates', '.views-exposed-form [data-drupal-selector="edit-' + settings.civicrm_entity.country_identifier + '"]', context)).on('change', function() {
         var countries = $(this).val();
 
+        var $stateElement = $('[data-drupal-selector="edit-' + settings.civicrm_entity.states_identifier + '"]', $(this).parents('form'));
+        $stateElement.find('option').not(':first').remove();
+
         if (countries != Drupal.t('All')) {
-          var $stateElement = $('[data-drupal-selector="edit-' + settings.civicrm_entity.states_identifier + '"]', $(this).parents('form'));
-          $stateElement.find('option').not(':first').remove();
           countries = Array.isArray(countries) ? countries : [countries];
           countries.forEach((v) => {
             $stateElement.append(settings.civicrm_entity.states[v]);

--- a/js/civicrm_entity.states.js
+++ b/js/civicrm_entity.states.js
@@ -14,11 +14,11 @@
    */
   Drupal.behaviors.civicrmEntityStates = {
     attach(context, settings) {
-      $(once('loadStates', '.views-exposed-form [data-drupal-selector="edit-country-id"]', context)).on('change', function() {
+      $(once('loadStates', '.views-exposed-form [data-drupal-selector="edit-' + settings.civicrm_entity.country_identifier + '"]', context)).on('change', function() {
         var countries = $(this).val();
 
         if (countries != Drupal.t('All')) {
-          var $stateElement = $('[data-drupal-selector="edit-state-province-id"]', $(this).parents('form'));
+          var $stateElement = $('[data-drupal-selector="edit-' + settings.civicrm_entity.states_identifier + '"]', $(this).parents('form'));
           $stateElement.find('option').not(':first').remove();
           countries = Array.isArray(countries) ? countries : [countries];
           countries.forEach((v) => {

--- a/js/civicrm_entity.states.js
+++ b/js/civicrm_entity.states.js
@@ -1,0 +1,32 @@
+/**
+ * @file
+ * civicrm_entity.states.js
+ */
+
+(function ($, Drupal) {
+
+  /**
+   * Sets states depending on the chosen country.
+   *
+   * @type {Drupal~behavior}
+   *
+   * @prop {Drupal~behaviorAttach} attach
+   */
+  Drupal.behaviors.civicrmEntityStates = {
+    attach(context, settings) {
+      $(once('loadStates', '.views-exposed-form [data-drupal-selector="edit-country-id"]', context)).on('change', function() {
+        var countries = $(this).val();
+
+        if (countries != Drupal.t('All')) {
+          var $stateElement = $('[data-drupal-selector="edit-state-province-id"]', $(this).parents('form'));
+          $stateElement.find('option').not(':first').remove();
+          countries = Array.isArray(countries) ? countries : [countries];
+          countries.forEach((v) => {
+            $stateElement.append(settings.civicrm_entity.states[v]);
+          });
+        }
+      }).trigger('change');
+    },
+  };
+
+})(jQuery, Drupal, drupalSettings);

--- a/src/Plugin/views/filter/StateProvince.php
+++ b/src/Plugin/views/filter/StateProvince.php
@@ -3,6 +3,7 @@
 namespace Drupal\civicrm_entity\Plugin\views\filter;
 
 use Drupal\civicrm_entity\CiviCrmApiInterface;
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\options\Plugin\views\filter\ListField;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -52,6 +53,13 @@ class StateProvince extends ListField {
     $handler = $view->getHandler($this->view->current_display, 'filter', 'country_id');
 
     if ($exposed && !empty($handler) && $handler['table'] == 'civicrm_address' && $handler['field'] == 'country_id') {
+      $user_input = $form_state->getUserInput();
+
+      $selected = [];
+      if (isset($user_input[$this->options['expose']['identifier']])) {
+        $selected = is_array($user_input[$this->options['expose']['identifier']]) ? $user_input[$this->options['expose']['identifier']] : [$user_input[$this->options['expose']['identifier']]];
+      }
+
       if ($handler['exposed']) {
         $countries = array_keys(\CRM_Core_PseudoConstant::country());
         $country_states = $this->getStates($countries);
@@ -64,9 +72,11 @@ class StateProvince extends ListField {
           }
 
           foreach ($states as $k => $v) {
-            $js_country_states[$country_id] .= '<option value="' . $k . '">' . $v . '</option>';
+            $js_country_states[$country_id] .= '<option value="' . $k . '"' . (in_array($k, $selected) ? 'selected="selected"' : '') . '>' . $v . '</option>';
           }
         }
+        $form['#attached']['drupalSettings']['civicrm_entity']['states_identifier'] = Html::cleanCssIdentifier($this->options['expose']['identifier']);
+        $form['#attached']['drupalSettings']['civicrm_entity']['country_identifier'] = Html::cleanCssIdentifier($handler['expose']['identifier']);
         $form['#attached']['drupalSettings']['civicrm_entity']['states'] = $js_country_states;
         $form['#attached']['library'][] = 'civicrm_entity/states';
       }

--- a/src/Plugin/views/filter/StateProvince.php
+++ b/src/Plugin/views/filter/StateProvince.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Drupal\civicrm_entity\Plugin\views\filter;
+
+use Drupal\civicrm_entity\CiviCrmApiInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\options\Plugin\views\filter\ListField;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Filter handler for proximity.
+ *
+ * @ViewsFilter("civicrm_entity_civicrm_address_state_province")
+ */
+class StateProvince extends ListField {
+
+  /**
+   * The CiviCRM API.
+   *
+   * @var \Drupal\civicrm_entity\CiviCrmApiInterface
+   */
+  protected $civicrmApi;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, array $plugin_definition, CiviCrmApiInterface $civicrm_api) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->civicrmApi = $civicrm_api;
+
+    $this->civicrmApi->civicrmInitialize();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('civicrm_entity.api')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function valueForm(&$form, FormStateInterface $form_state) {
+    $exposed = $form_state->get('exposed');
+    $view = $form_state->get('view');
+    $handler = $view->getHandler($this->view->current_display, 'filter', 'country_id');
+
+    if ($exposed && !empty($handler) && $handler['table'] == 'civicrm_address' && $handler['field'] == 'country_id') {
+      if ($handler['exposed']) {
+        $countries = array_keys(\CRM_Core_PseudoConstant::country());
+        $country_states = $this->getStates($countries);
+
+        // Convert to HTML options.
+        $js_country_states = [];
+        foreach ($country_states as $country_id => $states) {
+          if (empty($js_country_states[$country_id])) {
+            $js_country_states[$country_id] = '';
+          }
+
+          foreach ($states as $k => $v) {
+            $js_country_states[$country_id] .= '<option value="' . $k . '">' . $v . '</option>';
+          }
+        }
+        $form['#attached']['drupalSettings']['civicrm_entity']['states'] = $js_country_states;
+        $form['#attached']['library'][] = 'civicrm_entity/states';
+      }
+      else {
+        $selected_countries = is_array($handler['value']) ? $handler['value'] : [$handler['value']];
+        $country_states = $this->getStates($selected_countries);
+        $this->valueOptions = [];
+        foreach ($country_states as $states) {
+          $this->valueOptions += $states;
+        }
+      }
+    }
+
+    parent::valueForm($form, $form_state);
+  }
+
+  /**
+   * Gets the corresponding states.
+   *
+   * @param array $countries
+   *   The countries.
+   *
+   * @return array
+   *   The states keyed by country_id.
+   */
+  protected function getStates(array $countries): array {
+    $states = [];
+
+    $countries = implode(', ', $countries);
+    $query = "SELECT id, name, country_id FROM civicrm_state_province WHERE country_id IN ($countries) ORDER BY name ASC";
+    $result = \CRM_Core_DAO::executeQuery($query);
+
+    while ($result->fetch()) {
+      $states[$result->country_id][$result->id] = $result->name;
+    }
+
+    return $states;
+  }
+
+}

--- a/src/Plugin/views/filter/StateProvince.php
+++ b/src/Plugin/views/filter/StateProvince.php
@@ -48,7 +48,7 @@ class StateProvince extends ListField {
    */
   protected function valueForm(&$form, FormStateInterface $form_state) {
     $exposed = $form_state->get('exposed');
-    $view = $form_state->get('view');
+    $view = $this->view;
     $handler = $view->getHandler($this->view->current_display, 'filter', 'country_id');
 
     if ($exposed && !empty($handler) && $handler['table'] == 'civicrm_address' && $handler['field'] == 'country_id') {


### PR DESCRIPTION
Overview
----------------------------------------
There was no "State/Province" filter for in D10 version similar to D7's civicrm_handler_filter_state_multi. This provides a similar feature including the limitations. These includes:

* The "State/Province" filter also doesn't work if the country field does not exist. 
* The filter also doesn't work when there are multiple country and state province fields.

Before
----------------------------------------
No "State/Province" filter.

After
----------------------------------------
Has "State/Province" filter.