### PR TITLE
require Drupal 10.3 as minimum version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - drupal: '10.2.*'
-            civicrm: '5.69.*'
+          - drupal: '10.3.*'
+            civicrm: '5.75.*'
             php: '8.1'
           - drupal: '10.3.*'
             civicrm: '5.75.*'

--- a/civicrm_entity.info.yml
+++ b/civicrm_entity.info.yml
@@ -2,7 +2,7 @@ name: CiviCRM Entity
 type: module
 description: 'Expose CiviCRM entities as Drupal entities.'
 package: CiviCRM
-core_version_requirement: ^10.1 || ^11
+core_version_requirement: ^10.3 || ^11
 dependencies:
   - civicrm
   - drupal:datetime


### PR DESCRIPTION
Overview
----------------------------------------
Require Drupal 10.3 as minimum version.

10.2 is EOL when 10.4 is released in a few days. 

