### PR TITLE
Don't use depdency injection for logger.

### DIFF
--- a/src/Hook/EntityHooks.php
+++ b/src/Hook/EntityHooks.php
@@ -21,8 +21,6 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\Entity\BaseFieldOverride;
 use Drupal\Core\Hook\Attribute\Hook;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\FieldConfigInterface;
@@ -33,23 +31,14 @@ use Drupal\field\FieldConfigInterface;
 class EntityHooks {
 
   /**
-   * The logger channel.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
-   */
-  protected LoggerChannelInterface $logger;
-
-  /**
    * Constructor for EntityHooks.
    */
   public function __construct(
-    LoggerChannelFactoryInterface $loggerChannelFactory,
     protected CiviCrmApiInterface $civicrmApi,
     protected EntityTypeManagerInterface $entityTypeManager,
     protected EntityLastInstalledSchemaRepositoryInterface $entityLastInstalledSchemaRepository,
     protected EntityFieldManagerInterface $entityFieldManager,
   ) {
-    $this->logger = $loggerChannelFactory->get('civicrm_entity');
   }
 
   /**
@@ -68,7 +57,7 @@ class EntityHooks {
       $civicrm_entity_name = $civicrm_entity_info['civicrm entity name'];
 
       if (empty($civicrm_entity_info['label property'])) {
-        $this->logger->debug(sprintf('Missing label property: %s', $entity_type_id));
+        \Drupal::logger('civicrm_entity')->debug(sprintf('Missing label property: %s', $entity_type_id));
         continue;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
When having syslog and symfony_mailer 1.x enabled, this error is thrown when clearing the cache from the UI:

```
Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException: Circular reference detected for service "Drupal\civicrm_entity\Hook\EntityHooks", path: "Drupal\civicrm_entity\Hook\EntityHooks -> logger.factory -> logger.syslog". in Drupal\Component\DependencyInjection\Container->get() (line 147 of /var/www/web/demo11-dev.skvare.com/web/core/lib/Drupal/Component/DependencyInjection/Container.php).
```

It looks like this maybe caused by symfony_mailer. There is a fix but it is for [2.x](https://www.drupal.org/project/symfony_mailer/issues/3524894).

A similar issue for another module is [here](https://www.drupal.org/project/ultimenu/issues/3419031) which also mentions symfony_mailer and the fix involves removing one dependency injection.

Considering the logger is only used once, quickest fix is to probably not use dependency injection.

Before
----------------------------------------
Throws error on clearing cache from the UI.

After
----------------------------------------
No more error.