### PR TITLE
Uninstall page throwing an error

### DIFF
--- a/civicrm_entity.services.yml
+++ b/civicrm_entity.services.yml
@@ -20,14 +20,6 @@ services:
     tags:
       - { name: event_subscriber }
 
-  civicrm_entity.module_installer:
-    class: Drupal\civicrm_entity\ModuleInstaller
-    decorates: module_installer
-    public: true
-    arguments: ['@civicrm_entity.module_installer.inner', '%app.root%', '@module_handler', '@kernel', '@database', '@update.update_hook_registry', '@logger.factory']
-    tags:
-      - { name: service_collector, tag: 'module_install.uninstall_validator', call: addUninstallValidator }
-
   civicrm_entity.contact_checksum_access_checker:
     class: Drupal\civicrm_entity\Access\ContactChecksumCheckAccess
     autowire: true

--- a/civicrm_entity.services.yml
+++ b/civicrm_entity.services.yml
@@ -24,7 +24,7 @@ services:
     class: Drupal\civicrm_entity\ModuleInstaller
     decorates: module_installer
     public: true
-    arguments: ['@civicrm_entity.module_installer.inner', '%app.root%', '@module_handler', '@kernel', '@database', '@update.update_hook_registry', '@logger.factory']
+    arguments: ['@civicrm_entity.module_installer.inner', '%app.root%', '@module_handler', '@kernel', '@database', '@update.update_hook_registry', '@logger.channel.default']
     tags:
       - { name: service_collector, tag: 'module_install.uninstall_validator', call: addUninstallValidator }
 

--- a/civicrm_entity.services.yml
+++ b/civicrm_entity.services.yml
@@ -20,14 +20,6 @@ services:
     tags:
       - { name: event_subscriber }
 
-  civicrm_entity.module_installer:
-    class: Drupal\civicrm_entity\ModuleInstaller
-    decorates: module_installer
-    public: true
-    arguments: ['@civicrm_entity.module_installer.inner', '%app.root%', '@module_handler', '@kernel', '@database', '@update.update_hook_registry', '@logger.channel.default']
-    tags:
-      - { name: service_collector, tag: 'module_install.uninstall_validator', call: addUninstallValidator }
-
   civicrm_entity.contact_checksum_access_checker:
     class: Drupal\civicrm_entity\Access\ContactChecksumCheckAccess
     autowire: true

--- a/civicrm_entity.services.yml
+++ b/civicrm_entity.services.yml
@@ -20,6 +20,14 @@ services:
     tags:
       - { name: event_subscriber }
 
+  civicrm_entity.module_installer:
+    class: Drupal\civicrm_entity\ModuleInstaller
+    decorates: module_installer
+    public: true
+    arguments: ['@civicrm_entity.module_installer.inner', '%app.root%', '@module_handler', '@kernel', '@database', '@update.update_hook_registry', '@logger.factory']
+    tags:
+      - { name: service_collector, tag: 'module_install.uninstall_validator', call: addUninstallValidator }
+
   civicrm_entity.contact_checksum_access_checker:
     class: Drupal\civicrm_entity\Access\ContactChecksumCheckAccess
     autowire: true

--- a/src/CivicrmEntityServiceProvider.php
+++ b/src/CivicrmEntityServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\civicrm_entity;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceModifierInterface;
+
+/**
+ * Defines a service provider for the CiviCRM Entity module.
+ */
+final class CivicrmEntityServiceProvider implements ServiceModifierInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container): void {
+    if ($container->hasDefinition('module_installer')) {
+      $definition = $container->getDefinition('module_installer');
+      $definition->setClass('Drupal\civicrm_entity\ModuleInstaller');
+    }
+  }
+
+}

--- a/src/ModuleInstaller.php
+++ b/src/ModuleInstaller.php
@@ -2,33 +2,12 @@
 
 namespace Drupal\civicrm_entity;
 
-use Drupal\Core\DrupalKernelInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Extension\ModuleInstaller as ExtensionModuleInstaller;
-use Drupal\Core\Extension\ModuleInstallerInterface;
-use Drupal\Core\Database\Connection;
-use Drupal\Core\Update\UpdateHookRegistry;
-use Psr\Log\LoggerInterface;
 
 /**
- * Class ContentUninstallValidator.
+ * Class ModuleInstaller.
  */
 class ModuleInstaller extends ExtensionModuleInstaller {
-
-  /**
-   * The module installer.
-   *
-   * @var \Drupal\Core\Extension\ModuleInstallerInterface
-   */
-  protected $moduleInstaller;
-
-  /**
-   * {@inheritdoc}
-   */
-  public function __construct(ModuleInstallerInterface $module_installer, $root, ModuleHandlerInterface $module_handler, DrupalKernelInterface $kernel, Connection $connection, UpdateHookRegistry $update_registry, protected LoggerInterface $logger) {
-    parent::__construct($root, $module_handler, $kernel, $connection, $update_registry, $logger);
-    $this->moduleInstaller = $module_installer;
-  }
 
   /**
    * {@inheritdoc}

--- a/src/ModuleInstaller.php
+++ b/src/ModuleInstaller.php
@@ -13,23 +13,8 @@ use Drupal\Core\Update\UpdateHookRegistry;
 /**
  * Class ContentUninstallValidator.
  */
+#[AsDecorator(decorates: ExtensionModuleInstaller::class)]
 class ModuleInstaller extends ExtensionModuleInstaller {
-
-  /**
-   * The module installer.
-   *
-   * @var \Drupal\Core\Extension\ModuleInstallerInterface
-   */
-  protected $moduleInstaller;
-
-  /**
-   * {@inheritdoc}
-   */
-  public function __construct(ModuleInstallerInterface $module_installer, $root, ModuleHandlerInterface $module_handler, DrupalKernelInterface $kernel, Connection $connection, UpdateHookRegistry $update_registry, LoggerChannelFactoryInterface $logger_factory) {
-    $logger = $logger_factory->get('civicrm_entity');
-    parent::__construct($root, $module_handler, $kernel, $connection, $update_registry, $logger);
-    $this->moduleInstaller = $module_installer;
-  }
 
   /**
    * {@inheritdoc}

--- a/src/ModuleInstaller.php
+++ b/src/ModuleInstaller.php
@@ -9,6 +9,7 @@ use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Update\UpdateHookRegistry;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class ContentUninstallValidator.
@@ -25,8 +26,7 @@ class ModuleInstaller extends ExtensionModuleInstaller {
   /**
    * {@inheritdoc}
    */
-  public function __construct(ModuleInstallerInterface $module_installer, $root, ModuleHandlerInterface $module_handler, DrupalKernelInterface $kernel, Connection $connection, UpdateHookRegistry $update_registry, LoggerChannelFactoryInterface $logger_factory) {
-    $logger = $logger_factory->get('civicrm_entity');
+  public function __construct(ModuleInstallerInterface $module_installer, $root, ModuleHandlerInterface $module_handler, DrupalKernelInterface $kernel, Connection $connection, UpdateHookRegistry $update_registry, protected ?LoggerInterface $logger = NULL) {
     parent::__construct($root, $module_handler, $kernel, $connection, $update_registry, $logger);
     $this->moduleInstaller = $module_installer;
   }

--- a/src/ModuleInstaller.php
+++ b/src/ModuleInstaller.php
@@ -7,7 +7,6 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Extension\ModuleInstaller as ExtensionModuleInstaller;
 use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\Core\Database\Connection;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Update\UpdateHookRegistry;
 use Psr\Log\LoggerInterface;
 
@@ -26,7 +25,7 @@ class ModuleInstaller extends ExtensionModuleInstaller {
   /**
    * {@inheritdoc}
    */
-  public function __construct(ModuleInstallerInterface $module_installer, $root, ModuleHandlerInterface $module_handler, DrupalKernelInterface $kernel, Connection $connection, UpdateHookRegistry $update_registry, protected ?LoggerInterface $logger = NULL) {
+  public function __construct(ModuleInstallerInterface $module_installer, $root, ModuleHandlerInterface $module_handler, DrupalKernelInterface $kernel, Connection $connection, UpdateHookRegistry $update_registry, protected LoggerInterface $logger) {
     parent::__construct($root, $module_handler, $kernel, $connection, $update_registry, $logger);
     $this->moduleInstaller = $module_installer;
   }

--- a/src/ModuleInstaller.php
+++ b/src/ModuleInstaller.php
@@ -13,8 +13,23 @@ use Drupal\Core\Update\UpdateHookRegistry;
 /**
  * Class ContentUninstallValidator.
  */
-#[AsDecorator(decorates: ExtensionModuleInstaller::class)]
 class ModuleInstaller extends ExtensionModuleInstaller {
+
+  /**
+   * The module installer.
+   *
+   * @var \Drupal\Core\Extension\ModuleInstallerInterface
+   */
+  protected $moduleInstaller;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ModuleInstallerInterface $module_installer, $root, ModuleHandlerInterface $module_handler, DrupalKernelInterface $kernel, Connection $connection, UpdateHookRegistry $update_registry, LoggerChannelFactoryInterface $logger_factory) {
+    $logger = $logger_factory->get('civicrm_entity');
+    parent::__construct($root, $module_handler, $kernel, $connection, $update_registry, $logger);
+    $this->moduleInstaller = $module_installer;
+  }
 
   /**
    * {@inheritdoc}

--- a/src/ModuleInstaller.php
+++ b/src/ModuleInstaller.php
@@ -5,7 +5,7 @@ namespace Drupal\civicrm_entity;
 use Drupal\Core\Extension\ModuleInstaller as ExtensionModuleInstaller;
 
 /**
- * Class ModuleInstaller.
+ * Class for ModuleInstaller.
  */
 class ModuleInstaller extends ExtensionModuleInstaller {
 

--- a/src/ProxyClass/ModuleInstaller.php
+++ b/src/ProxyClass/ModuleInstaller.php
@@ -1,0 +1,104 @@
+<?php
+// phpcs:ignoreFile
+
+/**
+ * This file was generated via php core/scripts/generate-proxy-class.php 'Drupal\civicrm_entity\ModuleInstaller' "modules/contrib/civicrm_entity/src".
+ */
+
+namespace Drupal\civicrm_entity\ProxyClass {
+
+    /**
+     * Provides a proxy class for \Drupal\civicrm_entity\ModuleInstaller.
+     *
+     * @see \Drupal\Component\ProxyBuilder
+     */
+    class ModuleInstaller implements \Drupal\Core\Extension\ModuleInstallerInterface
+    {
+
+        use \Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
+        /**
+         * The id of the original proxied service.
+         *
+         * @var string
+         */
+        protected $drupalProxyOriginalServiceId;
+
+        /**
+         * The real proxied service, after it was lazy loaded.
+         *
+         * @var \Drupal\civicrm_entity\ModuleInstaller
+         */
+        protected $service;
+
+        /**
+         * The service container.
+         *
+         * @var \Symfony\Component\DependencyInjection\ContainerInterface
+         */
+        protected $container;
+
+        /**
+         * Constructs a ProxyClass Drupal proxy object.
+         *
+         * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+         *   The container.
+         * @param string $drupal_proxy_original_service_id
+         *   The service ID of the original service.
+         */
+        public function __construct(\Symfony\Component\DependencyInjection\ContainerInterface $container, $drupal_proxy_original_service_id)
+        {
+            $this->container = $container;
+            $this->drupalProxyOriginalServiceId = $drupal_proxy_original_service_id;
+        }
+
+        /**
+         * Lazy loads the real service from the container.
+         *
+         * @return object
+         *   Returns the constructed real service.
+         */
+        protected function lazyLoadItself()
+        {
+            if (!isset($this->service)) {
+                $this->service = $this->container->get($this->drupalProxyOriginalServiceId);
+            }
+
+            return $this->service;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function validateUninstall(array $module_list)
+        {
+            return $this->lazyLoadItself()->validateUninstall($module_list);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function addUninstallValidator(\Drupal\Core\Extension\ModuleUninstallValidatorInterface $uninstall_validator)
+        {
+            return $this->lazyLoadItself()->addUninstallValidator($uninstall_validator);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function install(array $module_list, $enable_dependencies = true)
+        {
+            return $this->lazyLoadItself()->install($module_list, $enable_dependencies);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function uninstall(array $module_list, $uninstall_dependents = true)
+        {
+            return $this->lazyLoadItself()->uninstall($module_list, $uninstall_dependents);
+        }
+
+    }
+
+}

--- a/tests/src/FunctionalJavascript/CivicrmEntitySettingsFormTest.php
+++ b/tests/src/FunctionalJavascript/CivicrmEntitySettingsFormTest.php
@@ -78,4 +78,14 @@ final class CivicrmEntitySettingsFormTest extends CivicrmEntityTestBase {
     $this->assertSession()->pageTextContains('The configuration options have been saved.');
   }
 
+  /**
+   * Tests that going to uninstall page works.
+   */
+  public function testModuleUninstall() {
+    $admin_user = $this->createUser(['administer modules']);
+    $this->drupalLogin($admin_user);
+    $this->drupalGet(Url::fromRoute('system.modules_uninstall'));
+    $this->assertSession()->elementExists('css', 'form.system-modules-uninstall');
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This error is thrown when going to the /admin/modules/uninstall page:

`Exception: Cannot rewind a generator that was already run in IteratorIterator->rewind() (line 656 of /var/www/html/web/core/lib/Drupal/Core/Extension/ModuleInstaller.php)`

Before
----------------------------------------
Error is thrown

After
----------------------------------------
No more errors.

Technical Details
----------------------------------------
Implementation of decorating a service is different now.