### PR TITLE
Resolve #3501116 "Declaration error firstdotlastfiltercanfilter"

### DIFF
--- a/src/Plugin/TypedDataFilter/FirstDotLastFilter.php
+++ b/src/Plugin/TypedDataFilter/FirstDotLastFilter.php
@@ -26,7 +26,7 @@ class FirstDotLastFilter extends DataFilterBase {
   /**
    * {@inheritdoc}
    */
-  public function canFilter(DataDefinitionInterface $definition) {
+  public function canFilter(DataDefinitionInterface $definition) : bool {
     if ($definition->getConstraints()['EntityType'] == "civicrm_contact") {
       return TRUE;
     }
@@ -39,7 +39,7 @@ class FirstDotLastFilter extends DataFilterBase {
   /**
    * {@inheritdoc}
    */
-  public function filtersTo(DataDefinitionInterface $definition, array $arguments) {
+  public function filtersTo(DataDefinitionInterface $definition, array $arguments) : DataDefinitionInterface {
     return DataDefinition::create('string');
   }
 

--- a/src/Plugin/TypedDataFilter/FirstLastFilter.php
+++ b/src/Plugin/TypedDataFilter/FirstLastFilter.php
@@ -26,7 +26,7 @@ class FirstLastFilter extends DataFilterBase {
   /**
    * {@inheritdoc}
    */
-  public function canFilter(DataDefinitionInterface $definition) {
+  public function canFilter(DataDefinitionInterface $definition) : bool {
     if ($definition->getConstraints()['EntityType'] == "civicrm_contact") {
       return TRUE;
     }
@@ -38,7 +38,7 @@ class FirstLastFilter extends DataFilterBase {
   /**
    * {@inheritdoc}
    */
-  public function filtersTo(DataDefinitionInterface $definition, array $arguments) {
+  public function filtersTo(DataDefinitionInterface $definition, array $arguments) : DataDefinitionInterface {
     return DataDefinition::create('string');
   }
 

--- a/src/Plugin/TypedDataFilter/InitialDotLastFilter.php
+++ b/src/Plugin/TypedDataFilter/InitialDotLastFilter.php
@@ -26,7 +26,7 @@ class InitialDotLastFilter extends DataFilterBase {
   /**
    * {@inheritdoc}
    */
-  public function canFilter(DataDefinitionInterface $definition) {
+  public function canFilter(DataDefinitionInterface $definition) : bool {
     if ($definition->getConstraints()['EntityType'] == "civicrm_contact") {
       return TRUE;
     }
@@ -38,7 +38,7 @@ class InitialDotLastFilter extends DataFilterBase {
   /**
    * {@inheritdoc}
    */
-  public function filtersTo(DataDefinitionInterface $definition, array $arguments) {
+  public function filtersTo(DataDefinitionInterface $definition, array $arguments) : DataDefinitionInterface {
     return DataDefinition::create('string');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Close issues #3501116

after upgrade to php 8, declaration of FirstDotLastFilter::canFilter() is not compatible with Drupal\typed_data\DataFilterInterface::canFilter(Drupal\Core\TypedDataDefinitionInterface $definition) : bool

Before
----------------------------------------
public function canFilter(DataDefinitionInterface $definition) {

After
----------------------------------------
Update signatures of the methods canFilter and filtersTo
public function canFilter(DataDefinitionInterface $definition) : bool {


Technical Details
----------------------------------------


Comments
----------------------------------------


Release notes snippet
----------------------------------------

