### PR TITLE
Fix metatag not loading.

### DIFF
--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -416,7 +416,7 @@ class CiviEntityStorage extends SqlContentEntityStorage {
     $civicrm_entity_settings = $this->getConfigFactory()->get('civicrm_entity.settings');
     $field_definitions = $entity->getFieldDefinitions();
     foreach ($field_definitions as $definition) {
-      if ($definition->isComputed()) {
+      if ($definition->getType() == 'metatag_computed') {
         continue;
       }
 

--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -416,6 +416,10 @@ class CiviEntityStorage extends SqlContentEntityStorage {
     $civicrm_entity_settings = $this->getConfigFactory()->get('civicrm_entity.settings');
     $field_definitions = $entity->getFieldDefinitions();
     foreach ($field_definitions as $definition) {
+      if ($definition->isComputed()) {
+        continue;
+      }
+
       $items = $entity->get($definition->getName());
       if ($items->isEmpty()) {
         continue;


### PR DESCRIPTION
Overview
----------------------------------------
When metatag ^2 module is installed, visiting a CE page e.g. /civicrm-contact/1 throws this error:

```
Error: Call to a member function getDefaults() on null in civicrm_metatags_alter() (line 404 of modules/contrib/civicrm/civicrm.module).
```

Before
----------------------------------------
Throws an error.

After
----------------------------------------
No more error.