### PR TITLE
Skip path field when entity has no link.

### DIFF
--- a/src/CiviEntityStorage.php
+++ b/src/CiviEntityStorage.php
@@ -419,6 +419,10 @@ class CiviEntityStorage extends SqlContentEntityStorage {
         continue;
       }
 
+      if ($definition->getName() == 'path' && (!$entity->hasLinkTemplate('canonical') || !$entity->hasLinkTemplate('edit-form'))) {
+        continue;
+      }
+
       $items = $entity->get($definition->getName());
       if ($items->isEmpty()) {
         continue;

--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -201,6 +201,11 @@ class CivicrmEntity extends ContentEntityBase {
     /** @var \Drupal\Core\Field\FieldItemListInterface $items */
     foreach ($this->getFields() as $field_name => $items) {
       $items->filterEmptyItems();
+
+      if ($field_name == 'path' && (!$this->hasLinkTemplate('canonical') || !$this->hasLinkTemplate('edit-form'))) {
+        continue;
+      }
+
       if ($items->isEmpty()) {
         continue;
       }


### PR DESCRIPTION
Overview
----------------------------------------
If "View" and "Edit" is disabled but "Contact" is enabled, this error is thrown with the following script:

```php
<?php

$contact = \Drupal::entityTypeManager()->getStorage('civicrm_contact')->load(3);
$contact->save();
var_dump($contact->id());
var_dump($contact->get('path')->getValue());
```

```
Drupal\Core\Entity\Exception\UndefinedLinkTemplateException: Cannot generate default URL because no link template 'canonical' or 'edit-form' was found for the 'civicrm_contact' entity type in Drupal\Core\Entity\EntityBase->toUrl() (line 211 of /var/www/web/warmshowers.org/web/core/lib/Drupal/Core/Entity/EntityBase.php).
```

Before
----------------------------------------
Error is thrown.

After
----------------------------------------
No more error.

Technical Details
----------------------------------------
Path is enabled for each entity type enabled. Path is being generated despite not having a canonical nor edit URLs.