### PR TITLE
Bundle info base field definitions fix

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -35,6 +35,7 @@ use Drupal\Core\Entity\Display\EntityDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\civicrm_entity\Plugin\search_api\datasource\CivicrmEntity as DatasourceCivicrmEntity;
+use Drupal\Core\Field\Entity\BaseFieldOverride;
 
 /**
  * Implements hook_theme().
@@ -235,6 +236,14 @@ function civicrm_entity_entity_bundle_field_info(EntityTypeInterface $entity_typ
     foreach ($cloned_field_configs as $field_instance) {
       $result[$field_instance->getName()] = $field_instance;
     }
+  }
+  // Ensure all fields have a definition.
+  foreach ($base_field_definitions as $field_name => $definition) {
+    if (isset($result[$field_name])) {
+      continue;
+    }
+    $field = BaseFieldOverride::createFromBaseFieldDefinition($base_field_definitions[$field_name], $bundle);
+    $result[$field_name] = $field;
   }
   return $result;
 }


### PR DESCRIPTION
Overview
----------------------------------------
For issue: https://www.drupal.org/project/civicrm_entity/issues/3420771

When addtocalendar module is installed. "Manage Display" pages for enabled entity types have error like
`Drupal\Core\Field\FieldException: Attempt to create a base field bundle override of field birth_date without a bundle in Drupal\Core\Field\Entity\BaseFieldOverride->__construct() (line 110 of /var/www/web/distro10.skvare.com/web/core/lib/Drupal/Core/Field/Entity/BaseFieldOverride.php).`


https://www.drupal.org/files/issues/2024-02-12/entity_missing_bundle-3420771-1.patch
