### PR TITLE
custom field Views plugin, test not using createEntity

### DIFF
--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -453,6 +453,7 @@ class CiviEntityStorage extends SqlContentEntityStorage {
           else {
             $datetime_format = $definition->getSetting('datetime_type') === DateTimeItem::DATETIME_TYPE_DATE ? DateTimeItemInterface::DATE_STORAGE_FORMAT : DateTimeItemInterface::DATETIME_STORAGE_FORMAT;
             $default_timezone = $definition->getSetting('datetime_type') === DateTimeItem::DATETIME_TYPE_DATE ? DateTimeItemInterface::STORAGE_TIMEZONE : \Drupal::config('system.date')->get('timezone.default') ?? date_default_timezone_get();
+            $item_values[$delta]['original_value'] = $item[$main_property_name];
             $datetime_value = (new \DateTime($item[$main_property_name], new \DateTimeZone($default_timezone)))->setTimezone(new \DateTimeZone('UTC'))->format($datetime_format);
             $item_values[$delta][$main_property_name] = $datetime_value;
           }

--- a/src/Plugin/views/field/CustomEntityField.php
+++ b/src/Plugin/views/field/CustomEntityField.php
@@ -180,7 +180,7 @@ class CustomEntityField extends EntityField {
     ];
 
     if (($entity = $this->getEntity($values)) && isset($entity->{$this->definition['field_name']})) {
-      // $entity = $this->createEntity($entity);
+      $entity = $this->createEntity($entity);
 
       if (isset($this->aliases['id']) && isset($values->{$this->aliases['id']})) {
         $values->delta = $this->getDelta($values->{$this->aliases['id']});
@@ -240,7 +240,7 @@ class CustomEntityField extends EntityField {
    *   Returns the processed entity.
    */
   protected function createEntity(EntityInterface $entity) {
-    $processed_entity = clone $entity;
+    $processed_entity = $entity;
 
     try {
       $result = $this->civicrmApi->get('CustomValue', [

--- a/src/Plugin/views/field/CustomEntityField.php
+++ b/src/Plugin/views/field/CustomEntityField.php
@@ -243,19 +243,21 @@ class CustomEntityField extends EntityField {
     $processed_entity = $entity;
 
     try {
-      $result = $this->civicrmApi->get('CustomValue', [
-        'sequential' => 1,
-        'return' => [$this->definition['field_name']],
-        'entity_id' => $entity->id(),
-        'entity_table' => $entity->getEntityTypeId(),
-      ]);
-
+      $result = $processed_entity->{$this->definition['field_name']}->getValue();
+      error_log('Result: ' . print_r($result, TRUE));
       if (!empty($result)) {
         $result = reset($result);
-        $result = array_filter($result, function ($key) {
-          return is_int($key);
-        }, ARRAY_FILTER_USE_KEY);
-
+        if (isset($result['original_value'])) {
+          $result = [$result['original_value']];
+        }
+        elseif (isset($result['value'])) {
+          $result = [$result['value']];
+        }
+        else {
+          $result = array_filter($result, function ($key) {
+            return is_int($key);
+          }, ARRAY_FILTER_USE_KEY);
+        }
         if (!empty($result)) {
           if (isset($result[0]) && is_array($result[0])) {
             $result = reset($result);

--- a/src/Plugin/views/field/CustomEntityField.php
+++ b/src/Plugin/views/field/CustomEntityField.php
@@ -244,7 +244,6 @@ class CustomEntityField extends EntityField {
 
     try {
       $result = $processed_entity->{$this->definition['field_name']}->getValue();
-      error_log('Result: ' . print_r($result, TRUE));
       if (!empty($result)) {
         $result = reset($result);
         if (isset($result['original_value'])) {

--- a/src/Plugin/views/field/CustomEntityField.php
+++ b/src/Plugin/views/field/CustomEntityField.php
@@ -180,7 +180,7 @@ class CustomEntityField extends EntityField {
     ];
 
     if (($entity = $this->getEntity($values)) && isset($entity->{$this->definition['field_name']})) {
-      $entity = $this->createEntity($entity);
+      // $entity = $this->createEntity($entity);
 
       if (isset($this->aliases['id']) && isset($values->{$this->aliases['id']})) {
         $values->delta = $this->getDelta($values->{$this->aliases['id']});


### PR DESCRIPTION
Overview
----------------------------------------
I saw a request for some performance optimization of Views with a large dataset
https://civicrm.stackexchange.com/questions/48376/drupal-views-using-civicrm-entity-with-relationships-added-takes-too-long-to-ren

Was provided an XHProf profile, and we discovered an inordinate amount of time spent cloning entities. 

Optimize CustomEntityField plugin.

We know that cloning the entity takes ALOT of time. 
I also wonder if we can get rid of the API call to CustomValue

Before
----------------------------------------
Molasses is faster

After
----------------------------------------
Competitive speed vs. Molasses.

