### PR TITLE
Issue #3555743 by codebymikey: Add validation for optional mandatory fields

### DIFF
--- a/src/CiviCrmApi.php
+++ b/src/CiviCrmApi.php
@@ -58,7 +58,43 @@ class CiviCrmApi implements CiviCrmApiInterface {
     if (!function_exists('_civicrm_api3_validate')) {
       require_once 'api/v3/utils.php';
     }
-    return _civicrm_api3_validate($entity, 'create', $params);
+    [$errors] = _civicrm_api3_validate($entity, 'create', $params);
+
+    if (empty($errors)) {
+      // Validate that all optional params are also valid.
+      /** @see \_civicrm_api3_activity_check_params() */
+      /** @see \_civicrm_api3_contact_check_params() */
+      $check_params_callback = "_civicrm_api3_{$entity}_check_params";
+      if (function_exists($check_params_callback)) {
+        try {
+          $check_params = $params + ['version' => 3];
+          $check_params_callback($check_params);
+        }
+        catch (\CRM_Core_Exception $e) {
+          $handled_missing_fields = FALSE;
+          if ($e->getErrorCode() === 'mandatory_missing') {
+            $mandatory_fields = $e->getErrorData()['fields'] ?? [];
+            foreach ($mandatory_fields as $mandatory_field) {
+              $handled_missing_fields = TRUE;
+              if (!isset($errors[$mandatory_field])) {
+                $errors[$mandatory_field] = [
+                  'message' => ":{$mandatory_field} field is required.",
+                  'code' => 'mandatory_missing',
+                ];
+              }
+            }
+          }
+          if (!$handled_missing_fields) {
+            $errors["{$entity}_validation_error"] = [
+              'message' => $e->getMessage(),
+              'code' => $e->getErrorCode(),
+            ];
+          }
+        }
+      }
+    }
+
+    return [$errors];
   }
 
   /**

--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -189,7 +189,7 @@ class CivicrmEntity extends ContentEntityBase {
           [],
           '',
           $civicrm_field,
-          $params[$civicrm_field]
+          $params[$civicrm_field] ?? NULL
         );
         $violations->add($violation);
       }


### PR DESCRIPTION

Overview
----------------------------------------
Some CRM entities require some fields that are not explicitly declared as required, and aren't currently picked up by the `_civicrm_api3_validate()` function.

Upstream Drupal issue: https://www.drupal.org/project/civicrm_entity/issues/3555743

### Steps to reproduce
1. Go to /admin/structure/civicrm-entity/settings and enable integration with the "Contact" type
2. Go to /civicrm-contact/add
3. Set the Contact type to Household
4. Attempt to save the page.

The Household Name field is actually required, but isn't enforced as required leading to the page crashing:

Before
----------------------------------------
A crash occurs when you try to save a "Household" `Contact`:

```
The website encountered an unexpected error. Try again later.

Drupal\Core\Entity\EntityStorageException: Mandatory key(s) missing from params array: household_name in Drupal\Core\Entity\Sql\SqlContentEntityStorage->save() (line 817 of core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php).
Drupal\civicrm_entity\CiviCrmApi->save('contact', Array) (Line: 157)
Drupal\civicrm_entity\CiviEntityStorage->doSave(NULL, Object) (Line: 486)
Drupal\Core\Entity\EntityStorageBase->save(Object) (Line: 806)
Drupal\Core\Entity\Sql\SqlContentEntityStorage->save(Object) (Line: 354)
Drupal\Core\Entity\EntityBase->save() (Line: 48)
Drupal\civicrm_entity\Entity\CivicrmEntity->save() (Line: 144)
Drupal\civicrm_entity\Form\CivicrmEntityForm->save(Array, Object)
```

After
----------------------------------------
The error is caught and shown to the user during the validation step.

Technical Details
----------------------------------------
During the entity validation step, dynamically check for the existence of the `_civicrm_api3_{$entity}_check_params()` (`_civicrm_api3_contact_check_params()` in this case) function, and use that to validate potentially required fields.

Initially thought to patch it in civicrm/civicrm-core so the validation also picks up optional fields, but since validation already works on there end, and this is a Drupal issue, it seemed easier to tackle it here.

It might still be worth tackling in civicrm/civicrm-core long term, as the validate function should ideally pick this up.

Comments
----------------------------------------
N/A

Release notes snippet
----------------------------------------
N/A