### PR TITLE
update test versions of Drupal 10.2 and CiviCRM 5.69

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - drupal: '10.0.*'
+          - drupal: '10.2.*'
+            civicrm: '5.69.*'
+          - drupal: '10.2.*'
             civicrm: 'dev-master'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:

--- a/tests/src/FunctionalJavascript/Views/CivicrmAddressViewsTest.php
+++ b/tests/src/FunctionalJavascript/Views/CivicrmAddressViewsTest.php
@@ -193,7 +193,7 @@ final class CivicrmAddressViewsTest extends CivicrmEntityViewsTestBase {
       case 2:
         $assert_session->pageTextContainsOnce('Billing');
         $assert_session->pageTextContains('United States');
-        $assert_session->pageTextContainsOnce(75001);
+        $assert_session->pageTextContainsOnce('75001');
         $assert_session->pageTextContainsOnce('Texas');
         $assert_session->pageTextContainsOnce('3820 Vitruvian Way');
         break;


### PR DESCRIPTION
Overview
----------------------------------------
Test against Drupal 10.2 and dev-master
Add tests for Drupal 10.2 and CiviCRM 5.69