### PR TITLE
Add reset to the file URLs generated.

### DIFF
--- a/src/Plugin/views/field/CustomFile.php
+++ b/src/Plugin/views/field/CustomFile.php
@@ -76,7 +76,7 @@ class CustomFile extends FieldPluginBase {
       $entity_id = $this->getValue($values, 'entity_id');
       $file_hash = \CRM_Core_BAO_File::generateFileHash($entity_id, $value);
 
-      $query = ['id' => $value, 'eid' => $entity_id, 'fcs' => $file_hash];
+      $query = ['id' => $value, 'eid' => $entity_id, 'fcs' => $file_hash, 'reset' => 1];
       return \CRM_Utils_System::url($path, UrlHelper::buildQuery($query), TRUE, FALSE, FALSE, TRUE);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
When creating a view that contains file URLs, the URLs generated when visited throws this error:

> Supplied mime-type is not accepted

It looks like the URLs need `reset=1` query parameter in them.

Before
----------------------------------------
File URLs throws error.

After
----------------------------------------
No more error.