### PR TITLE
create configuration settings to disable pre/post hooks per entity type

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -473,6 +473,12 @@ function civicrm_entity_civicrm_pre($op, $objectName, $id, &$params) {
     return;
   }
 
+  // Disable hook per entity type settings.
+  $disable_hooks_per_type = \Drupal::config('civicrm_entity.settings')->get('disable_hooks_per_type');
+  if (!empty($disable_hooks_per_type[$entityType])) {
+    return;
+  }
+
   /** @var \Drupal\civicrm_entity\CiviEntityStorage $storage */
   $storage = \Drupal::entityTypeManager()->getStorage($entityType);
 
@@ -542,6 +548,12 @@ function civicrm_entity_civicrm_post($op, $objectName, $objectId, &$objectRef) {
 
   // Check valid entity type.
   if (!$entityType) {
+    return;
+  }
+
+  // Disable hook per entity type settings.
+  $disable_hooks_per_type = \Drupal::config('civicrm_entity.settings')->get('disable_hooks_per_type');
+  if (!empty($disable_hooks_per_type[$entityType])) {
     return;
   }
 

--- a/config/install/civicrm_entity.settings.yml
+++ b/config/install/civicrm_entity.settings.yml
@@ -3,3 +3,4 @@ enabled_entity_types: {  }
 disable_hooks: FALSE
 disable_links: FALSE
 enable_links_per_type: {  }
+disable_hooks_per_type: {  }

--- a/config/schema/civicrm_entity.schema.yml
+++ b/config/schema/civicrm_entity.schema.yml
@@ -30,3 +30,9 @@ civicrm_entity.settings:
     disable_links:
       type: boolean
       label: 'Disable Drupal pages'
+    disable_hooks_per_type:
+      type: sequence
+      label: 'Disable pre/post hooks per entity type'
+      sequence:
+        type: integer
+        label: 'Entity type disabled'

--- a/src/Form/CivicrmEntitySettings.php
+++ b/src/Form/CivicrmEntitySettings.php
@@ -153,6 +153,7 @@ class CivicrmEntitySettings extends ConfigFormBase {
 
     $enabled_entity_types = $config->get('enabled_entity_types') ?? [];
     $enable_links_per_type = $config->get('enable_links_per_type') ?? [];
+    $disable_hooks_per_type = $config->get('disable_hooks_per_type') ?? [];
     foreach ($civicrm_entity_types as $key => $entity_info) {
       $form['enabled_entity_types'][$key]['#type'] = 'fieldset';
 
@@ -192,13 +193,6 @@ class CivicrmEntitySettings extends ConfigFormBase {
       '#open' => FALSE,
     ];
 
-    $form['advanced_settings']['disable_hooks'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Disable pre/post hooks'),
-      '#default_value' => $config->get('disable_hooks'),
-      '#description' => $this->t('Not intended for normal use. Provided to temporarily disable Drupal entity hooks for CiviCRM Entity types for special cases, such as migrations. Only disable if you know you need to.'),
-    ];
-
     $form['advanced_settings']['disable_links'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Disable Drupal pages'),
@@ -206,6 +200,27 @@ class CivicrmEntitySettings extends ConfigFormBase {
       '#description' => $this->t('Globally disables Drupal versions of view page and, add, edit, and delete forms for all enabled entity types. This option overrides the "per type" Drupal pages.'),
     ];
 
+    $form['advanced_settings']['disable_hooks'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Disable pre/post hooks'),
+      '#default_value' => $config->get('disable_hooks'),
+      '#description' => $this->t('Not intended for normal use. Provided to temporarily disable Drupal entity hooks for CiviCRM Entity types for special cases, such as migrations. Only disable if you know you need to.'),
+    ];
+
+    $form['advanced_settings']['disable_hooks_per_type'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Disable pre/post hooks per entity type'),
+      '#description' => $this->t('Pre/post hooks are used by Rules integration, or anytime Drupal CRUD hooks are required for an entity type. They have a performance cost though. Disable pre/post hooks per entity type here.'),
+      '#open' => FALSE,
+      '#tree' => TRUE,
+    ];
+    foreach ($civicrm_entity_types as $key => $entity_info) {
+      $form['advanced_settings']['disable_hooks_per_type'][$key] = [
+        '#type' => 'checkbox',
+        '#title' => $entity_info['civicrm entity label'],
+        '#default_value' => !empty($disable_hooks_per_type[$key]) ?? 0,
+      ];
+    }
     return $form;
   }
 
@@ -229,6 +244,7 @@ class CivicrmEntitySettings extends ConfigFormBase {
       ->set('disable_hooks', $form_state->getValue('disable_hooks'))
       ->set('disable_links', $form_state->getValue('disable_links'))
       ->set('enable_links_per_type', $enable_links_per_type)
+      ->set('disable_hooks_per_type', $form_state->getValue('disable_hooks_per_type'))
       ->save();
 
     // Need to rebuild derivative routes.


### PR DESCRIPTION
Overview
----------------------------------------
hook_civicrm_post() and hook_civicrm_pre() implementations execute for every entity, regardless of "enabled" status or not. 
This has performance impacts. 
Provide settings for site admins to disable pre/post hooks per entity type. 
Default remains that pre/post hooks run unless site admins check a box for each entity type they want to disable.
new fieldset in "Advanced settings" here: /admin/structure/civicrm-entity/settings

There is a global "disable pre/post hooks" setting, but you don't get a choice of which entity types to disable them for. 

Pre/post hooks are necessary for
Rules
Drupal fields on CiviCRM entity types
Contrib or Custom modules that need Drupal CRUD hooks to fire for CiviCRM entity types CRUD events (like Search API)

Before
----------------------------------------
Pre/post hooks run for each entity type, admins have no per entity type disabling capability.

After
----------------------------------------
Site admins can disable pre/post hooks per entity type.

Technical Details
----------------------------------------
Backward compatibility maintained. Site admins need to take action to disable.

