### PR TITLE
define contact reference views filter plugin schema

### DIFF
--- a/config/schema/civicrm_entity.views.schema.yml
+++ b/config/schema/civicrm_entity.views.schema.yml
@@ -36,6 +36,10 @@ views.filter.civicrm_entity_in_operator:
   type: views.filter.in_operator
   label: 'IN operator'
 
+views.filter.civicrm_entity_contact_reference:
+  type: views.filter.in_operator
+  label: 'Contact Reference'
+
 views.filter.civicrm_entity_date:
   type: views.filter.date
 

--- a/src/CivicrmEntityViewsData.php
+++ b/src/CivicrmEntityViewsData.php
@@ -762,11 +762,14 @@ class CivicrmEntityViewsData extends EntityViewsData {
         return $filter;
 
       case 'ContactReference':
-        return [
+        $filter = [
           'id' => 'civicrm_entity_contact_reference',
           'allow empty' => TRUE,
-          'multi' => TRUE,
         ];
+        if (!empty($field_metadata['serialize'])) {
+          $filter['multi'] = TRUE;
+        }
+        return $filter;
     }
 
     $type = !empty($field_metadata['pseudoconstant']) ? 'pseudoconstant' :


### PR DESCRIPTION
Overview
----------------------------------------
Adding a CiviCRM custom contact reference field Views filter causes error on save
```
InvalidArgumentException: The configuration property display.default.display_options.filters.test_contact_ref_9.value.0 doesn't exist. in Drupal\Core\Config\Schema\ArrayElement->get() (line 95 of /var/www/web/drupal11-experiments/web/core/lib/Drupal/Core/Config/Schema/ArrayElement.php).
```

Additionally, a "Single value" contact reference field returns no rows, where the filter does work if the field is set to "Multi-Select"

The DAO Separator is included in the where clause in both cases, but should only be so if "Multi-Select" is configured for the custom field. 

Before
----------------------------------------
Error and query works

After
----------------------------------------
No error and query works

