### PR TITLE
double check for id of entity tag

### DIFF
--- a/civicrm_entity.module
+++ b/civicrm_entity.module
@@ -262,8 +262,10 @@ function civicrm_entity_civicrm_pre($op, $objectName, $id, &$params) {
         $id = $storage->getEntityTagEntityId($params[0][0], $params[1]);
       }
     }
-    /** @var \Drupal\civicrm_entity\Entity\CivicrmEntity $entity */
-    $entity = $storage->load($id);
+    if (!empty($id)) {
+      /** @var \Drupal\civicrm_entity\Entity\CivicrmEntity $entity */
+      $entity = $storage->load($id);
+    }
   }
   if (!$entity) {
     return;


### PR DESCRIPTION
Overview
----------------------------------------
Fix for issue: https://www.drupal.org/project/civicrm_entity/issues/3570584
When trying to execute an api4 delete command on the entity_table this is causing an undefined array key 0 error, see below:

Example command and output:

cv api4 EntityTag.delete '{"where":[["entity_table","=","civicrm_contact"],["tag_id","=",10]]}'

[PHP Warning] Undefined array key 0 at /var/www/html/web/modules/contrib/civicrm_entity/civicrm_entity.module:262
[PHP Warning] Trying to access array offset on null at /var/www/html/web/modules/contrib/civicrm_entity/civicrm_entity.module:262
[PHP Warning] Undefined array key 1 at /var/www/html/web/modules/contrib/civicrm_entity/civicrm_entity.module:262

Line 262 is: $id = $storage->getEntityTagEntityId($params[0][0], $params[1]);. The issue is there is no $params[0][0] or $params[1]. 

Before
----------------------------------------
error

After
----------------------------------------
no error
