### PR TITLE
fix test to use string instead of integer for zip code

### DIFF
--- a/tests/src/FunctionalJavascript/Views/CivicrmAddressViewsTest.php
+++ b/tests/src/FunctionalJavascript/Views/CivicrmAddressViewsTest.php
@@ -159,7 +159,7 @@ final class CivicrmAddressViewsTest extends CivicrmEntityViewsTestBase {
     $assert_session = $this->assertSession();
     $assert_session->elementTextContains('css', '.views-row:first-child', 'Texas');
     $assert_session->elementTextContains('css', '.views-row:first-child', 'United States');
-    $assert_session->elementTextContains('css', '.views-row:first-child', 75001);
+    $assert_session->elementTextContains('css', '.views-row:first-child', '75001');
     $assert_session->elementTextContains('css', '.views-row:first-child', '3820 Vitruvian Way');
   }
 


### PR DESCRIPTION
Fix test error on local 