### PR TITLE
Pathauto

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -762,3 +762,19 @@ function civicrm_entity_query_pathauto_bulk_update_alter(AlterableInterface $que
     }
   }
 }
+
+/**
+ * Implements hook_query_TAG_alter().
+ */
+function civicrm_entity_query_pathauto_bulk_delete_alter(AlterableInterface $query) {
+  $tables = &$query->getTables();
+
+  if (strpos($tables['base_table']['table'], 'civicrm_') !== FALSE) {
+    $civicrm_connection_name = drupal_valid_test_ua() ? 'civicrm_test' : 'civicrm';
+    $civicrm_database_info = Database::getConnectionInfo($civicrm_connection_name);
+    if (isset($civicrm_database_info['default'])) {
+      $connection = Database::getConnection('default', $civicrm_connection_name);
+      $tables['base_table']['table'] = $connection->getFullQualifiedTableName($tables['base_table']['table']);
+    }
+  }
+}

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -15,6 +15,7 @@ use Drupal\civicrm_entity\Entity\Sql\CivicrmEntityStorageSchema;
 use Drupal\civicrm_entity\Form\CivicrmEntityForm;
 use Drupal\civicrm_entity\Routing\CiviCrmEntityRouteProvider;
 use Drupal\civicrm_entity\SupportedEntities;
+use Drupal\Core\Database\Query\AlterableInterface;
 use Drupal\Core\Entity\ContentEntityDeleteForm;
 use Drupal\Core\Entity\ContentEntityType;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
@@ -742,6 +743,22 @@ function civicrm_entity_search_api_datasource_info_alter(array &$infos) {
     if (strpos($entity_type, 'entity:civicrm_') !== FALSE) {
       unset($info['deriver']);
       $info['class'] = DatasourceCivicrmEntity::class;
+    }
+  }
+}
+
+/**
+ * Implements hook_query_TAG_alter().
+ */
+function civicrm_entity_query_pathauto_bulk_update_alter(AlterableInterface $query) {
+  $tables = &$query->getTables();
+
+  if (strpos($tables['base_table']['table'], 'civicrm_') !== FALSE) {
+    $civicrm_connection_name = drupal_valid_test_ua() ? 'civicrm_test' : 'civicrm';
+    $civicrm_database_info = Database::getConnectionInfo($civicrm_connection_name);
+    if (isset($civicrm_database_info['default'])) {
+      $connection = Database::getConnection('default', $civicrm_connection_name);
+      $tables['base_table']['table'] = $connection->getFullQualifiedTableName($tables['base_table']['table']);
     }
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
Bulk update for pathauto throws the following error when generating for CiviCRM entities:

```
Drupal\Core\Database\DatabaseExceptionWrapper: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'drupal10.civicrm_event' doesn't exist: SELECT COUNT(*) AS "expression" FROM (SELECT 1 AS "expression" FROM "civicrm_event" "base_table" LEFT OUTER JOIN "path_alias" "pa" ON CONCAT('/civicrm-event/' , base_table.id) = pa.path WHERE "base_table"."id" > :db_condition_placeholder_0) "subquery"; Array ( [:db_condition_placeholder_0] => 0 ) in Drupal\pathauto\Plugin\pathauto\AliasType\EntityAliasTypeBase->batchUpdate() (line 177 of /app/web/modules/contrib/pathauto/src/Plugin/pathauto/AliasType/EntityAliasTypeBase.php).
```

A similar error is also being thrown when doing a bulk delete for aliases generated using pathauto.

Individually updating CiviCRM entities when ticking "Generate automatic URL alias" works fine though.

Before
----------------------------------------
Bulk update or delete in pathauto doesn't work.

After
----------------------------------------
Works now.