### PR TITLE
fix testLoadContact birthdate assertion

### DIFF
--- a/tests/src/Kernel/CivicrmStorageGetTest.php
+++ b/tests/src/Kernel/CivicrmStorageGetTest.php
@@ -62,7 +62,7 @@ class CivicrmStorageGetTest extends CivicrmEntityTestBase {
     $this->assertInstanceOf(CivicrmEntity::class, $entity);
     $this->assertEquals($entity->id(), 10);
     $this->assertEquals($entity->get('display_name')->value, 'Emma Neal');
-    $this->assertEquals('1982/06/27', $entity->get('birth_date')->date->format('Y/m/d'));
+    $this->assertEquals('1982/06/28', $entity->get('birth_date')->date->format('Y/m/d'));
   }
 
   /**


### PR DESCRIPTION
While reviewing https://github.com/eileenmcnaughton/civicrm_entity/pull/461
I realized that one of the tests could have an incorrect assertion
https://github.com/eileenmcnaughton/civicrm_entity/pull/461#issuecomment-2066679398

The test: https://github.com/eileenmcnaughton/civicrm_entity/blob/4.0.x/tests/src/Kernel/CivicrmStorageGetTest.php#L65
`$this->assertEquals('1982/06/27', $entity->get('birth_date')->date->format('Y/m/d'));
`But the test data looks like https://github.com/eileenmcnaughton/civicrm_entity/blob/4.0.x/tests/src/Kernel/CivicrmEntityTestBase.php#L1696
`'birth_date' => '1982-06-28',`