### PR TITLE
use LoggerChannelFactoryInterface instead of default service

### DIFF
--- a/src/ModuleInstaller.php
+++ b/src/ModuleInstaller.php
@@ -7,7 +7,7 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Extension\ModuleInstaller as ExtensionModuleInstaller;
 use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\Core\Database\Connection;
-use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Update\UpdateHookRegistry;
 
 /**
@@ -25,7 +25,7 @@ class ModuleInstaller extends ExtensionModuleInstaller {
   /**
    * {@inheritdoc}
    */
-  public function __construct(ModuleInstallerInterface $module_installer, $root, ModuleHandlerInterface $module_handler, DrupalKernelInterface $kernel, Connection $connection, UpdateHookRegistry $update_registry, LoggerChannelFactory $logger_factory) {
+  public function __construct(ModuleInstallerInterface $module_installer, $root, ModuleHandlerInterface $module_handler, DrupalKernelInterface $kernel, Connection $connection, UpdateHookRegistry $update_registry, LoggerChannelFactoryInterface $logger_factory) {
     $logger = $logger_factory->get('civicrm_entity');
     parent::__construct($root, $module_handler, $kernel, $connection, $update_registry, $logger);
     $this->moduleInstaller = $module_installer;


### PR DESCRIPTION
Overview
----------------------------------------
Error installing some other modules when CiviCRM Entity installed
https://www.drupal.org/project/civicrm_entity/issues/3453051

Technical Details
----------------------------------------
Accept LoggerChannelFactoryInterface instead of LoggerChannelFactory
