### PR TITLE
Add workaround for views_aggregator.

### DIFF
--- a/src/Plugin/views/field/CustomEntityField.php
+++ b/src/Plugin/views/field/CustomEntityField.php
@@ -103,6 +103,9 @@ class CustomEntityField extends EntityField {
         $this->fieldDefinition->setCardinality($this->fieldMetadata['max_multiple']);
       }
     }
+
+    $options['entity_field'] = $options['field'];
+
     parent::init($view, $display, $options);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
When views_aggregator.module is used and custom fields are included in the view, the view throws this error:

```
Error: Call to a member function getValue() on null in Drupal\views\Plugin\views\style\StylePluginBase->getFieldValue() (line 803 of /var/www/web/uschess.org/web/core/modules/views/src/Plugin/views/style/StylePluginBase.php).
```

Before
----------------------------------------
Throws error.

After
----------------------------------------
No more error.