### PR TITLE
Replace deprecation for search_api.

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -33,7 +33,6 @@ use Drupal\Core\Database\Database;
 use Drupal\Core\Entity\Display\EntityDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\civicrm_entity\Plugin\search_api\datasource\CivicrmEntity as DatasourceCivicrmEntity;
 
 /**
  * Implements hook_theme().
@@ -731,17 +730,5 @@ function civicrm_entity_rules_action_info_alter(&$rules_actions) {
         '@url' => 'https://www.drupal.org/docs/8/modules/typed-data-api-enhancements/typeddata-tokens',
         '@filters' => $filters,
       ]));
-  }
-}
-
-/**
- * Implements hook_search_api_datasource_info_alter().
- */
-function civicrm_entity_search_api_datasource_info_alter(array &$infos) {
-  foreach ($infos as $entity_type => &$info) {
-    if (strpos($entity_type, 'entity:civicrm_') !== FALSE) {
-      unset($info['deriver']);
-      $info['class'] = DatasourceCivicrmEntity::class;
-    }
   }
 }

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -734,18 +734,6 @@ function civicrm_entity_rules_action_info_alter(&$rules_actions) {
 }
 
 /**
- * Implements hook_search_api_datasource_info_alter().
- */
-function civicrm_entity_search_api_datasource_info_alter(array &$infos) {
-  foreach ($infos as $entity_type => &$info) {
-    if (strpos($entity_type, 'entity:civicrm_') !== FALSE) {
-      unset($info['deriver']);
-      $info['class'] = DatasourceCivicrmEntity::class;
-    }
-  }
-}
-
-/**
  * Implements hook_civicrm_merge().
  */
 function civicrm_entity_civicrm_merge($mode, &$sqls, $mainId = NULL, $otherId = NULL, $tables = NULL) {

--- a/civicrm_entity.services.yml
+++ b/civicrm_entity.services.yml
@@ -25,3 +25,8 @@ services:
     arguments: ['@civicrm_entity.module_installer.inner', '%app.root%', '@module_handler', '@kernel', '@database', '@update.update_hook_registry']
     tags:
       - { name: service_collector, tag: 'module_install.uninstall_validator', call: addUninstallValidator }
+
+  civicrm_entity.search_api:
+    class: Drupal\civicrm_entity\EventSubscriber\SearchApiSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/src/EventSubscriber/SearchApiSubscriber.php
+++ b/src/EventSubscriber/SearchApiSubscriber.php
@@ -3,7 +3,6 @@
 namespace Drupal\civicrm_entity\EventSubscriber;
 
 use Drupal\search_api\Event\GatheringPluginInfoEvent;
-use Drupal\search_api\Event\SearchApiEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Drupal\civicrm_entity\Plugin\search_api\datasource\CivicrmEntity as DatasourceCivicrmEntity;
 
@@ -32,7 +31,7 @@ class SearchApiSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      SearchApiEvents::GATHERING_DATA_SOURCES => ['onGatheringDataSources'],
+      'search_api.gathering_data_sources' => ['onGatheringDataSources'],
     ];
   }
 

--- a/src/EventSubscriber/SearchApiSubscriber.php
+++ b/src/EventSubscriber/SearchApiSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\civicrm_entity\EventSubscriber;
+
+use Drupal\search_api\Event\GatheringPluginInfoEvent;
+use Drupal\search_api\Event\SearchApiEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\civicrm_entity\Plugin\search_api\datasource\CivicrmEntity as DatasourceCivicrmEntity;
+
+/**
+ * CiviCRM Entity event subscriber.
+ */
+class SearchApiSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Gathering plugin info event handler.
+   *
+   * @param \Drupal\search_api\Event\GatheringPluginInfoEvent $event
+   *   Gathering info event.
+   */
+  public function onGatheringDataSources(GatheringPluginInfoEvent $event) {
+    foreach ($event->getDefinitions() as $entity_type => &$definition) {
+      if (strpos($entity_type, 'entity:civicrm_') !== FALSE) {
+        unset($definition['deriver']);
+        $definition['class'] = DatasourceCivicrmEntity::class;
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      SearchApiEvents::GATHERING_DATA_SOURCES => ['onGatheringDataSources'],
+    ];
+  }
+
+}


### PR DESCRIPTION
Follow up for #450.

Replaces deprecation for search_api - https://git.drupalcode.org/project/search_api/-/blob/8.x-1.x/search_api.api.php?ref_type=heads#L68.