### PR TITLE
Ignore convert to UTC if custom field is date only

### DIFF
--- a/src/Plugin/views/field/CustomEntityField.php
+++ b/src/Plugin/views/field/CustomEntityField.php
@@ -362,7 +362,7 @@ class CustomEntityField extends EntityField {
         'id' => $custom_field_id,
       ];
       $date_field = $this->civicrmApi->get('CustomField', $params);
-      if (!empty($date_field[0]['date_format']) && $date_field[0]['date_format'] === 'yy') {
+      if (empty($date_field[0]['time_format'])) {
         $utc = FALSE;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
This activity in CiviCRM has custom field Date of 01/06/2023. The same is stored in db

However, when displaying within a view, this changes to 31/05/2023

Ref:https://github.com/eileenmcnaughton/civicrm_entity/pull/439/files

