### PR TITLE
Support for basefield overrides

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -240,7 +240,7 @@ function civicrm_entity_entity_bundle_field_info(EntityTypeInterface $entity_typ
   // Ensure all fields have a definition.
   if ($entity_type->get('civicrm_entity_ui_exposed') && $entity_type->hasKey('bundle')) {
     foreach ($base_field_definitions as $field_name => $definition) {
-      if (isset($result[$field_name])) {
+      if (isset($result[$field_name]) || isset($definition)) {
         continue;
       }
       $field = BaseFieldOverride::createFromBaseFieldDefinition($base_field_definitions[$field_name], $bundle);

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -147,6 +147,24 @@ final class RouteSubscriber extends RouteSubscriberBase {
         ];
       }
 
+      if ($this->moduleHandler->moduleExists('base_field_override_ui')) {
+        $field_ui_routes["entity.base_field_override.{$entity_type_id}_base_field_override_add_form"] = [
+          'bundle' => $entity_type_id,
+        ];
+
+        $field_ui_routes["entity.base_field_override.{$entity_type_id}_base_field_override_add_form"] = [
+          'bundle' => $entity_type_id,
+        ];
+
+        $field_ui_routes["entity.base_field_override.{$entity_type_id}_base_field_override_edit_form"] = [
+          'bundle' => $entity_type_id,
+        ];
+
+        $field_ui_routes["entity.base_field_override.{$entity_type_id}.base_field_override_ui_fields"] = [
+          'bundle' => $entity_type_id,
+        ];
+      }
+
       foreach ($field_ui_routes as $route_name => $defaults) {
         $route = $collection->get($route_name);
 


### PR DESCRIPTION
Overview
----------------------------------------
This adds support for basefield overrides for entities with bundles.

Before
----------------------------------------
Base field override with bundles do not work.

After
----------------------------------------
Base field override with bundles do work. This can be tested by using https://www.drupal.org/project/base_field_override_ui to override titles and/or descriptions of base fields.
