### PR TITLE
Allow custom CiviCRM entity type ID

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -87,7 +87,7 @@ function civicrm_entity_entity_type_build(array &$entity_types) {
         'id' => 'id',
         'label' => $civicrm_entity_info['label property'],
       ],
-      'base_table' => $entity_type_id,
+      'base_table' => $civicrm_entity_info['base table'] ?? $entity_type_id,
       'admin_permission' => 'administer civicrm entity',
       'permission_granularity' => 'entity_type',
       'handlers' => [


### PR DESCRIPTION
Overview
----------------------------------------
If a table name for a CiviCRM entity is longer than 32, Drupal throws this error:

```
Attempt to create an entity type with an ID longer than 32 characters: civicrm_inventory_product_membership.
```

The changes here allows having a CiviCRM entity type ID different from the base table. This is an example:

```php
/**
 * Implements hook_civicrm_alter_drupal_entities().
 */
function civicrm_tweaks_civicrm_alter_drupal_entities(&$info) {
  $info['civicrm_i_product_membership'] = [
    'civicrm entity label' => t('Product membership'),
    'civicrm entity name' => 'inventory_product_membership',
    'label property' => 'id',
    'base table' => 'civicrm_inventory_product_membership',
    'permissions' => [
      'view' => [],
      'update' => [],
      'create' => [],
      'delete' => [],
    ],
  ];
}
```

Before
----------------------------------------
Drupal throws error if CiviCRM entity name is longer than 32 characters.

After
----------------------------------------
No more errors.