### PR TITLE
check for metatag_computed field, for Drupal entity based saves with …

### DIFF
--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -201,6 +201,10 @@ class CivicrmEntity extends ContentEntityBase {
         continue;
       }
 
+      if ($storage_definition->getType() == 'metatag_computed') {
+        continue;
+      }
+
       $main_property_name = $storage_definition->getMainPropertyName();
       $list = [];
       /** @var \Drupal\Core\Field\FieldItemInterface $item */


### PR DESCRIPTION
…Metatag 2.0

Overview
----------------------------------------
Error saving Drupal based entity forms with Metatag 2.0

Before
----------------------------------------

WSOD
`
Uncaught PHP Exception InvalidArgumentException: "Property value is unknown." at /var/www/web/distro10.skvare.com/web/core/lib/Drupal/Core/TypedData/TypedDataManager.php line 204
`

After
----------------------------------------
save successful


Comments
----------------------------------------
Similar change we did for #481 

Release notes snippet
----------------------------------------
Metatag 2.0 compatibility
