### PR TITLE
Clean up the value of the float (number) and money field types in the custom field.

### DIFF
--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -429,7 +429,21 @@ class CiviEntityStorage extends SqlContentEntityStorage {
 
     // Handle special cases for field definitions.
     foreach ($field_definitions as $definition) {
-      if (($field_metadata = $definition->getSetting('civicrm_entity_field_metadata')) && isset($field_metadata['custom_group_id']) && $field_metadata['data_type'] === 'File') {
+      if (($field_metadata = $definition->getSetting('civicrm_entity_field_metadata')) && isset($field_metadata['custom_group_id']) && in_array($field_metadata['data_type'],['Float', 'Money'])) {
+        $items = $entity->get($definition->getName());
+        $item_values = $items->getValue();
+        if (!empty($item_values)) {
+          $ret = [];
+          foreach ($item_values as $value) {
+            $v = \CRM_Utils_Rule::cleanMoney($value['value']);
+            $ret[] = ['value' => $v];
+          }
+          if (!empty($ret)) {
+            $items->setValue($ret);
+          }
+        }
+      }
+      elseif (($field_metadata = $definition->getSetting('civicrm_entity_field_metadata')) && isset($field_metadata['custom_group_id']) && $field_metadata['data_type'] === 'File') {
         $items = $entity->get($definition->getName());
         $item_values = $items->getValue();
 


### PR DESCRIPTION
Overview
----------------------------------------
Clean the field value for custom field of type Money and Number (Float).

Before
----------------------------------------
Error on formatted custom field values activity entity.

After
----------------------------------------
Error not present. Using the views formatter, admins can decide about value.


Technical Details
----------------------------------------

```
#0 demo10/web/core/lib/Drupal/Core/Field/Plugin/Field/FieldFormatter/DecimalFormatter.php(67): number_format('123,456,789', 2, '.', '')
#1 demo10/web/core/lib/Drupal/Core/Field/Plugin/Field/FieldFormatter/NumericFormatterBase.php(66): Drupal\Core\Field\Plugin\Field\FieldFormatter\DecimalFormatter->numberFormat('123,456,789')
#2 demo10/web/core/lib/Drupal/Core/Field/FormatterBase.php(89): Drupal\Core\Field\Plugin\Field\FieldFormatter\NumericFormatterBase->viewElements(Object(Drupal\Core\Field\FieldItemList), 'en')
#3 demo10/web/core/lib/Drupal/Core/Entity/Entity/EntityViewDisplay.php(268): Drupal\Core\Field\FormatterBase->view(Object(Drupal\Core\Field\FieldItemList), 'en')
#4 demo10/web/core/lib/Drupal/Core/Entity/EntityViewBuilder.php(339): Drupal\Core\Entity\Entity\EntityViewDisplay->buildMultiple(Array)
#5 demo10/web/core/lib/Drupal/Core/Entity/EntityViewBuilder.php(281): Drupal\Core\Entity\EntityViewBuilder->buildComponents(Array, Array, Array, 'full')
#6 demo10/web/core/lib/Drupal/Core/Entity/EntityViewBuilder.php(238): Drupal\Core\Entity\EntityViewBuilder->buildMultiple(Array)
#7 [internal function]: Drupal\Core\Entity\EntityViewBuilder->build(Array)
#8 demo10/web/core/lib/Drupal/Core/Security/DoTrustedCallbackTrait.php(111): call_user_func_array(Array, Array)
#9 demo10/web/core/lib/Drupal/Core/Render/Renderer.php(858): Drupal\Core\Render\Renderer->doTrustedCallback(Array, Array, 'Render #pre_ren...', 'exception', 'Drupal\\Core\\Ren...')
#10 demo10/web/core/lib/Drupal/Core/Render/Renderer.php(421): Drupal\Core\Render\Renderer->doCallback('#pre_render', Array, Array)
#11 demo10/web/core/lib/Drupal/Core/Render/Renderer.php(240): Drupal\Core\Render\Renderer->doRender(Array, false)
#12 demo10/web/core/lib/Drupal/Core/Render/MainContent/HtmlRenderer.php(238): Drupal\Core\Render\Renderer->render(Array, false)
#13 demo10/web/core/lib/Drupal/Core/Render/Renderer.php(627): Drupal\Core\Render\MainContent\HtmlRenderer->Drupal\Core\Render\MainContent\{closure}()
#14 demo10/web/core/lib/Drupal/Core/Render/MainContent/HtmlRenderer.php(239): Drupal\Core\Render\Renderer->executeInRenderContext(Object(Drupal\Core\Render\RenderContext), Object(Closure))
#15 demo10/web/core/lib/Drupal/Core/Render/MainContent/HtmlRenderer.php(128): Drupal\Core\Render\MainContent\HtmlRenderer->prepare(Array, Object(Symfony\Component\HttpFoundation\Request), Object(Drupal\Core\Routing\CurrentRouteMatch))
#16 demo10/web/core/lib/Drupal/Core/EventSubscriber/MainContentViewSubscriber.php(90): Drupal\Core\Render\MainContent\HtmlRenderer->renderResponse(Array, Object(Symfony\Component\HttpFoundation\Request), Object(Drupal\Core\Routing\CurrentRouteMatch))
#17 [internal function]: Drupal\Core\EventSubscriber\MainContentViewSubscriber->onViewRenderArray(Object(Symfony\Component\HttpKernel\Event\ViewEvent), 'kernel.view', Object(Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher))
#18 demo10/web/core/lib/Drupal/Component/EventDispatcher/ContainerAwareEventDispatcher.php(111): call_user_func(Array, Object(Symfony\Component\HttpKernel\Event\ViewEvent), 'kernel.view', Object(Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher))
#19 demo10/vendor/symfony/http-kernel/HttpKernel.php(186): Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch(Object(Symfony\Component\HttpKernel\Event\ViewEvent), 'kernel.view')
#20 demo10/vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#21 demo10/web/core/lib/Drupal/Core/StackMiddleware/Session.php(58): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#22 demo10/web/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(48): Drupal\Core\StackMiddleware\Session->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#23 demo10/web/core/lib/Drupal/Core/StackMiddleware/ContentLength.php(28): Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#24 demo10/web/core/modules/big_pipe/src/StackMiddleware/ContentLength.php(32): Drupal\Core\StackMiddleware\ContentLength->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#25 demo10/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(106): Drupal\big_pipe\StackMiddleware\ContentLength->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#26 demo10/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(85): Drupal\page_cache\StackMiddleware\PageCache->pass(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#27 demo10/web/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(48): Drupal\page_cache\StackMiddleware\PageCache->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#28 demo10/web/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(51): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#29 demo10/web/core/lib/Drupal/Core/StackMiddleware/AjaxPageState.php(36): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#30 demo10/web/core/lib/Drupal/Core/StackMiddleware/StackedHttpKernel.php(51): Drupal\Core\StackMiddleware\AjaxPageState->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#31 demo10/web/core/lib/Drupal/Core/DrupalKernel.php(704): Drupal\Core\StackMiddleware\StackedHttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#32 demo10/web/index.php(19): Drupal\Core\DrupalKernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#33 {main}
```

Custom field types of numbers and money are created for activity types.

Access that activity record using the following URL (here 12 is the activity ID).

https://demo10/civicrm-activity/12