### PR TITLE
Use custom InOperator for Autocomplete-Select.

### DIFF
--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -798,7 +798,7 @@ class CivicrmEntityViewsData extends EntityViewsData {
             'options callback' => "{$class_name}::buildOptions",
             'options arguments' => $field_metadata['name'],
           ];
-          $multi_type_fields = ['Multi-Select', 'CheckBox'];
+          $multi_type_fields = ['Multi-Select', 'CheckBox', 'Autocomplete-Select'];
           if (in_array($field_metadata['html_type'], $multi_type_fields)) {
             $filter['multi'] = TRUE;
           }


### PR DESCRIPTION
Overview
----------------------------------------
Add support for "Autocomplete-Select" for InOperator. This is so `civicrm_entity_in_operator` would be used. If it isn't used, views wouldn't show any results.

To reproduce it, you can add a custom field with "Autocomplete-Select" as the "Field Type" and include it as a filter in the views.

Before
----------------------------------------
No Results when filtering with fields that are "Autocomplete-Select".

After
----------------------------------------
Has results.