### PR TITLE
Add workaround for views activity related fields.

### DIFF
--- a/civicrm_entity.views.inc
+++ b/civicrm_entity.views.inc
@@ -144,6 +144,15 @@ function civicrm_entity_views_data_alter(&$data) {
   $data['civicrm_contact']['current_employer']['real field'] = 'organization_name';
   $data['civicrm_contact']['employer_id']['field']['id'] = 'standard';
   $data['civicrm_contribution']['contribution_source']['real field'] = 'source';
+
+  $service = \Drupal::service('entity_field.manager');
+  $field_definitions = $service->getFieldDefinitions('civicrm_activity', 'civicrm_activity');
+
+  foreach (['status_id', 'activity_type_id'] as $key) {
+    $data['civicrm_activity'][$key]['filter']['id'] = 'in_operator';
+    $data['civicrm_activity'][$key]['filter']['options callback'] = 'civicrm_entity_pseudoconstant_options';
+    $data['civicrm_activity'][$key]['filter']['options arguments'] = [$field_definitions[$key]];
+  }
 }
 
 /**

--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -500,7 +500,7 @@ class CivicrmEntityViewsData extends EntityViewsData {
           $views_field['civicrm_contact']['reverse__civicrm_website__contact_id']['relationship']['id'] = 'civicrm_entity_reverse_website_type';
           $views_field['civicrm_contact']['reverse__civicrm_website__contact_id']['relationship']['label'] = $this->t('Website');
         }
-  
+
         break;
       case 'civicrm_address':
         if (isset($views_field['civicrm_contact']['reverse__civicrm_address__contact_id']['relationship'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Activity status and type filters throw the following errors:

```
Error: Attempt to assign property "type" on null in Drupal\views\ManyToOneHelper->ensureMyTable() (line 251 of ./web/core/modules/views/src/ManyToOneHelper.php).
```

This happens when creating a view like this:

> Create View listing Activities
> Add "Activity Status" filter
> Choose "is none of" or "is all of" operation.
> Save View, now error.

Before
----------------------------------------
Throws an error.

After
----------------------------------------
The whole filter plugin is overridden from "list_field" to "in_operator" as a workaround to avoid the error.

Technical Details
----------------------------------------
Existing views that use the filters for activity status and type might need to reconfigure their views. The other difference is that "list_field" has the following operators:

* Is one of
* Is all of
* Is none of

The in_operator is somewhat simpler where in the operators are only the following:

* Is one of
* Is not one of