### PR TITLE
Views argument default for contact ID; New option to limit cid to own contact for argument_validator/CivicrmContact

### DIFF
--- a/src/Plugin/views/argument_default/ContactId.php
+++ b/src/Plugin/views/argument_default/ContactId.php
@@ -70,7 +70,6 @@ class ContactId extends ArgumentDefaultPluginBase implements CacheableDependency
       $container->get('civicrm_entity.api'));
   }
 
-
   /**
    * {@inheritdoc}
    */

--- a/src/Plugin/views/argument_default/ContactId.php
+++ b/src/Plugin/views/argument_default/ContactId.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Drupal\civicrm_entity\Plugin\views\argument_default;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheableDependencyInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\views\Attribute\ViewsArgumentDefault;
+use Drupal\views\Plugin\views\argument_default\ArgumentDefaultPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Session\AccountProxy;
+use Drupal\civicrm_entity\CiviCrmApiInterface;
+
+/**
+ * Default argument plugin to get the current user's civicrm contact ID.
+ *
+ * This plugin actually has no options so it does not need to do a great deal.
+ *
+ * @ViewsArgumentDefault(
+ *   id = "current_user_contact_id",
+ *   title = @Translation("Contact ID from logged in user")
+ * )
+ */
+#[ViewsArgumentDefault(
+  id: 'current_user_contact_id',
+  title: new TranslatableMarkup('Contact ID from logged in user'),
+)]
+class ContactId extends ArgumentDefaultPluginBase implements CacheableDependencyInterface {
+
+  /**
+   * Drupal\Core\Session\AccountProxy definition.
+   *
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  protected $currentUser;
+
+  /**
+   * The CiviCRM API.
+   *
+   * @var \Drupal\civicrm_entity\CiviCrmApiInterface
+   */
+  protected $civicrmApi;
+
+  /**
+   * Constructs a new ContactId instance.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Session\AccountProxy $currentUser
+   *   The current user.
+   * @param \Drupal\civicrm_entity\CiviCrmApiInterface $civicrmApi
+   *   The CiviCRM Api.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, AccountProxy $currentUser, CiviCrmApiInterface $civicrmApi) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->currentUser = $currentUser;
+    $this->civicrmApi = $civicrmApi;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static($configuration, $plugin_id, $plugin_definition,
+      $container->get('current_user'),
+      $container->get('civicrm_entity.api'));
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getArgument() {
+    // Default return value 0 (there is never a contact with this ID).
+    $cid = 0;
+
+    $results = $this->civicrmApi->get('UFMatch', [
+      'sequential' => 1,
+      'uf_id' => $this->currentUser->id(),
+    ]);
+
+    if (!empty($results) && !empty($results[0]['contact_id'])) {
+      $cid = $results[0]['contact_id'];
+    }
+
+    return $cid;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() {
+    return Cache::PERMANENT;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return ['user'];
+  }
+
+}

--- a/src/Plugin/views/argument_default/ContactSubtype.php
+++ b/src/Plugin/views/argument_default/ContactSubtype.php
@@ -117,7 +117,7 @@ class ContactSubtype extends ArgumentDefaultPluginBase implements CacheableDepen
 
     $results = $this->civicrmApi->get('UFMatch', [
       'sequential' => 1,
-      'id' => $this->currentUser->id(),
+      'uf_id' => $this->currentUser->id(),
     ]);
 
     if (!empty($results) && !empty($results[0]['contact_id'])) {

--- a/src/Plugin/views/argument_default/ContactSubtype.php
+++ b/src/Plugin/views/argument_default/ContactSubtype.php
@@ -3,19 +3,13 @@
 namespace Drupal\civicrm_entity\Plugin\views\argument_default;
 
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Cache\CacheableDependencyInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\views\Attribute\ViewsArgumentDefault;
-use Drupal\views\Plugin\views\argument_default\ArgumentDefaultPluginBase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Session\AccountProxy;
-use Drupal\civicrm_entity\CiviCrmApiInterface;
+use \Drupal\civicrm_entity\Plugin\views\argument_default\ContactId;
 
 /**
  * Default argument plugin to get the current user's civicrm contact subtype.
- *
- * This plugin actually has no options so it does not need to do a great deal.
  *
  * @ViewsArgumentDefault(
  *   id = "current_user_contact_subtype",
@@ -26,50 +20,7 @@ use Drupal\civicrm_entity\CiviCrmApiInterface;
   id: 'current_user_contact_subtype',
   title: new TranslatableMarkup('Contact subtype from logged in user'),
 )]
-class ContactSubtype extends ArgumentDefaultPluginBase implements CacheableDependencyInterface {
-
-  /**
-   * Drupal\Core\Session\AccountProxy definition.
-   *
-   * @var \Drupal\Core\Session\AccountProxy
-   */
-  protected $currentUser;
-
-  /**
-   * The CiviCRM API.
-   *
-   * @var \Drupal\civicrm_entity\CiviCrmApiInterface
-   */
-  protected $civicrmApi;
-
-  /**
-   * Constructs a new ContactSubtype instance.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Session\AccountProxy $currentUser
-   *   The current user.
-   * @param \Drupal\civicrm_entity\CiviCrmApiInterface $civicrmApi
-   *   The CiviCRM Api.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, AccountProxy $currentUser, CiviCrmApiInterface $civicrmApi) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->currentUser = $currentUser;
-    $this->civicrmApi = $civicrmApi;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static($configuration, $plugin_id, $plugin_definition,
-      $container->get('current_user'),
-      $container->get('civicrm_entity.api'));
-  }
+class ContactSubtype extends ContactId {
 
   /**
    * {@inheritdoc}
@@ -115,14 +66,8 @@ class ContactSubtype extends ArgumentDefaultPluginBase implements CacheableDepen
 
     $current_user_contact_subtype = ($this->options['no_subtype'] == 'none') ? '<none>' : 'all';
 
-    $results = $this->civicrmApi->get('UFMatch', [
-      'sequential' => 1,
-      'uf_id' => $this->currentUser->id(),
-    ]);
-
-    if (!empty($results) && !empty($results[0]['contact_id'])) {
-      $cid = $results[0]['contact_id'];
-
+    $cid = parent::getArgument();
+    if ($cid) {
       $results = $this->civicrmApi->get('contact', [
         'sequential' => 1,
         'return' => ['contact_sub_type'],
@@ -161,3 +106,4 @@ class ContactSubtype extends ArgumentDefaultPluginBase implements CacheableDepen
   }
 
 }
+

--- a/src/Plugin/views/argument_default/ContactSubtype.php
+++ b/src/Plugin/views/argument_default/ContactSubtype.php
@@ -6,7 +6,6 @@ use Drupal\Core\Cache\Cache;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\views\Attribute\ViewsArgumentDefault;
 use Drupal\Core\Form\FormStateInterface;
-use \Drupal\civicrm_entity\Plugin\views\argument_default\ContactId;
 
 /**
  * Default argument plugin to get the current user's civicrm contact subtype.
@@ -106,4 +105,3 @@ class ContactSubtype extends ContactId {
   }
 
 }
-

--- a/src/Plugin/views/argument_validator/CivicrmContact.php
+++ b/src/Plugin/views/argument_validator/CivicrmContact.php
@@ -37,7 +37,7 @@ class CivicrmContact extends Entity {
     EntityTypeManagerInterface $entity_type_manager,
     EntityTypeBundleInfoInterface $entity_type_bundle_info,
     AccountProxy $currentUser,
-    CiviCrmApiInterface $civicrmApi
+    CiviCrmApiInterface $civicrmApi,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $entity_type_bundle_info);
     $this->currentUser = $currentUser;
@@ -85,7 +85,7 @@ class CivicrmContact extends Entity {
       '#options' => array_combine($contact_types, $contact_types),
     ];
     $form['limit_own_contact'] = [
-      '#title' => $this->t('Limit to current user\'s own contact'),
+      '#title' => $this->t("Limit to current user's own contact"),
       '#default_value' => $this->options['limit_own_contact'],
       '#type' => 'checkbox',
     ];
@@ -126,4 +126,3 @@ class CivicrmContact extends Entity {
   }
 
 }
-

--- a/src/Plugin/views/argument_validator/CivicrmContact.php
+++ b/src/Plugin/views/argument_validator/CivicrmContact.php
@@ -2,14 +2,62 @@
 
 namespace Drupal\civicrm_entity\Plugin\views\argument_validator;
 
+use Drupal\civicrm_entity\CiviCrmApiInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountProxy;
 use Drupal\views\Plugin\views\argument_validator\Entity;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Validates whether the argument matches a contact type.
  */
 class CivicrmContact extends Entity {
+
+  /**
+   * Drupal\Core\Session\AccountProxy definition.
+   *
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  protected $currentUser;
+
+  /**
+   * The CiviCRM API.
+   *
+   * @var \Drupal\civicrm_entity\CiviCrmApiInterface
+   */
+  protected $civicrmApi;
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    EntityTypeBundleInfoInterface $entity_type_bundle_info,
+    AccountProxy $currentUser,
+    CiviCrmApiInterface $civicrmApi
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $entity_type_bundle_info);
+    $this->currentUser = $currentUser;
+    $this->civicrmApi = $civicrmApi;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('current_user'),
+      $container->get('civicrm_entity.api')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -18,6 +66,7 @@ class CivicrmContact extends Entity {
     $options = parent::defineOptions();
 
     $options['contact_type'] = ['default' => []];
+    $options['limit_own_contact'] = ['default' => FALSE];
 
     return $options;
   }
@@ -35,6 +84,11 @@ class CivicrmContact extends Entity {
       '#type' => 'checkboxes',
       '#options' => array_combine($contact_types, $contact_types),
     ];
+    $form['limit_own_contact'] = [
+      '#title' => $this->t('Limit to current user\'s own contact'),
+      '#default_value' => $this->options['limit_own_contact'],
+      '#type' => 'checkbox',
+    ];
   }
 
   /**
@@ -48,6 +102,7 @@ class CivicrmContact extends Entity {
    * {@inheritdoc}
    */
   protected function validateEntity(EntityInterface $entity) {
+
     /** @var \Drupal\civicrm_entity\Entity\CivicrmEntity $entity */
     $valid = TRUE;
 
@@ -55,7 +110,20 @@ class CivicrmContact extends Entity {
       $valid = FALSE;
     }
 
+    if ($valid && !empty($this->options['limit_own_contact'])) {
+      $results = $this->civicrmApi->get('UFMatch', [
+        'sequential' => 1,
+        'contact_id' => $entity->id(),
+      ]);
+      if (empty($results) || empty($results[0]['contact_id'])
+        || $results[0]['uf_id'] != $this->currentUser->id()
+      ) {
+        $valid = FALSE;
+      }
+    }
+
     return $valid && parent::validateEntity($entity);
   }
 
 }
+


### PR DESCRIPTION
Overview
----------------------------------------
* New possibility to set views contextual filter for Contact ID
* Added validator for contextual filter to limit for currently logged in user`s Contact

Contains fix "use uf_id to match user-id in UFMatch" from #536


Before
----------------------------------------
See #536 for discussion of `uf_id` in Views argument default "Contact subtype from logged in user".


After
----------------------------------------
This proposal adds a new contextual filter to get data from a CiviCRM contact ID.


Technical Details
----------------------------------------
I added new `src/Plugin/views/argument_default/ContactId.php` and moved stuff from `ContactSubtype.php` to this new class:
* `$currentUser` and `$civicrmApi`
* `__construct() and `create()`
`ContactId::getArgument()` returns contact ID of current user (or 0 if none found).

With this I simplified `ContactSubtype`:
* extends `ContactId`
* thus inherits `$currentUser`, `$civicrmAp`i, `__construct()` and `create()`
* `ContactSubtype::getArgument()` now calls `parent::getArgument()` to get the cid (and then gets the subtype as before)

I also added a new option 'limit_own_contact' to `src/Plugin/views/argument_validator/CivicrmContact.php` which 
limits to current user\'s own contact ID. 


Comments
----------------------------------------
Included the change from #536


Release notes snippet
----------------------------------------
Enhanced views integration: new contextual filter Contact-ID, possibility to limit to currently logged in user`s contact. 