### PR TITLE
Pre and Post hooks don't check if the entities are enabled for sync

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -474,7 +474,7 @@ function civicrm_entity_civicrm_pre($op, $objectName, $id, &$params) {
   }
 
   $enabled_components = \Drupal::config('civicrm_entity.settings')->get('enabled_entity_types');
-  if (!in_array($entityType, $enabled_components)) {
+  if (empty($enabled_components) || !in_array($entityType, $enabled_components)) {
     return;
   }
 
@@ -551,7 +551,7 @@ function civicrm_entity_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   }
 
   $enabled_components = \Drupal::config('civicrm_entity.settings')->get('enabled_entity_types');
-  if (!in_array($entityType, $enabled_components)) {
+  if (empty($enabled_components) || !in_array($entityType, $enabled_components)) {
     return;
   }
 

--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -473,6 +473,11 @@ function civicrm_entity_civicrm_pre($op, $objectName, $id, &$params) {
     return;
   }
 
+  $enabled_components = \Drupal::config('civicrm_entity.settings')->get('enabled_entity_types');
+  if (!in_array($entityType, $enabled_components)) {
+    return;
+  }
+
   /** @var \Drupal\civicrm_entity\CiviEntityStorage $storage */
   $storage = \Drupal::entityTypeManager()->getStorage($entityType);
 
@@ -542,6 +547,11 @@ function civicrm_entity_civicrm_post($op, $objectName, $objectId, &$objectRef) {
 
   // Check valid entity type.
   if (!$entityType) {
+    return;
+  }
+
+  $enabled_components = \Drupal::config('civicrm_entity.settings')->get('enabled_entity_types');
+  if (!in_array($entityType, $enabled_components)) {
     return;
   }
 


### PR DESCRIPTION
This is a fix for https://www.drupal.org/project/civicrm_entity/issues/3496954

Here I am checking whether the component is enabled and skip if not