### PR TITLE
Fix wrong method.

### DIFF
--- a/src/Hook/RulesHooks.php
+++ b/src/Hook/RulesHooks.php
@@ -13,7 +13,7 @@ class RulesHooks {
    * Implements hook_rules_action_info_alter().
    */
   #[Hook('rules_action_info_alter')]
-  public function rulesInfoActionAlter(array &$rules_actions): void {
+  public function rulesActionInfoAlter(array &$rules_actions): void {
     $definitions = \Drupal::service('plugin.manager.typed_data_filter')->getDefinitions();
     $filters = "";
     foreach ($definitions as $key) {


### PR DESCRIPTION
Update from #515 breaks rules page. Steps to reproduce:

Add a new Rule to react on new webform submission
Click "Add Action", then the following error is logged in the watchdog:-

Error: Call to undefined method Drupal\civicrm_entity\Hook\RulesHooks::rulesActionInfoAlter() in civicrm_entity_rules_action_info_alter() (line 429 of /var/src/drupal/site/web/modules/contrib/civicrm_entity/civicrm_entity.module).