### PR TITLE
Views argument default "Contact subtype from logged in user": use uf_id to match user-id in UFMatch

### DIFF
--- a/src/Plugin/views/argument_default/ContactSubtype.php
+++ b/src/Plugin/views/argument_default/ContactSubtype.php
@@ -117,7 +117,7 @@ class ContactSubtype extends ArgumentDefaultPluginBase implements CacheableDepen
 
     $results = $this->civicrmApi->get('UFMatch', [
       'sequential' => 1,
-      'id' => $this->currentUser->id(),
+      'uf_id' => $this->currentUser->id(),
     ]);
 
     if (!empty($results) && !empty($results[0]['contact_id'])) {


### PR DESCRIPTION
Overview
----------------------------------------
The views default argument to get Contact subtype from logged in user (`src/Plugin/views/argument_default/ContactSubtype.php`) wrongly uses `uf_match.id` to match user id.
I think it should use `uf_match.uf_id` instead. As far as I understand `id` is just the autoincrement ID and has no further meaning.

Before
----------------------------------------
Does not match currently logged in user to this user's CiviCRM contact but so some other ID:
* either some other contact who randomly has `uf_match.id` as contact ID
* or to no existing contact at all.

After
----------------------------------------
Does match currently logged in user to this user's CiviCRM contact.

Comments
----------------------------------------
I encountered this while creating a new argument default handler to get the CiviCRM contact ID of the currently logged in user - so I can restrict my view to data from the current user.

I extended the existing `ContactSubtype` rewriting `getArgument()` (and dropping the configuration options). This is where I noticed that a wrong contact was matched. 

If we can agree on the fix addressed here I would propose another MR including this new argument default handler (`ContactID`).
This change would be a little bigger (I would move some functionality to the new class and let `ContactSubtype` extend the new class). I thought just changing one line would make the fix "cleaner" and easier to understand (instead of "hiding" it in a bigger MR). 
Any thoughts on this?
Or am I missing something?

Release notes snippet
----------------------------------------
FIX views default argument to get Contact subtype from logged in user
