### PR TITLE
Add check to ensure CiviCRM container is booted before invoking hooks

### DIFF
--- a/src/SupportedEntities.php
+++ b/src/SupportedEntities.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\civicrm_entity;
 
+use Civi\Core\Container;
 use Drupal\Component\Transliteration\TransliterationInterface;
 use Drupal\Core\Language\LanguageInterface;
 
@@ -909,6 +910,10 @@ final class SupportedEntities {
    */
   public static function alterEntityInfo(array &$civicrm_entity_info) {
     \Drupal::service('civicrm_entity.api')->civicrmInitialize();
+
+    if (!Container::isContainerBooted()) {
+        return FALSE;
+    }
 
     $code_version = explode('.', \CRM_Utils_System::version());
     if (version_compare($code_version[0] . '.' . $code_version[1], 4.5) >= 0) {


### PR DESCRIPTION
Overview
----------------------------------------
This pull request introduces a check to ensure the CiviCRM container is booted before invoking hooks.
While this patch masks the underlying issue, it follows CiviCRM's rule that hooks should not run before the container is booted and prevents similar future bugs.

Before
----------------------------------------
Previously, hooks were invoked without checking if the CiviCRM container had been initialized. This led to potential errors if the container was not yet booted.

For instance, when using symfony_mailer, the hook_civicrm_alter_drupal_entities was invoked while the CiviCRM container was not ready (not-ready status). This caused errors due to uninitialized services.

After
----------------------------------------
With this update, the system will first check if the CiviCRM container is booted before invoking any hooks. If the container is not booted, hooks will not be invoked.

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
In our case, **symfony_mailer** was triggering _entity_type_build_ which tried to invoke _hook_civicrm_alter_drupal_entities_ before the container was booted. Later on, the hook was invoked correctly by Drupal running _entity_type_build_. As a result, the first attempt to invoke the hook was prevented (which would have thrown an error), and the second correct attempt was successfully invoked.

By using this check, any incorrect invocation of the hook (due to a bug) is avoided, and only the correct invocation during the normal execution time of entity_type_build in Drupal core is processed.

Release notes snippet
----------------------------------------
_The notes to be added on the release_
