### PR TITLE
supportedentities update AllCoreTables function

### DIFF
--- a/src/SupportedEntities.php
+++ b/src/SupportedEntities.php
@@ -882,7 +882,7 @@ final class SupportedEntities {
   public static function getEntityTypeDaoClass($entity_type_id) {
     \Drupal::service('civicrm_entity.api')->civicrmInitialize();
 
-    $tables = \CRM_Core_DAO_AllCoreTables::getCoreTables();
+    $tables = \CRM_Core_DAO_AllCoreTables::tables();
     return $tables[$entity_type_id] ?? NULL;
   }
 


### PR DESCRIPTION
From https://www.drupal.org/project/civicrm_entity/issues/3444138
### Problem/Motivation

Many message
Deprecated function CRM_Core_DAO_AllCoreTables::getCoreTables, use CRM_Core_DAO_AllCoreTables::tables. CRM_Core_Error::deprecatedFunctionWarning CRM_Core_DAO_AllCoreTables::getCoreTables Drupal\civicrm_entity\SupportedEntities::getEntityTypeDaoClass Drupal\civicrm_entity\CivicrmEntityViewsData::getViewsFilterPlugin Array ( [civi.tag] => deprecated )

### Proposed resolution

In SupporteddEntities class, method getEntityTypeDaoClass, call \CRM_Core_DAO_AllCoreTables::tables(); instead of \CRM_Core_DAO_AllCoreTables::getCoreTables();

### Other notes

Function was deprecated in 5.72
Only thing to be sure of here is will this change break functionality in older versions of CiviCRM. 

