### PR TITLE
Add orderafter.

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -18,6 +18,7 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Hook\Attribute\LegacyModuleImplementsAlter;
 use Drupal\Core\Render\Element;
 use Drupal\views\ViewExecutable;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
@@ -101,6 +102,7 @@ function civicrm_entity_form_alter(array &$form, FormStateInterface $form_state,
 /**
  * Implements hook_module_implements_alter().
  */
+#[LegacyModuleImplementsAlter]
 function civicrm_entity_module_implements_alter(&$implementations, $hook) {
   switch ($hook) {
     case 'form_alter':

--- a/src/Hook/FormHooks.php
+++ b/src/Hook/FormHooks.php
@@ -6,6 +6,7 @@ use Drupal\civicrm_entity\Form\CivicrmEntityForm;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\Hook\Order\OrderAfter;
 
 /**
  * Hook implementations for forms.
@@ -21,7 +22,7 @@ class FormHooks {
   /**
    * Implements hook_form_alter().)
    */
-  #[Hook('form_alter')]
+  #[Hook('form_alter', order: new OrderAfter(['field_group']))]
   public function formAlter(array &$form, FormStateInterface $form_state, $form_id) {
     $form_object = $form_state->getFormObject();
     if ($form_object instanceof CivicrmEntityForm) {


### PR DESCRIPTION
Implement ordering of hooks for Drupal 11.2.x - https://www.drupal.org/node/3497308.