### PR TITLE
check if bundle is empty before creating base field definition

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -239,7 +239,7 @@ function civicrm_entity_entity_bundle_field_info(EntityTypeInterface $entity_typ
   // Ensure all fields have a definition.
   if ($entity_type->get('civicrm_entity_ui_exposed') && $entity_type->hasKey('bundle')) {
     foreach ($base_field_definitions as $field_name => $definition) {
-      if (isset($result[$field_name]) || isset($definition)) {
+      if (isset($result[$field_name]) || isset($definition) || empty($bundle)) {
         continue;
       }
       $field = BaseFieldOverride::createFromBaseFieldDefinition($base_field_definitions[$field_name], $bundle);


### PR DESCRIPTION
Overview
----------------------------------------
Error reported in https://www.drupal.org/project/civicrm_entity/issues/3475302
in combination with #497 

```
Drupal\Core\Field\FieldException: Attempt to create a base field bundle override of field id without a bundle in Drupal\Core\Field\Entity\BaseFieldOverride->__construct() (line 110 of /var/www/drupal/web/core/lib/Drupal/Core/Field/Entity/BaseFieldOverride.php).
```
