### PR TITLE
adding logger parameter to ModulerInstaller service

### DIFF
--- a/civicrm_entity.info.yml
+++ b/civicrm_entity.info.yml
@@ -2,7 +2,7 @@ name: CiviCRM Entity
 type: module
 description: 'Expose CiviCRM entities as Drupal entities.'
 package: CiviCRM
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.1 || ^11
 dependencies:
   - civicrm
   - drupal:datetime

--- a/civicrm_entity.services.yml
+++ b/civicrm_entity.services.yml
@@ -22,7 +22,7 @@ services:
     class: Drupal\civicrm_entity\ModuleInstaller
     decorates: module_installer
     public: true
-    arguments: ['@civicrm_entity.module_installer.inner', '%app.root%', '@module_handler', '@kernel', '@database', '@update.update_hook_registry', '@logger.factory'],
+    arguments: ['@civicrm_entity.module_installer.inner', '%app.root%', '@module_handler', '@kernel', '@database', '@update.update_hook_registry', '@logger.factory']
     tags:
       - { name: service_collector, tag: 'module_install.uninstall_validator', call: addUninstallValidator }
 

--- a/civicrm_entity.services.yml
+++ b/civicrm_entity.services.yml
@@ -22,7 +22,7 @@ services:
     class: Drupal\civicrm_entity\ModuleInstaller
     decorates: module_installer
     public: true
-    arguments: ['@civicrm_entity.module_installer.inner', '%app.root%', '@module_handler', '@kernel', '@database', '@update.update_hook_registry']
+    arguments: ['@civicrm_entity.module_installer.inner', '%app.root%', '@module_handler', '@kernel', '@database', '@update.update_hook_registry', '@logger.factory'],
     tags:
       - { name: service_collector, tag: 'module_install.uninstall_validator', call: addUninstallValidator }
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://drupal.org/project/civicrm_entity",
     "license": "GPL-2.0+",
     "require": {
-        "drupal/core": "^10.1",
+        "drupal/core": "^10.1 || ^11",
         "civicrm/civicrm-drupal-8": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://drupal.org/project/civicrm_entity",
     "license": "GPL-2.0+",
     "require": {
-        "drupal/core": "^10",
+        "drupal/core": "^10.1",
         "civicrm/civicrm-drupal-8": "*"
     },
     "require-dev": {

--- a/src/ModuleInstaller.php
+++ b/src/ModuleInstaller.php
@@ -7,6 +7,7 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Extension\ModuleInstaller as ExtensionModuleInstaller;
 use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\Core\Update\UpdateHookRegistry;
 
 /**
@@ -24,8 +25,9 @@ class ModuleInstaller extends ExtensionModuleInstaller {
   /**
    * {@inheritdoc}
    */
-  public function __construct(ModuleInstallerInterface $module_installer, $root, ModuleHandlerInterface $module_handler, DrupalKernelInterface $kernel, Connection $connection, UpdateHookRegistry $update_registry) {
-    parent::__construct($root, $module_handler, $kernel, $connection, $update_registry);
+  public function __construct(ModuleInstallerInterface $module_installer, $root, ModuleHandlerInterface $module_handler, DrupalKernelInterface $kernel, Connection $connection, UpdateHookRegistry $update_registry, LoggerChannelFactory $logger_factory) {
+    $logger = $logger_factory->get('civicrm_entity');
+    parent::__construct($root, $module_handler, $kernel, $connection, $update_registry, $logger);
     $this->moduleInstaller = $module_installer;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
per https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Extension%21ModuleInstaller.php/class/ModuleInstaller/11.x
without the $logger argument is deprecated in drupal:10.1.0 and it will be required in drupal:11.0.0

Before
----------------------------------------
Error installing the module in D11

After
----------------------------------------
No error installing the module
