### PR TITLE
Adding a raw value function to return value from values array

### DIFF
--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -229,4 +229,8 @@ class CivicrmEntity extends ContentEntityBase {
     return $params;
   }
 
+  public function getRawValue($field) {
+    return $this->values[$field] ?? '';
+  }
+
 }


### PR DESCRIPTION
Problem/Motivation
I was working on a custom field handler and I got ResultRow class from views where I can access _entity which then has $values which has raw values of the entity fields, the entity I am working on had a contact reference field so the $values has the referred contact id and that is what I wanted, but as the $values is a protected variable I can't access it outside the class and there is no option to get the value in it. I tried using the $row->_entity->toArray() but that returns the display_name or label of the contact and not the id, I also tried civicrmApiNormalize function but the result is same.

Proposed resolution
We can add a function which acts like a getter to fetch value from the $values array.

as reported in https://www.drupal.org/project/civicrm_entity/issues/3420872