### PR TITLE
update CustomEntityField views field plugin with entity type bundle service in constructor

### DIFF
--- a/src/Plugin/views/field/CustomEntityField.php
+++ b/src/Plugin/views/field/CustomEntityField.php
@@ -6,6 +6,7 @@ use Drupal\views\Attribute\ViewsField;
 use Drupal\views\Plugin\views\field\EntityField;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\FieldTypePluginManagerInterface;
 use Drupal\Core\Field\FormatterPluginManager;
@@ -64,8 +65,8 @@ class CustomEntityField extends EntityField {
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, FormatterPluginManager $formatter_plugin_manager, FieldTypePluginManagerInterface $field_type_plugin_manager, LanguageManagerInterface $language_manager, RendererInterface $renderer, EntityRepositoryInterface $entity_repository = NULL, EntityFieldManagerInterface $entity_field_manager = NULL, CiviCrmApiInterface $civicrm_api) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $formatter_plugin_manager, $field_type_plugin_manager, $language_manager, $renderer, $entity_repository, $entity_field_manager);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, FormatterPluginManager $formatter_plugin_manager, FieldTypePluginManagerInterface $field_type_plugin_manager, LanguageManagerInterface $language_manager, RendererInterface $renderer, EntityRepositoryInterface $entity_repository = NULL, EntityFieldManagerInterface $entity_field_manager = NULL, EntityTypeBundleInfoInterface $entity_type_bundle_info, CiviCrmApiInterface $civicrm_api) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $formatter_plugin_manager, $field_type_plugin_manager, $language_manager, $renderer, $entity_repository, $entity_field_manager, $entity_type_bundle_info);
     $this->civicrmApi = $civicrm_api;
   }
 
@@ -84,6 +85,7 @@ class CustomEntityField extends EntityField {
       $container->get('renderer'),
       $container->get('entity.repository'),
       $container->get('entity_field.manager'),
+      $container->get('entity_type.bundle.info'),
       $container->get('civicrm_entity.api')
     );
   }


### PR DESCRIPTION

Overview
----------------------------------------
Adding a CiviCRM custom field throws an  error in Drupal 11

Before
----------------------------------------
Error
```


ArgumentCountError: Too few arguments to function Drupal\views\Plugin\views\field\EntityField::__construct(), 10 passed in /var/www/web/drupal11-experiments/web/modules/contrib/civicrm_entity/src/Plugin/views/field/CustomEntityField.php on line 68 and exactly 11 expected in Drupal\views\Plugin\views\field\EntityField->__construct() (line 171 of /var/www/web/drupal11-experiments/web/core/modules/views/src/Plugin/views/field/EntityField.php).
```

After
----------------------------------------
No error
