### PR TITLE
Fix multiselect search option issue with Drupal views

### DIFF
--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -802,7 +802,15 @@ class CivicrmEntityViewsData extends EntityViewsData {
           ];
           $multi_type_fields = ['Multi-Select', 'CheckBox', 'Autocomplete-Select'];
           if (in_array($field_metadata['html_type'], $multi_type_fields)) {
-            $filter['multi'] = TRUE;
+            // Check if the field type is in the list of multi-type fields (e.g., multiple select options)            
+            if ($field_metadata['html_type'] == 'Autocomplete-Select') {
+                // If the field type is 'Autocomplete-Select', set the 'multi' filter 
+                // based on the 'serialize' attribute (whether multi-select is enabled)
+                $filter['multi'] = $field_metadata['serialize'];
+            } else {
+                // For other types, assume it's a multi-select field
+                $filter['multi'] = TRUE;
+            }
           }
 
           return $filter;

--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -802,14 +802,15 @@ class CivicrmEntityViewsData extends EntityViewsData {
           ];
           $multi_type_fields = ['Multi-Select', 'CheckBox', 'Autocomplete-Select'];
           if (in_array($field_metadata['html_type'], $multi_type_fields)) {
-            // Check if the field type is in the list of multi-type fields (e.g., multiple select options)            
+            // Check if the field type is in the list of multi-type fields,  
+            // such as multiple select options.
             if ($field_metadata['html_type'] == 'Autocomplete-Select') {
-                // If the field type is 'Autocomplete-Select', set the 'multi' filter 
-                // based on the 'serialize' attribute (whether multi-select is enabled)
-                $filter['multi'] = $field_metadata['serialize'];
+              // If the field type is 'Autocomplete-Select', set the 'multi' filter.  
+              // Based on the 'serialize' attribute (whether multi-select is enabled).
+              $filter['multi'] = $field_metadata['serialize'];
             } else {
-                // For other types, assume it's a multi-select field
-                $filter['multi'] = TRUE;
+              // For other types, assume it's a multi-select field
+              $filter['multi'] = TRUE;
             }
           }
 


### PR DESCRIPTION
Overview
This patch updates the CiviCRM Entity module in Drupal 10 to properly handle Autocomplete-Select fields. Previously, enabling the Multi-Select option in CiviCRM custom fields was required for Autocomplete fields to work correctly with Drupal Views. After modifying the CiviCRM Entity module, Autocomplete fields now function as expected in Views without requiring the Multi-Select option to be checked.


Before
Autocomplete-Select fields only worked in Drupal Views if the Multi-Select option was enabled in CiviCRM custom fields.
This caused issues when using single-value Autocomplete fields, as they were incorrectly treated as multi-select. **Please see checked-multi-select-option.png**
![checked-multi-select-option](https://github.com/user-attachments/assets/87109590-3e0e-433d-8fe1-fecf20ff07fc)

After
Autocomplete-Select fields now work correctly in Drupal Views without requiring the Multi-Select option to be checked in CiviCRM custom fields.

Technical Details
Updated the condition to check if the field type is 'Autocomplete-Select'.
If the field has a 'serialize' attribute, it is used to set $filter['multi'].
If not, it defaults to TRUE for other multi-select field types.