### PR TITLE
backport PR #451 to 7.x-2.x

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -3598,7 +3598,7 @@ function civicrm_entity_civicrm_post($op, $object_name, $object_id, &$object_ref
       break;
 
   }
-  if ($entity_name == 'entity_tag') {
+  if ($entity_name == 'entity_tag' && is_array($object_ref)) {
     // Argh entity tag is completely non-standard!!!
     // @see CRM-11933
     foreach ($object_ref[0] as $entity_tag) {


### PR DESCRIPTION
Overview
----------------------------------------
EntityTag is only non-standard with API3, API4 has fixed it.  This applies the same fix from #451 on 4.0.x to 7.x-2.x.

Before
----------------------------------------
Crash when saving in SearchKit.

After
----------------------------------------
No crash.

Release notes snippet
----------------------------------------
Fix crash when saving SearchKit on Drupal 7.
