### PR TITLE
Add a Distance field to Views for Proximity filters

### DIFF
--- a/civicrm_entity.views.inc
+++ b/civicrm_entity.views.inc
@@ -145,6 +145,19 @@ function civicrm_entity_views_data_alter(&$data) {
   $data['civicrm_contact']['employer_id']['field']['id'] = 'standard';
   $data['civicrm_contribution']['contribution_source']['real field'] = 'source';
   $data['civicrm_address']['state_province_id']['filter']['id'] = 'civicrm_entity_civicrm_address_state_province';
+  
+  if (isset($data['civicrm_address'])) {
+    $data['civicrm_address']['distance'] = [
+      'title' => t('Distance'),
+      'help' => t('Calculated distance from proximity filter location.'),
+      'field' => [
+        'id' => 'civicrm_entity_distance',
+      ],
+      'sort' => [
+        'id' => 'civicrm_entity_distance_sort',
+      ],
+    ];
+  }
 }
 
 /**

--- a/src/Plugin/views/field/CivicrmEntityDistance.php
+++ b/src/Plugin/views/field/CivicrmEntityDistance.php
@@ -1,0 +1,204 @@
+<?php
+
+/**
+ * @file
+ * Issue: 3541996 - Provides a new "Distance" field for CiviCRM proximity filters.
+ */
+
+namespace Drupal\civicrm_entity\Plugin\views\field;
+
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Field handler to display calculated distance from proximity filter.
+ *
+ * @ViewsField("civicrm_entity_distance")
+ */
+#[ViewsField("civicrm_entity_distance")]
+class CivicrmEntityDistance extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function canExpose() {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Get coordinates from proximity filter
+    $center_lat = $center_lon = NULL;
+    
+    // Method 1: Check view storage (set by proximity filter)
+    if (!empty($this->view->proximity_center)) {
+      $center_lat = $this->view->proximity_center['latitude'];
+      $center_lon = $this->view->proximity_center['longitude'];
+    } else {
+      // Method 2: Get directly from proximity filter
+      $proximity_filter = $this->getProximityFilter();
+      if ($proximity_filter && method_exists($proximity_filter, 'getProximityValues')) {
+        $values = $proximity_filter->getProximityValues();
+        if (!empty($values['latitude']) && !empty($values['longitude'])) {
+          $center_lat = $values['latitude'];
+          $center_lon = $values['longitude'];
+        }
+      }
+    }
+
+    if ($center_lat && $center_lon) {
+      // Get the correct table alias for civicrm_address
+      $address_table = 'contact_id_civicrm_contact';
+      
+      // Create distance formula with proper table alias
+      $formula = $this->getDistanceFormula($center_lat, $center_lon, $address_table);
+      
+      // Add the field to the query
+      $this->field_alias = $this->query->addField(NULL, $formula, 'distance_calculated');
+      $this->addAdditionalFields();
+    }
+  }
+
+  /**
+   * Get the proximity filter from the current view.
+   */
+  protected function getProximityFilter() {
+    $filters = $this->view->display_handler->getHandlers('filter');
+    
+    foreach ($filters as $filter_id => $filter) {
+      if ($filter->getPluginId() == 'civicrm_entity_civicrm_address_proximity') {
+        return $filter;
+      }
+    }
+    
+    return NULL;
+  }
+
+  /**
+   * Calculate distance formula with proper table alias and units.
+   */
+  protected function getDistanceFormula($center_lat, $center_lon, $address_table) {
+    // Make sure we have a table alias
+    if (empty($address_table)) {
+      $address_table = 'civicrm_address';
+    }
+    
+    // Determine the unit to use
+    $unit = $this->getDistanceUnit();
+    
+    // Set earth radius based on unit
+    if ($unit == 'mi' || $unit == 'miles') {
+      $earth_radius = 3958.8; // Earth radius in miles
+    } else {
+      $earth_radius = 6378.137; // Earth radius in kilometers
+    }
+    
+    // Distance formula with proper units
+    $formula = "
+      (ACOS(
+        COS(RADIANS({$address_table}.geo_code_1)) *
+        COS(RADIANS($center_lat)) *
+        COS(RADIANS({$address_table}.geo_code_2) - RADIANS($center_lon)) +
+        SIN(RADIANS({$address_table}.geo_code_1)) *
+        SIN(RADIANS($center_lat))
+      ) * $earth_radius)
+    ";
+    
+    return $formula;
+  }
+
+  /**
+   * Get the distance unit to use for calculations.
+   */
+  protected function getDistanceUnit() {
+    // Priority 1: Field configuration
+    if (!empty($this->options['unit'])) {
+      return $this->options['unit'];
+    }
+    
+    // Priority 2: Proximity filter settings
+    if (!empty($this->view->proximity_center['distance_unit'])) {
+      $proximity_unit = $this->view->proximity_center['distance_unit'];
+      // Convert proximity filter units to field units
+      if ($proximity_unit == 'miles') {
+        return 'mi';
+      } elseif ($proximity_unit == 'kilometers') {
+        return 'km';
+      }
+    }
+    
+    // Priority 3: Get from proximity filter directly
+    $proximity_filter = $this->getProximityFilter();
+    if ($proximity_filter && !empty($proximity_filter->value['distance_unit'])) {
+      $proximity_unit = $proximity_filter->value['distance_unit'];
+      if ($proximity_unit == 'miles') {
+        return 'mi';
+      } elseif ($proximity_unit == 'kilometers') {
+        return 'km';
+      }
+    }
+    
+    // Default to kilometers
+    return 'km';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $value = $this->getValue($values);
+    
+    if ($value !== NULL && $value !== '') {
+      $distance = round((float)$value, (int)($this->options['precision'] ?? 2));
+      $unit = $this->getDistanceUnit();
+      
+      // Display unit labels
+      $unit_label = ($unit == 'mi' || $unit == 'miles') ? 'mi' : 'km';
+      
+      return $distance . ' ' . $unit_label;
+    }
+    
+    return '';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+    $options['unit'] = ['default' => '']; // Empty = use proximity filter unit
+    $options['precision'] = ['default' => 2];
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+    
+    $form['unit'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Distance unit'),
+      '#description' => $this->t('Override the unit from the proximity filter. Leave empty to use the proximity filter\'s unit setting.'),
+      '#options' => [
+        '' => $this->t('- Use proximity filter unit -'),
+        'km' => $this->t('Kilometers'),
+        'mi' => $this->t('Miles'),
+      ],
+      '#default_value' => $this->options['unit'],
+    ];
+    
+    $form['precision'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Decimal places'),
+      '#description' => $this->t('Number of decimal places to display.'),
+      '#default_value' => $this->options['precision'],
+      '#min' => 0,
+      '#max' => 5,
+    ];
+  }
+}

--- a/src/Plugin/views/filter/Proximity.php
+++ b/src/Plugin/views/filter/Proximity.php
@@ -172,6 +172,14 @@ class Proximity extends FilterPluginBase {
 
       $geocoded_address = $this->getGeocodedAddress($proximity_address);
 
+      $this->view->proximity_center = [
+        'latitude' => $geocoded_address['latitude'],
+        'longitude' => $geocoded_address['longitude'],
+        'distance' => $this->value['distance'],
+        'distance_unit' => $this->value['distance_unit'],
+        'distance_meters' => $distance,
+      ];
+
       [$min_longitude, $max_longitude] = \CRM_Contact_BAO_ProximityQuery::earthLongitudeRange($geocoded_address['longitude'], $geocoded_address['latitude'], $distance);
       [$min_latitude, $max_latitude] = \CRM_Contact_BAO_ProximityQuery::earthLatitudeRange($geocoded_address['longitude'], $geocoded_address['latitude'], $distance);
 
@@ -265,4 +273,53 @@ class Proximity extends FilterPluginBase {
     ];
   }
 
+  /**
+   * NEW: Get the processed proximity values for use by distance field.
+   */
+  public function getProximityValues() {
+    if (empty($this->value) || 
+        (empty($this->value['value']) && empty($this->value['city']) && empty($this->value['state_province_id'])) || 
+        empty($this->value['distance'])) {
+      return [];
+    }
+
+    try {
+      $config = \CRM_Core_Config::singleton();
+      $countries = $this->civicrmApi->get('Country', [
+        'sequential' => 1,
+        'id' => $config->defaultContactCountry,
+        'return' => ['name'],
+      ]);
+
+      $proximity_address = [
+        'postal_code' => $this->value['value'],
+        'state_province_id' => $this->value['state_province_id'],
+        'city' => $this->value['city'],
+        'country' => !empty($countries) ? $countries[0]['name'] : '',
+        'country_id' => $config->defaultContactCountry,
+        'distance_unit' => $this->value['distance_unit'],
+      ];
+
+      $geocoded_address = $this->getGeocodedAddress($proximity_address);
+      
+      return [
+        'latitude' => $geocoded_address['latitude'],
+        'longitude' => $geocoded_address['longitude'],
+        'distance' => $this->value['distance'],
+        'distance_unit' => $this->value['distance_unit'],
+        'distance_meters' => $this->getCalculatedDistance($this->value['distance'], $this->value['distance_unit']),
+      ];
+    } catch (\Exception $e) {
+      \Drupal::logger('civicrm_entity')->error('Error getting proximity values: @error', ['@error' => $e->getMessage()]);
+      return [];
+    }
+  }
+
+  /**
+   * Check if proximity filter has valid geocoded coordinates.
+   */
+  public function hasValidProximityData() {
+    $values = $this->getProximityValues();
+    return !empty($values['latitude']) && !empty($values['longitude']);
+  }
 }

--- a/src/Plugin/views/sort/CivicrmEntityDistanceSort.php
+++ b/src/Plugin/views/sort/CivicrmEntityDistanceSort.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Drupal\civicrm_entity\Plugin\views\sort;
+
+use Drupal\views\Plugin\views\sort\SortPluginBase;
+
+/**
+ * Sort handler for distance calculations.
+ *
+ * @ViewsSort("civicrm_entity_distance_sort")
+ */
+class CivicrmEntityDistanceSort extends SortPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Get coordinates from proximity filter
+    $center_lat = $center_lon = NULL;
+    
+    // Method 1: Check view storage (set by proximity filter)
+    if (!empty($this->view->proximity_center)) {
+      $center_lat = $this->view->proximity_center['latitude'];
+      $center_lon = $this->view->proximity_center['longitude'];
+    } else {
+      // Method 2: Get directly from proximity filter
+      $proximity_filter = $this->getProximityFilter();
+      if ($proximity_filter && method_exists($proximity_filter, 'getProximityValues')) {
+        $values = $proximity_filter->getProximityValues();
+        if (!empty($values['latitude']) && !empty($values['longitude'])) {
+          $center_lat = $values['latitude'];
+          $center_lon = $values['longitude'];
+        }
+      }
+    }
+
+    if ($center_lat && $center_lon) {
+      // Use the same formula as the distance field
+      $formula = $this->getDistanceFormula($center_lat, $center_lon);
+      
+      // Add the sort to the query
+      $this->query->addOrderBy(NULL, $formula, $this->options['order']);
+    }
+  }
+
+  /**
+   * Get the proximity filter from the current view.
+   */
+  protected function getProximityFilter() {
+    $filters = $this->view->display_handler->getHandlers('filter');
+    
+    foreach ($filters as $filter_id => $filter) {
+      if ($filter->getPluginId() == 'civicrm_entity_civicrm_address_proximity') {
+        return $filter;
+      }
+    }
+    
+    return NULL;
+  }
+
+  /**
+   * Get the correct table alias for CiviCRM address table.
+   * Using the same hardcoded alias as the distance field.
+   */
+  protected function getAddressTableAlias() {
+    // Use the same alias that works in the distance field
+    return 'contact_id_civicrm_contact';
+  }
+
+  /**
+   * Calculate distance formula (same as distance field).
+   */
+  protected function getDistanceFormula($center_lat, $center_lon) {
+    $address_table = $this->getAddressTableAlias();
+    
+    // Get the unit from proximity filter or default to kilometers
+    $unit = $this->getDistanceUnit();
+    
+    // Set earth radius based on unit
+    if ($unit == 'mi' || $unit == 'miles') {
+      $earth_radius = 3958.8; // Earth radius in miles
+    } else {
+      $earth_radius = 6378.137; // Earth radius in kilometers
+    }
+    
+    $formula = "
+      (ACOS(
+        COS(RADIANS({$address_table}.geo_code_1)) *
+        COS(RADIANS($center_lat)) *
+        COS(RADIANS({$address_table}.geo_code_2) - RADIANS($center_lon)) +
+        SIN(RADIANS({$address_table}.geo_code_1)) *
+        SIN(RADIANS($center_lat))
+      ) * $earth_radius)
+    ";
+    
+    return $formula;
+  }
+
+  /**
+   * Get the distance unit (same logic as distance field).
+   */
+  protected function getDistanceUnit() {
+    // Check proximity filter settings
+    if (!empty($this->view->proximity_center['distance_unit'])) {
+      $proximity_unit = $this->view->proximity_center['distance_unit'];
+      // Convert proximity filter units to field units
+      if ($proximity_unit == 'miles') {
+        return 'mi';
+      } elseif ($proximity_unit == 'kilometers') {
+        return 'km';
+      }
+    }
+    
+    // Get from proximity filter directly
+    $proximity_filter = $this->getProximityFilter();
+    if ($proximity_filter && !empty($proximity_filter->value['distance_unit'])) {
+      $proximity_unit = $proximity_filter->value['distance_unit'];
+      if ($proximity_unit == 'miles') {
+        return 'mi';
+      } elseif ($proximity_unit == 'kilometers') {
+        return 'km';
+      }
+    }
+    
+    // Default to kilometers
+    return 'km';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function canExpose() {
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function adminSummary() {
+    if (!empty($this->options['exposed'])) {
+      return $this->t('exposed');
+    }
+    
+    $order = $this->options['order'] == 'ASC' ? $this->t('ascending') : $this->t('descending');
+    return $this->t('Distance (@order)', ['@order' => $order]);
+  }
+}
+
+?>


### PR DESCRIPTION
Overview
----------------------------------------
We have a client who needs the distance showing for proximity searches from Civi Addresses.

https://www.drupal.org/project/civicrm_entity/issues/3541996#comment-16233331

Before
----------------------------------------
No Distance available for view results based on proximity filter origin.

After
----------------------------------------
A field called "Distance" is available, respecting the Units chosen in the filter.
A sort option called "Distance" is available, to order summary results in a table by distance.

Technical Details
----------------------------------------
See PR

Comments
----------------------------------------
_Anything else you would like the reviewer to note_

Release notes snippet
----------------------------------------
The field and sort options are both called "Distance" available with CiviCRM_Address entity.
