### PR TITLE
Drupal issue #3584360: Fixed bundle mismatch

### DIFF
--- a/src/Entity/CivicrmEntity.php
+++ b/src/Entity/CivicrmEntity.php
@@ -77,22 +77,39 @@ class CivicrmEntity extends ContentEntityBase {
     // This ensures the values array has the bundle property set.
     $entity_type = $storage->getEntityType();
     if ($entity_type->hasKey('bundle')) {
+      $bundle_key = $entity_type->getKey('bundle');
       $bundle_property = $entity_type->get('civicrm_bundle_property');
       /** @var \Drupal\civicrm_entity\CiviCrmApiInterface $civicrm_api */
       $civicrm_api = \Drupal::service('civicrm_entity.api');
       $options = $civicrm_api->getOptions($entity_type->get('civicrm_entity'), $bundle_property);
+      $transliteration = \Drupal::transliteration();
 
-      if (isset($values[$entity_type->getKey('bundle')]) && $values[$entity_type->getKey('bundle')] === $entity_type->id()) {
+      if (isset($values[$bundle_key]) && $values[$bundle_key] !== $entity_type->id()) {
+        if (!isset($values[$bundle_property])) {
+          foreach ($options as $raw => $label) {
+            if (SupportedEntities::optionToMachineName($label, $transliteration) === $values[$bundle_key]) {
+              $values[$bundle_property] = $raw;
+              break;
+            }
+          }
+        }
+        return;
+      }
+
+      if (isset($values[$bundle_key]) && $values[$bundle_key] === $entity_type->id()) {
         $raw_bundle_value = key($options);
       }
       else {
-        $raw_bundle_value = $values[$bundle_property];
+        $raw_bundle_value = $values[$bundle_property] ?? key($options);
       }
 
       $bundle_value = $options[$raw_bundle_value];
-      $transliteration = \Drupal::transliteration();
       $machine_name = SupportedEntities::optionToMachineName($bundle_value, $transliteration);
-      $values[$entity_type->getKey('bundle')] = $machine_name;
+      $values[$bundle_key] = $machine_name;
+      // Ensure the bundle property is set for CiviCRM.
+      if (!isset($values[$bundle_property])) {
+        $values[$bundle_property] = $raw_bundle_value;
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
I'm running into an issue when I attempt to create a CiviCRM event via an Inline Entity Form widget. I cannot select any event category other than the default one ("Event"). If I select an option that is not the default, I get a generic error message ("Oops, something went wrong...") and my event is never created.

I did manage to find a way around this for my content authors by applying a patch generated by AI. I thought I'd raise the issue and share the patch as it may prove to be helpful to others.

Before
----------------------------------------
When trying to create a new CiviCRM entity using Inline Entity Form, the system throws a preCreate exception. This happens because Inline Entity Form passes a string (the machine name) for the bundle, but CiviCRM strictly expects a numeric property ID.

After
----------------------------------------
Users can now successfully create CiviCRM entities via Inline Entity Form without errors. The module correctly intercepts the bundle string and maps it to the expected integer ID before attempting creation.

Technical Details
----------------------------------------
In CivicrmEntity::preCreate(), logic was added to handle the bundle value. If the bundle is passed as a string machine name by the form state, it is converted into the correct numeric CiviCRM property ID required by the API.

Comments
----------------------------------------
Fixes https://www.drupal.org/project/civicrm_entity/issues/3584360

Release notes snippet
----------------------------------------
Fixed: Bundle ID mismatch exception when creating CiviCRM entities via Inline Entity Form.