### PR TITLE
Update default timezone handling for dates in CiviEntityStorage.php

### DIFF
--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -418,7 +418,7 @@ class CiviEntityStorage extends SqlContentEntityStorage {
           }
           else {
             $datetime_format = $definition->getSetting('datetime_type') === DateTimeItem::DATETIME_TYPE_DATE ? DateTimeItemInterface::DATE_STORAGE_FORMAT : DateTimeItemInterface::DATETIME_STORAGE_FORMAT;
-            $default_timezone = \Drupal::config('system.date')->get('timezone.default') ?? date_default_timezone_get();
+            $default_timezone = $definition->getSetting('datetime_type') === DateTimeItem::DATETIME_TYPE_DATE ? DateTimeItemInterface::STORAGE_TIMEZONE : \Drupal::config('system.date')->get('timezone.default') ?? date_default_timezone_get();
             $datetime_value = (new \DateTime($item[$main_property_name], new \DateTimeZone($default_timezone)))->setTimezone(new \DateTimeZone('UTC'))->format($datetime_format);
             $item_values[$delta][$main_property_name] = $datetime_value;
           }


### PR DESCRIPTION
Overview
----------------------------------------
When handling date values, always use the `DateTimeItemInterface::STORAGE_TIMEZONE` when converting the data.

Before
----------------------------------------
When a view is taking a `date` field from a CIVICRM entity, it uses the site's default timezone when setting the value to be displayed. Given that this is a date field, it does not have a timezone. 
<img width="560" alt="image" src="https://github.com/eileenmcnaughton/civicrm_entity/assets/569924/540fcd9a-e387-4279-9e9d-e8330cf799a3">

<img width="273" alt="image" src="https://github.com/eileenmcnaughton/civicrm_entity/assets/569924/3d2fba23-df94-4905-ad7f-dcc2640dbf24">


After
----------------------------------------
We check to see if this is a date field or a datetime field. if it is a date field, use `DateTimeItemInterface::STORAGE_TIMEZONE` to ensure we don't accidentally change the date in the process.

<img width="316" alt="image" src="https://github.com/eileenmcnaughton/civicrm_entity/assets/569924/086a5b4b-0e6e-47b8-b1c2-7770b6935c13">

Technical Details
----------------------------------------
The `DateTimeItemInterface::STORAGE_TIMEZONE` assumes that all datetime data is stored in UTC, so we must also ensure our default timezone is UTC when dealing with date fields.

Comments
----------------------------------------
I note that Drupal still shows a time of `12:00` no matter what, but that can be handled via formatting.

